### PR TITLE
Store coverage reports as build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,9 @@ jobs:
           command: make build
 
       - store_artifacts:
-          path: /tmp/test-results
-          destination: test-output
-
-      - store_test_results:
           path: ./coverage
+          destination: coverage
+
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Confio Weave
-
+[![Build Status circleCI](https://circleci.com/gh/confio/weave.png?style=shield&circle-token=4a0ef9d48e00e82022cc6750ba63b2fd6d75343c)](https://circleci.com/gh/confio/weave)
 [![API Reference](https://godoc.org/github.com/confio/weave?status.svg
 )](https://godoc.org/github.com/confio/weave)
 [![license](https://img.shields.io/github/license/confio/weave.svg)](https://github.com/confio/weave/blob/master/LICENSE)


### PR DESCRIPTION
* Store generated coverage report as artifact in circleCI
* Badge

example report from this branch:: https://16-118366160-gh.circle-artifacts.com/0/coverage/weave_crypto.html#file0