### PR TITLE
Replace tendermint abci package dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,22 @@
   version = "v9"
 
 [[projects]]
+  branch = "master"
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c0decf632843204d2b8781de7b26e7038584e2dcccc7e2f401e88ae85b1df2b7"
+  name = "github.com/btcsuite/btcd"
+  packages = ["btcec"]
+  pruneopts = "UT"
+  revision = "67e573d211ace594f1366b4ce9d39726c4b19bd0"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -18,12 +34,23 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:704b145137b5555c6bac6a7e52875e4df8a0a1b7ea74aaae864abcab61e672b0"
+  digest = "1:c7644c73a3d23741fdba8a99b1464e021a224b7e205be497271a8003a15ca41b"
+  name = "github.com/ebuchman/fail-test"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "95f809107225be108efcf10a3509e4ea6ceef3c4"
+
+[[projects]]
+  digest = "1:fdf5169073fb0ad6dc12a70c249145e30f4058647bea25f0abd48b6d9f228a11"
   name = "github.com/go-kit/kit"
   packages = [
     "log",
     "log/level",
     "log/term",
+    "metrics",
+    "metrics/discard",
+    "metrics/internal/lv",
+    "metrics/prometheus",
   ]
   pruneopts = "UT"
   revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
@@ -95,6 +122,14 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:bc38c7c481812e178d85160472e231c5e1c9a7f5845d67e23ee4e706933c10d8"
+  name = "github.com/golang/mock"
+  packages = ["gomock"]
+  pruneopts = "UT"
+  revision = "c34cdb4725f4c3844d095133c6e40e448b86589b"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:17fe264ee908afc795734e8c4e63db2accabaf57326dbf21763a7d6b86096260"
   name = "github.com/golang/protobuf"
   packages = [
@@ -133,6 +168,14 @@
   revision = "0766667cb4d1cfb8d5fde1fe210ae41ead3cf589"
 
 [[projects]]
+  digest = "1:43dd08a10854b2056e615d1b1d22ac94559d822e1f8b6fcc92c1a1057e85188e"
+  name = "github.com/gorilla/websocket"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
+  version = "v1.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:39b27d1381a30421f9813967a5866fba35dc1d4df43a6eefe3b7a5444cb07214"
   name = "github.com/jmhodges/levigo"
@@ -157,6 +200,14 @@
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   branch = "master"
   digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
   name = "github.com/petar/GoLLRB"
@@ -179,6 +230,56 @@
   pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:c1a04665f9613e082e1209cf288bf64f4068dcd6c87a64bf1c4ff006ad422ba0"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "UT"
+  revision = "ae27198cdd90bf12cd134ad79d1366a6cf49f632"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+
+[[projects]]
+  branch = "master"
+  digest = "1:db712fde5d12d6cdbdf14b777f0c230f4ff5ab0be8e35b239fc319953ed577a4"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "7e9e6cabbd393fc208072eedef99188d0ce788b6"
+
+[[projects]]
+  branch = "master"
+  digest = "1:ef74914912f99c79434d9c09658274678bc85080ebe3ab32bec3940ebce5e1fc"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs",
+  ]
+  pruneopts = "UT"
+  revision = "185b4288413d2a0dd0806f78c90dde719829e5ae"
+
+[[projects]]
+  digest = "1:c4556a44e350b50a490544d9b06e9fba9c286c21d6c0e47f54f3a9214597298c"
+  name = "github.com/rcrowley/go-metrics"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e2704e165165ec55d062f5919b4b29494e9fa790"
 
 [[projects]]
   digest = "1:cc1c574c9cb5e99b123888c12b828e2d19224ab6c2244bda34647f230bf33243"
@@ -237,12 +338,43 @@
   revision = "6b91fda63f2e36186f1c9d0e48578defb69c5d43"
 
 [[projects]]
-  digest = "1:e9113641c839c21d8eaeb2c907c7276af1eddeed988df8322168c56b7e06e0e1"
+  digest = "1:5d7253bb6a2f9355cea7197e4c5c03f6c563be4c2ab1d7ff0f3b2584b69c6202"
+  name = "github.com/tendermint/abci"
+  packages = [
+    "example/code",
+    "example/kvstore",
+    "types",
+  ]
+  pruneopts = "UT"
+  revision = "198dccf0ddfd1bb176f87657e3286a05a6ed9540"
+  version = "v0.12.0"
+
+[[projects]]
+  digest = "1:605b6546f3f43745695298ec2d342d3e952b6d91cdf9f349bea9315f677d759f"
+  name = "github.com/tendermint/btcd"
+  packages = ["btcec"]
+  pruneopts = "UT"
+  revision = "e5840949ff4fff0c56f9b6a541e22b63581ea9df"
+
+[[projects]]
+  branch = "master"
+  digest = "1:087aaa7920e5d0bf79586feb57ce01c35c830396ab4392798112e8aae8c47722"
+  name = "github.com/tendermint/ed25519"
+  packages = [
+    ".",
+    "edwards25519",
+    "extra25519",
+  ]
+  pruneopts = "UT"
+  revision = "d8387025d2b9d158cf4efb07e7ebf814bcce2057"
+
+[[projects]]
+  digest = "1:2c971a45c89ca2ccc735af50919cdee05fbdc54d4bf50625073693300e31ead8"
   name = "github.com/tendermint/go-amino"
   packages = ["."]
   pruneopts = "UT"
-  revision = "2106ca61d91029c931fd54968c2bb02dc96b1412"
-  version = "0.10.1"
+  revision = "faa6e731944e2b7b6a46ad202902851e8ce85bee"
+  version = "v0.12.0"
 
 [[projects]]
   digest = "1:53397098d6acb7613358683cc84ae59281a60c6033f0bff62fa8d3f279c6c430"
@@ -253,34 +385,100 @@
   version = "v0.11.0"
 
 [[projects]]
-  digest = "1:1a4f3b76e8055836495ae4ea6af1c1393a31e9aed413b6a882543f3147b5693f"
+  digest = "1:762ad42ae1b83714c78c2285826574c58f4ed712d05562076dd188e75cf38563"
   name = "github.com/tendermint/tendermint"
   packages = [
+    "abci/client",
+    "abci/example/code",
+    "abci/example/kvstore",
     "abci/server",
     "abci/types",
+    "blockchain",
+    "config",
+    "consensus",
+    "consensus/types",
+    "crypto",
+    "crypto/ed25519",
+    "crypto/encoding/amino",
+    "crypto/merkle",
+    "crypto/multisig",
+    "crypto/multisig/bitarray",
+    "crypto/secp256k1",
     "crypto/tmhash",
+    "evidence",
+    "libs/autofile",
+    "libs/clist",
     "libs/common",
     "libs/db",
     "libs/errors",
+    "libs/events",
+    "libs/flowrate",
     "libs/log",
+    "libs/pubsub",
+    "libs/pubsub/query",
+    "mempool",
+    "node",
+    "p2p",
+    "p2p/conn",
+    "p2p/pex",
+    "privval",
+    "proxy",
+    "rpc/client",
+    "rpc/core",
+    "rpc/core/types",
+    "rpc/grpc",
+    "rpc/lib",
+    "rpc/lib/client",
+    "rpc/lib/server",
+    "rpc/lib/types",
+    "rpc/test",
+    "state",
+    "state/txindex",
+    "state/txindex/kv",
+    "state/txindex/null",
+    "types",
+    "types/time",
+    "version",
   ]
   pruneopts = "UT"
   revision = "0c9c3292c918617624f6f3fbcd95eceade18bcd5"
   version = "v0.25.0"
 
 [[projects]]
+  digest = "1:68921ddf468c0db04496dc49cc67948f1727a74520b1f1f06100bce5c65fa08b"
+  name = "github.com/tendermint/tmlibs"
+  packages = [
+    "common",
+    "db",
+    "log",
+  ]
+  pruneopts = "UT"
+  revision = "692f1d86a6e2c0efa698fd1e4541b68c74ffaf38"
+  version = "v0.8.4"
+
+[[projects]]
   branch = "master"
-  digest = "1:d5891c5bca9c62e5d394ca26491d2b710a1dc08cedeb0ca8f9ac4c3305120b02"
+  digest = "1:64523cd58deb8387038f0461d5f2600b9332edf215ac5eb5859bec7b042bc560"
   name = "golang.org/x/crypto"
   packages = [
+    "chacha20poly1305",
+    "curve25519",
     "ed25519",
     "ed25519/internal/edwards25519",
+    "hkdf",
+    "internal/chacha20",
+    "internal/subtle",
+    "nacl/box",
+    "nacl/secretbox",
+    "poly1305",
+    "ripemd160",
+    "salsa20/salsa",
   ]
   pruneopts = "UT"
   revision = "e84da0312774c21d64ee2317962ef669b27ffb41"
 
 [[projects]]
-  digest = "1:68349a8c755738add0b9dcc25e5bfcbc11862520e0dfa9ebd32d8b489d7d4971"
+  digest = "1:d36f55a999540d29b6ea3c2ea29d71c76b1d9853fdcd3e5c5cb4836f2ba118f1"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -289,10 +487,19 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
+    "netutil",
     "trace",
   ]
   pruneopts = "UT"
   revision = "292b43bbf7cb8d35ddf40f8d5100ef3837cced3f"
+
+[[projects]]
+  branch = "master"
+  digest = "1:8392490b249a3602a13813be12324d3b16eca044ae185ff32cdd9e267706e208"
+  name = "golang.org/x/sys"
+  packages = ["cpu"]
+  pruneopts = "UT"
+  revision = "d69651ed3497faee15a5363a89578e9991f6d5e2"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -368,17 +575,32 @@
     "github.com/gogo/protobuf/gogoproto",
     "github.com/gogo/protobuf/proto",
     "github.com/gogo/protobuf/protoc-gen-gogofaster",
+    "github.com/golang/mock/gomock",
     "github.com/google/btree",
+    "github.com/gorilla/websocket",
     "github.com/pkg/errors",
+    "github.com/rcrowley/go-metrics",
     "github.com/smartystreets/goconvey/convey",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
+    "github.com/tendermint/abci/example/kvstore",
+    "github.com/tendermint/abci/server",
+    "github.com/tendermint/abci/types",
+    "github.com/tendermint/go-amino",
     "github.com/tendermint/iavl",
-    "github.com/tendermint/tendermint/abci/server",
-    "github.com/tendermint/tendermint/abci/types",
+    "github.com/tendermint/tendermint/config",
     "github.com/tendermint/tendermint/libs/common",
     "github.com/tendermint/tendermint/libs/db",
     "github.com/tendermint/tendermint/libs/log",
+    "github.com/tendermint/tendermint/libs/pubsub",
+    "github.com/tendermint/tendermint/node",
+    "github.com/tendermint/tendermint/rpc/client",
+    "github.com/tendermint/tendermint/rpc/core/types",
+    "github.com/tendermint/tendermint/rpc/lib/types",
+    "github.com/tendermint/tendermint/rpc/test",
+    "github.com/tendermint/tendermint/types",
+    "github.com/tendermint/tmlibs/common",
+    "github.com/tendermint/tmlibs/log",
     "golang.org/x/crypto/ed25519",
   ]
   solver-name = "gps-cdcl"

--- a/abci.go
+++ b/abci.go
@@ -3,7 +3,7 @@ package weave
 import (
 	"fmt"
 
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/common"
 
 	"github.com/iov-one/weave/errors"

--- a/app/base.go
+++ b/app/base.go
@@ -1,7 +1,7 @@
 package app
 
 import (
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"

--- a/app/store.go
+++ b/app/store.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/iov-one/weave"

--- a/cmd/bcpd/app/app_test.go
+++ b/cmd/bcpd/app/app_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/iov-one/weave/app"

--- a/cmd/bcpd/app/init.go
+++ b/cmd/bcpd/app/init.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/iov-one/weave"

--- a/cmd/bnsd/app/app_nft_test.go
+++ b/cmd/bnsd/app/app_nft_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/iov-one/weave/x/nft/ticker"
 	"github.com/iov-one/weave/x/nft/username"
 	"github.com/stretchr/testify/require"
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 )
 
 func TestIssueNfts(t *testing.T) {

--- a/cmd/bnsd/app/app_test.go
+++ b/cmd/bnsd/app/app_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/iov-one/weave/x/cash"
 	"github.com/iov-one/weave/x/namecoin"
 	"github.com/iov-one/weave/x/sigs"
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 )
 
 func TestApp(t *testing.T) {

--- a/cmd/bnsd/app/init.go
+++ b/cmd/bnsd/app/init.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/iov-one/weave"

--- a/cmd/bnsd/app/testdata/fixtures/app.go
+++ b/cmd/bnsd/app/testdata/fixtures/app.go
@@ -10,7 +10,7 @@ import (
 	"github.com/iov-one/weave/crypto"
 	"github.com/iov-one/weave/x"
 	"github.com/iov-one/weave/x/namecoin"
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 )
 

--- a/commands/server/start.go
+++ b/commands/server/start.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/tendermint/tendermint/abci/server"
-	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/abci/server"
+	abci "github.com/tendermint/abci/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/libs/log"
 )

--- a/context.go
+++ b/context.go
@@ -27,7 +27,7 @@ import (
 	"fmt"
 	"regexp"
 
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 )
 

--- a/examples/mycoind/app/app_test.go
+++ b/examples/mycoind/app/app_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/iov-one/weave"

--- a/examples/mycoind/app/init.go
+++ b/examples/mycoind/app/init.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/iov-one/weave"

--- a/x/validators/controller.go
+++ b/x/validators/controller.go
@@ -4,7 +4,7 @@ import (
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/orm"
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 )
 
 type CheckAddress func(address weave.Address) bool

--- a/x/validators/controller_test.go
+++ b/x/validators/controller_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/x/cash"
 	. "github.com/smartystreets/goconvey/convey"
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 )
 
 func TestController(t *testing.T) {

--- a/x/validators/msg.go
+++ b/x/validators/msg.go
@@ -2,7 +2,7 @@ package validators
 
 import (
 	"github.com/iov-one/weave"
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/tendermint/abci/types"
 )
 
 // Ensure we implement the Msg interface


### PR DESCRIPTION
With Tendermint v0.25.x the abci lib was moved into the tendermint project itself. This patch replaces the imports and adds an updates Gopkg.lock