### PR TITLE
Better NFT errors

### DIFF
--- a/x/nft/base/handler.go
+++ b/x/nft/base/handler.go
@@ -42,7 +42,7 @@ func loadToken(bucket nft.BucketAccess, store weave.KVStore, id []byte) (orm.Obj
 	case err != nil:
 		return nil, nil, err
 	case o == nil:
-		return nil, nil, nft.ErrUnknownID()
+		return nil, nil, nft.ErrUnknownID(id)
 	}
 	t, e := asBase(o)
 	return o, t, e

--- a/x/nft/blockchain/handler.go
+++ b/x/nft/blockchain/handler.go
@@ -51,13 +51,14 @@ func (h IssueHandler) Deliver(ctx weave.Context, store weave.KVStore, tx weave.T
 		return res, err
 	}
 	//TODO: Need to discuss, maybe we need to also validate the linked blockchainID vs ours
-	if len(msg.Details.Chain.MainTickerID) != 0 {
-		ticker, err := h.tickerBucket.Get(store, msg.Details.Chain.MainTickerID)
+	mainTicker := msg.Details.Chain.MainTickerID
+	if len(mainTicker) != 0 {
+		ticker, err := h.tickerBucket.Get(store, mainTicker)
 		switch {
 		case err != nil:
 			return res, err
 		case ticker == nil:
-			return res, nft.ErrInvalidEntry()
+			return res, nft.ErrInvalidEntry(mainTicker)
 		}
 	}
 	o, err := h.bucket.Create(store, weave.Address(msg.Owner), msg.Id, msg.Approvals, msg.Details.Chain, msg.Details.Iov)

--- a/x/nft/blockchain/model.go
+++ b/x/nft/blockchain/model.go
@@ -100,7 +100,7 @@ func (m *TokenDetails) Validate() error {
 
 func (m IOV) Validate() error {
 	if !IsValidCodec(m.Codec) {
-		return nft.ErrInvalidCodec()
+		return nft.ErrInvalidCodec(m.Codec)
 	}
 
 	if m.CodecConfig != "" {

--- a/x/nft/blockchain/msg.go
+++ b/x/nft/blockchain/msg.go
@@ -34,7 +34,7 @@ func (i *IssueTokenMsg) Validate() error {
 	}
 
 	if !IsValidID(string(i.Id)) {
-		return nft.ErrInvalidID()
+		return nft.ErrInvalidID(i.Id)
 	}
 	if err := i.Details.Validate(); err != nil {
 		return err

--- a/x/nft/bootstrap_node/handler.go
+++ b/x/nft/bootstrap_node/handler.go
@@ -56,7 +56,7 @@ func (h IssueHandler) Deliver(ctx weave.Context, store weave.KVStore, tx weave.T
 	case err != nil:
 		return res, err
 	case chain == nil:
-		return res, nft.ErrInvalidEntry()
+		return res, nft.ErrInvalidEntry(msg.Details.BlockchainID)
 	}
 	o, err := h.bucket.Create(store, weave.Address(msg.Owner), msg.Id, msg.Approvals, msg.Details.BlockchainID, msg.Details.Uri)
 	if err != nil {

--- a/x/nft/bootstrap_node/model.go
+++ b/x/nft/bootstrap_node/model.go
@@ -106,7 +106,7 @@ func (m *TokenDetails) Validate() error {
 		return errors.ErrInternal("must not be nil")
 	}
 	if m.BlockchainID == nil || !blockchain.IsValidID(string(m.BlockchainID)) {
-		return nft.ErrInvalidEntry()
+		return nft.ErrInvalidEntry(m.BlockchainID)
 	}
 	return m.Uri.Validate()
 }

--- a/x/nft/bootstrap_node/msg.go
+++ b/x/nft/bootstrap_node/msg.go
@@ -34,7 +34,7 @@ func (i *IssueTokenMsg) Validate() error {
 	}
 
 	if !IsValidID(string(i.Id)) {
-		return nft.ErrInvalidID()
+		return nft.ErrInvalidID(i.Id)
 	}
 	if err := i.Details.Validate(); err != nil {
 		return err

--- a/x/nft/bucket.go
+++ b/x/nft/bucket.go
@@ -48,7 +48,7 @@ func (b *bucketDispatcher) Register(t string, bucket BucketAccess) error {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 	if _, ok := b.bucketMap[t]; ok {
-		return ErrDuplicateEntry()
+		return ErrDuplicateEntry([]byte(t))
 	}
 	b.bucketMap[t] = bucket
 

--- a/x/nft/errors.go
+++ b/x/nft/errors.go
@@ -1,6 +1,7 @@
 package nft
 
 import (
+	"encoding/hex"
 	stderrors "errors"
 
 	"github.com/iov-one/weave/errors"
@@ -74,4 +75,24 @@ func ErrInvalidCodec() error {
 }
 func ErrInvalidJson() error {
 	return errors.WithCode(errInvalidJson, CodeInvalidJson)
+}
+
+// id's are stored as bytes, but most are ascii text
+// if in ascii, just convert to string
+// if not, hex-encode it and prefix with 0x
+func printableId(id []byte) string {
+	if isSafeAscii(id) {
+		return string(id)
+	}
+	return "0x" + hex.EncodeToString(id)
+}
+
+// require all bytes between 0x20 and 0x7f
+func isSafeAscii(id []byte) bool {
+	for _, c := range id {
+		if c < 0x20 || c > 0x7f {
+			return false
+		}
+	}
+	return true
 }

--- a/x/nft/errors.go
+++ b/x/nft/errors.go
@@ -43,20 +43,20 @@ func ErrUnsupportedTokenType() error {
 	return errors.WithCode(errUnsupportedTokenType, CodeUnsupportedTokenType)
 }
 
-func ErrInvalidID() error {
-	return errors.WithCode(errInvalidID, CodeInvalidID)
+func ErrInvalidID(id []byte) error {
+	return errors.WithLog(printableId(id), errInvalidID, CodeInvalidID)
 }
-func ErrDuplicateEntry() error {
-	return errors.WithCode(errDuplicateEntry, CodeDuplicateEntry)
+func ErrDuplicateEntry(id []byte) error {
+	return errors.WithLog(printableId(id), errDuplicateEntry, CodeDuplicateEntry)
 }
 func ErrMissingEntry() error {
 	return errors.WithCode(errMissingEntry, CodeMissingEntry)
 }
-func ErrInvalidEntry() error {
-	return errors.WithCode(errInvalidEntry, CodeInvalidEntry)
+func ErrInvalidEntry(id []byte) error {
+	return errors.WithLog(printableId(id), errInvalidEntry, CodeInvalidEntry)
 }
-func ErrUnknownID() error {
-	return errors.WithCode(errUnknownID, CodeUnknownID)
+func ErrUnknownID(id []byte) error {
+	return errors.WithLog(printableId(id), errUnknownID, CodeUnknownID)
 }
 func ErrInvalidLength() error {
 	return errors.WithCode(errInvalidLength, CodeInvalidLength)
@@ -70,8 +70,8 @@ func ErrInvalidPort() error {
 func ErrInvalidProtocol() error {
 	return errors.WithCode(errInvalidProtocol, CodeInvalidProtocol)
 }
-func ErrInvalidCodec() error {
-	return errors.WithCode(errInvalidCodec, CodeInvalidCodec)
+func ErrInvalidCodec(codec string) error {
+	return errors.WithLog(codec, errInvalidCodec, CodeInvalidCodec)
 }
 func ErrInvalidJson() error {
 	return errors.WithCode(errInvalidJson, CodeInvalidJson)
@@ -81,6 +81,9 @@ func ErrInvalidJson() error {
 // if in ascii, just convert to string
 // if not, hex-encode it and prefix with 0x
 func printableId(id []byte) string {
+	if len(id) == 0 {
+		return "<nil>"
+	}
 	if isSafeAscii(id) {
 		return string(id)
 	}

--- a/x/nft/errors_test.go
+++ b/x/nft/errors_test.go
@@ -19,6 +19,7 @@ func TestPrintableId(t *testing.T) {
 		{[]byte{0x88, 0x99, 0xad, 0x00}, "0x8899ad00"},
 		// newline, or any control chars should also trigger hex
 		{[]byte{0x43, 0x55, 0x0a, 0x57}, "0x43550a57"},
+		{nil, "<nil>"},
 	}
 
 	for i, tc := range cases {

--- a/x/nft/errors_test.go
+++ b/x/nft/errors_test.go
@@ -1,0 +1,30 @@
+package nft
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintableId(t *testing.T) {
+	cases := []struct {
+		id       []byte
+		expected string
+	}{
+		// print as strings
+		{[]byte("ATOM"), "ATOM"},
+		{[]byte("test-chain-Ad6d2dD"), "test-chain-Ad6d2dD"},
+		// print as hex (special chars)
+		{[]byte{0x88, 0x99, 0xad, 0x00}, "0x8899ad00"},
+		// newline, or any control chars should also trigger hex
+		{[]byte{0x43, 0x55, 0x0a, 0x57}, "0x43550a57"},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(tt *testing.T) {
+			printable := printableId(tc.id)
+			assert.Equal(t, tc.expected, printable)
+		})
+	}
+}

--- a/x/nft/model.go
+++ b/x/nft/model.go
@@ -10,7 +10,7 @@ var _ orm.CloneableData = (*NonFungibleToken)(nil)
 func (m *NonFungibleToken) Validate() error {
 	var validation *Validation
 	if !validation.IsValidTokenID(m.Id) {
-		return ErrInvalidID()
+		return ErrInvalidID(m.Id)
 	}
 
 	if err := weave.Address(m.Owner).Validate(); err != nil {

--- a/x/nft/ticker/handler.go
+++ b/x/nft/ticker/handler.go
@@ -55,7 +55,7 @@ func (h IssueHandler) Deliver(ctx weave.Context, store weave.KVStore, tx weave.T
 	case err != nil:
 		return res, err
 	case chain == nil:
-		return res, nft.ErrInvalidEntry()
+		return res, nft.ErrInvalidEntry(msg.Details.BlockchainID)
 	}
 	o, err := h.bucket.Create(store, weave.Address(msg.Owner), msg.Id, msg.Approvals, msg.Details.BlockchainID)
 	if err != nil {

--- a/x/nft/ticker/model.go
+++ b/x/nft/ticker/model.go
@@ -74,7 +74,7 @@ func (m *TokenDetails) Validate() error {
 		return errors.ErrInternal("must not be nil")
 	}
 	if m.BlockchainID == nil || !blockchain.IsValidID(string(m.BlockchainID)) {
-		return nft.ErrInvalidEntry()
+		return nft.ErrInvalidEntry(m.BlockchainID)
 	}
 	return nil
 }

--- a/x/nft/ticker/msg.go
+++ b/x/nft/ticker/msg.go
@@ -34,7 +34,7 @@ func (i *IssueTokenMsg) Validate() error {
 	}
 
 	if !IsValidID(string(i.Id)) {
-		return nft.ErrInvalidID()
+		return nft.ErrInvalidID(i.Id)
 	}
 	if err := i.Details.Validate(); err != nil {
 		return err

--- a/x/nft/username/handler.go
+++ b/x/nft/username/handler.go
@@ -68,7 +68,7 @@ func (h IssueHandler) Deliver(ctx weave.Context, store weave.KVStore, tx weave.T
 		case err != nil:
 			return res, err
 		case chain == nil:
-			return res, nft.ErrInvalidEntry()
+			return res, nft.ErrInvalidEntry(a.ChainID)
 		}
 	}
 	// persist the data
@@ -133,7 +133,7 @@ func (h AddChainAddressHandler) Deliver(ctx weave.Context, store weave.KVStore, 
 	case err != nil:
 		return res, err
 	case chain == nil:
-		return res, nft.ErrInvalidEntry()
+		return res, nft.ErrInvalidEntry(msg.ChainID)
 	}
 
 	o, t, err := loadToken(h.tokenHandler, store, msg.GetId())
@@ -201,7 +201,7 @@ func (h RemoveChainAddressHandler) Deliver(ctx weave.Context, store weave.KVStor
 		return res, errors.ErrUnauthorized()
 	}
 	if len(t.GetChainAddresses()) == 0 {
-		return res, nft.ErrInvalidEntry()
+		return res, nft.ErrInvalidEntry([]byte("no chain to delete"))
 	}
 	obsoleteAddress := ChainAddress{msg.GetChainID(), msg.GetAddress()}
 	newAddresses := make([]ChainAddress, 0, len(t.GetChainAddresses()))
@@ -211,7 +211,7 @@ func (h RemoveChainAddressHandler) Deliver(ctx weave.Context, store weave.KVStor
 		}
 	}
 	if len(newAddresses) == len(t.GetChainAddresses()) {
-		return res, nft.ErrInvalidEntry()
+		return res, nft.ErrInvalidEntry([]byte("requested address not registered"))
 	}
 	if err := t.SetChainAddresses(actor, newAddresses); err != nil {
 		return res, err
@@ -240,7 +240,7 @@ func loadToken(h tokenHandler, store weave.KVStore, id []byte) (orm.Object, Toke
 	case err != nil:
 		return nil, nil, err
 	case o == nil:
-		return nil, nil, nft.ErrUnknownID()
+		return nil, nil, nft.ErrUnknownID(id)
 	}
 	t, e := AsUsername(o)
 	return o, t, e


### PR DESCRIPTION
Closes #183 

Adds some context to many of the common NFT errors.
ex. `ErrInvalidId` is not helpful when there are many sub-ids in the object that could trigger the issue (eg. chainId inside of a username nft). 

This now adds a bit of context to help debugging, especially client side, where there is not the luxury of unit tests and full stack traces.