### PR TITLE
fix sequence key creation

### DIFF
--- a/orm/bucket_test.go
+++ b/orm/bucket_test.go
@@ -149,7 +149,7 @@ func TestBucketSequence(t *testing.T) {
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
 			s := tc.bucket.Sequence(tc.seq)
-			res := incrementN(s, db, tc.add)
+			res, _ := s.increment(db, tc.add)
 			assert.Equal(t, tc.expect, res)
 		})
 	}

--- a/orm/sequence_test.go
+++ b/orm/sequence_test.go
@@ -1,52 +1,41 @@
 package orm
 
 import (
-	"bytes"
-	"fmt"
 	"testing"
 
-	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/store"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSequence(t *testing.T) {
 	db := store.MemStore()
-
-	cases := []struct {
-		bucket, name string
-		init         int64
-		increments   int64
-	}{
-		0: {"a", "bc", 0, 22},
-		1: {"ab", "c", 0, 11},
-		2: {"a", "bc", 22, 18},
-		3: {"", "abc", 0, 77},
-		4: {"ab", "c", 11, 248},
+	// Test using multiple sequences to ensure they do not share state.
+	sequences := []Sequence{
+		NewSequence("bucket-name-1", "sequence-name-1"),
+		NewSequence("bucket-name-1", "sequence-name-2"),
+		NewSequence("bucket-name-2", "sequence-name-1"),
+		NewSequence("bucket-name-2", "sequence-name-2"),
 	}
-
-	for i, tc := range cases {
-		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
-			s := NewSequence(tc.bucket, tc.name)
-			_, orig := s.curVal(db)
-
-			val := incrementN(s, db, tc.increments)
-			// expect the final value to be this
-			expect := tc.init + tc.increments
-			assert.Equal(t, expect, val)
-
-			// make sure final value is bigger than original value
-			// if we use the raw bytes to index stuff
-			_, last := s.curVal(db)
-			assert.Equal(t, 1, bytes.Compare(last, orig))
-		})
+	// Uninitialized sequence counter starts at 1.
+	for want := int64(1); want < 50; want++ {
+		// Ensure that multiple sequences can be used within the same
+		// store.
+		for _, s := range sequences {
+			got := s.NextInt(db)
+			if got != want {
+				t.Fatalf("want %d, got %d", want, got)
+			}
+		}
 	}
 }
 
-func incrementN(s Sequence, db weave.KVStore, n int64) int64 {
-	var val int64
-	for i := int64(0); i < n; i++ {
-		val = s.NextInt(db)
+func TestSequenceKeyFormat(t *testing.T) {
+	db := store.MemStore()
+	s := NewSequence("bucket", "name")
+	s.NextVal(db)
+	// As defined in NewSequence documentation
+	key := `_s.bucket:name`
+	if !db.Has([]byte(key)) {
+		t.Fatal("sequence not found in store, invalid key?")
 	}
-	return val
+
 }


### PR DESCRIPTION
Remove sequence duplicate prefix. Refactor and cleanup sequence code.

fix #168

This pull request came up much bigger than expected. :rabbit: :hole: 