### PR TITLE
fix bucket.Create method description

### DIFF
--- a/x/escrow/handler.go
+++ b/x/escrow/handler.go
@@ -88,11 +88,7 @@ func (h CreateEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 		Timeout:   msg.Timeout,
 		Memo:      msg.Memo,
 	}
-	obj, err := h.bucket.Create(db, escrow)
-	if err != nil {
-		return res, err
-	}
-
+	obj := h.bucket.Build(db, escrow)
 	if err := h.ops.Deposit(db, escrow, obj.Key(), sender, msg.Amount); err != nil {
 		return res, err
 	}

--- a/x/escrow/handler_test.go
+++ b/x/escrow/handler_test.go
@@ -6,9 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/app"
 	"github.com/iov-one/weave/orm"
@@ -16,6 +13,8 @@ import (
 	"github.com/iov-one/weave/x"
 	"github.com/iov-one/weave/x/cash"
 	"github.com/iov-one/weave/x/hashlock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const Timeout = 12345

--- a/x/escrow/model.go
+++ b/x/escrow/model.go
@@ -158,12 +158,11 @@ func idxArbiter(obj orm.Object) ([]byte, error) {
 	return esc.Arbiter, nil
 }
 
-// Create assigns an ID to given escrow instance, saves it and returns as an
-// orm Object.
-func (b Bucket) Create(db weave.KVStore, escrow *Escrow) (orm.Object, error) {
+// Build assigns an ID to given escrow instance and returns it as an orm
+// Object. It does not persist the escrow in the store.
+func (b Bucket) Build(db weave.KVStore, escrow *Escrow) orm.Object {
 	key := b.idSeq.NextVal(db)
-	obj := orm.NewSimpleObj(key, escrow)
-	return obj, b.Save(db, obj)
+	return orm.NewSimpleObj(key, escrow)
 }
 
 // Save enforces the proper type

--- a/x/escrow/model.go
+++ b/x/escrow/model.go
@@ -158,13 +158,12 @@ func idxArbiter(obj orm.Object) ([]byte, error) {
 	return esc.Arbiter, nil
 }
 
-// Create will calculate the next sequence number and then
-// store the escrow there.
-// Saves the object and returns it (to inspect the ID)
+// Create assigns an ID to given escrow instance, saves it and returns as an
+// orm Object.
 func (b Bucket) Create(db weave.KVStore, escrow *Escrow) (orm.Object, error) {
 	key := b.idSeq.NextVal(db)
 	obj := orm.NewSimpleObj(key, escrow)
-	return obj, nil
+	return obj, b.Save(db, obj)
 }
 
 // Save enforces the proper type


### PR DESCRIPTION
Escrow `Bucket.Create` method documentation is updated to be acurate.

fix #170

I think `Bucket.Create` method should be removed and assignment of an escrow ID moved to `Deposit` method. Current implementation goes through many indirect steps to achieve something that would best done in one place.