### PR TITLE
Add proof-of-concept .proto documentation 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.proto]
+indent_style = space
+indent_size = 4

--- a/x/codec.proto
+++ b/x/codec.proto
@@ -2,26 +2,34 @@ syntax = "proto3";
 
 package x;
 
-// Coin can hold any amount between -1 billion and +1 billion
-// at steps of 10^-9. It is a fixed-point decimal
-// representation and uses integers to avoid rounding
-// associated with floats.
-//
-// Every code has a denomination, which is just a
-//
-// If you want anything more complex, you should write your
-// own type, possibly borrowing from this code.
+/**
+ * Coin can hold any amount between -1 billion and +1 billion
+ * at steps of 10^-9. It is a fixed-point decimal
+ * representation and uses integers to avoid rounding
+ * associated with floats.
+ *
+ * Every code has a denomination, which is just a
+ *
+ * If you want anything more complex, you should write your
+ * own type, possibly borrowing from this code.
+ */
 message Coin {
-    // Whole coins, -10^15 < integer < 10^15
+    /// Whole coins, -10^15 < integer < 10^15
     int64 whole = 1;
-    // Billionth of coins. 0 <= abs(fractional) < 10^9
-    // If fractional != 0, must have same sign as integer
+    /**
+     * Billionth of coins. 0 <= abs(fractional) < 10^9
+     * If fractional != 0, must have same sign as integer
+     */
     int64 fractional = 2;
-    // Ticker is 3-4 upper-case letters and
-    // all Coins of the same currency can be combined
+    /**
+     * Ticker is 3-4 upper-case letters and
+     * all Coins of the same currency can be combined
+     */
     string ticker = 3;
-    // Issuer is optional string, maybe chain_id? maybe custodian name?
-    // can be empty. tokens are only fungible if CurrencyCode and
-    // Issuer both match.
+    /**
+     * Issuer is optional string, maybe chain_id? maybe custodian name?
+     * can be empty. tokens are only fungible if CurrencyCode and
+     * Issuer both match.
+     */
     string issuer = 4;
 }


### PR DESCRIPTION
As you can see in

> ProTip! Documenting your .proto files with /** ... */-blocks or (trailing) /// ... lines translates to generated static code.

https://github.com/dcodeIO/ProtoBuf.js/#pbjs-for-javascript there is a comment syntax that acts as documentation. Comments in this form are preserved when generating code from .proto file.

<img width="913" alt="proto_docs" src="https://user-images.githubusercontent.com/2603011/49163732-0dc72400-f32e-11e8-966b-eea0e5d2eacd.png">

This is a proof of concept or copy/paste template for documentation in .proto files.