### PR TITLE
documentatin for the extensions

### DIFF
--- a/x/escrow/doc.go
+++ b/x/escrow/doc.go
@@ -1,0 +1,18 @@
+/*
+
+Package escrow implements an Escrow.
+
+> An escrow is a financial arrangement where a third party holds and regulates
+> payment of the funds required for two parties involved in a given transaction.
+> It helps make transactions more secure by keeping the payment in a secure
+> escrow account which is only released when all of the terms of an agreement are
+> met as overseen by the escrow company.
+
+Escrow holds some coins.
+The arbiter or sender can release them to the recipient.
+The recipient can return them to the sender.
+Upon timeout, they will be returned to the sender.
+
+
+*/
+package escrow

--- a/x/hashlock/doc.go
+++ b/x/hashlock/doc.go
@@ -1,0 +1,17 @@
+/*
+
+Package hashlock implements token locking.
+
+> A Hashlock is a type of encumbrance that restricts the spending of an output
+> until a specified piece of data is publicly revealed. Hashlocks have the useful
+> property that once any hashlock is opened publicly, any other hashlock secured
+> using the same key can also be opened. This makes it possible to create
+> multiple outputs that are all encumbered by the same hashlock and which all
+> become spendable at the same time. Hashlocks have been used independently (see
+> below) but are most commonly described as part of a system such as Hashed
+> Timelock Contracts.
+
+https://en.bitcoinwiki.org/wiki/Hashlock
+
+*/
+package hashlock

--- a/x/paychan/doc.go
+++ b/x/paychan/doc.go
@@ -1,0 +1,18 @@
+/*
+Package paychan implements payment side channel functionality.
+
+Payment channel functionality  allows to deposit an amount that can be later
+transferred in chunks over that payment channel. Owner of the payment channel
+can choose to send full allocated amount or just a part of it over time and
+recipient can claim received money.  When funds from a payment channel are
+claimed, payment channel is closed and any remaining tokens are returned to the
+payment channel owner.
+
+Except creation and final closing transaction, all payment channel operations
+are made off the chain and therefore are very fast and cheap to execute.
+
+Payment channel can be closed only by the recipient when claiming received
+funds or by the payment channel owner after the deadline was reached.
+
+*/
+package paychan

--- a/x/sigs/doc.go
+++ b/x/sigs/doc.go
@@ -1,0 +1,3 @@
+/*
+ */
+package sigs


### PR DESCRIPTION
Extensions used by bcpd:
- x/escrow
- x/hashlock
- x/multisig
- x/namecoin
- x/sigs
- x/utils
- x/validators

Extensions used by bnsd:
- x/escrow
- x/hashlock
- x/multisig
- x/namecoin
- x/nft
- x/nft/base
- x/nft/blockchain
- x/nft/bootstrap_node
- x/nft/ticker
- x/nft/username
- x/sigs
- x/utils
- x/validators