### PR TITLE
x/nft/username: allow minimal address length of 2 charactes

### DIFF
--- a/x/nft/username/model.go
+++ b/x/nft/username/model.go
@@ -109,8 +109,7 @@ func (p *ChainAddress) Validate() error {
 	if !blockchain.IsValidID(string(p.ChainID)) {
 		return nft.ErrInvalidID(p.ChainID)
 	}
-	switch l := len(p.Address); {
-	case l < 12 || l > 50:
+	if n := len(p.Address); n < 2 || n > 50 {
 		return nft.ErrInvalidLength()
 	}
 	return nil

--- a/x/nft/username/model_test.go
+++ b/x/nft/username/model_test.go
@@ -88,7 +88,8 @@ func TestChainAddressValidation(t *testing.T) {
 		{chainID: "1234", address: "", expError: true}, // empty address
 		{chainID: "1234", address: "", expError: true},
 		{chainID: "", address: "123456789012", expError: true},
-		{chainID: "1234", address: "12345678901", expError: true},
+		{chainID: "1234", address: "1", expError: true},   // too short
+		{chainID: "1234", address: "1L", expError: false}, // Lisk uses <number>L with number being any uint64 number represented as decimal.
 		{chainID: "1234", address: string(anyIDWithLength(51)), expError: true},
 		{chainID: string(anyIDWithLength(257)), address: "123456789012", expError: true},
 	}

--- a/x/nft/username/msg_test.go
+++ b/x/nft/username/msg_test.go
@@ -189,6 +189,7 @@ func TestRemoveChainAddressMsgValidate(t *testing.T) {
 		})
 	}
 }
+
 func anyIDWithLength(n int) []byte {
 	r := make([]byte, n)
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
Update the chain address validation to allow address to be minimum 2
characters long.

resolve #197