### PR TITLE
x/nft/username: change chain address separator

### DIFF
--- a/cmd/bnsd/app/app_nft_test.go
+++ b/cmd/bnsd/app/app_nft_test.go
@@ -69,7 +69,7 @@ func TestIssueNfts(t *testing.T) {
 	require.EqualValues(t, 0, res.Code, res.Log)
 
 	// and query a username
-	query := abci.RequestQuery{Path: "/nft/usernames/chainaddr", Data: []byte("myChainAddress*myblockchain")}
+	query := abci.RequestQuery{Path: "/nft/usernames/chainaddr", Data: []byte("myChainAddress;myblockchain")}
 	qRes := myApp.Query(query)
 	require.EqualValues(t, 0, qRes.Code, qRes.Log)
 	var actual username.UsernameToken

--- a/x/nft/username/bucket.go
+++ b/x/nft/username/bucket.go
@@ -11,7 +11,7 @@ import (
 const (
 	BucketName            = "usrnft"
 	ChainAddressIndexName = "chainaddr"
-	chainAddressSeparator = "*"
+	chainAddressSeparator = ";"
 )
 
 type Bucket struct {

--- a/x/nft/username/handler_test.go
+++ b/x/nft/username/handler_test.go
@@ -207,13 +207,13 @@ func TestQueryUsernameToken(t *testing.T) {
 		{ // by username alice
 			"/nft/usernames", []byte("alice@example.com"), "alice@example.com"},
 		{ // by chain address
-			"/nft/usernames/chainaddr", []byte("aliceChainAddress*myChainID"), "alice@example.com"},
+			"/nft/usernames/chainaddr", []byte("aliceChainAddress;myChainID"), "alice@example.com"},
 		{ // by owner
 			"/nft/usernames/owner", alice.Address(), "alice@example.com"},
 		{ // by username bob
 			"/nft/usernames", []byte("bob@example.com"), "bob@example.com"},
 		{ // by chain address
-			"/nft/usernames/chainaddr", []byte("bobChainAddress*myChainID"), "bob@example.com"},
+			"/nft/usernames/chainaddr", []byte("bobChainAddress;myChainID"), "bob@example.com"},
 		{ // by owner
 			"/nft/usernames/owner", bob.Address(), "bob@example.com"},
 	}


### PR DESCRIPTION
Use ; for chain address separator. * (asterisk) character is used to
represent human readable address as represented by bnsd. To not confuse
those two, pick different separator character.

resolve #196