### PR TITLE
x/nft/ticker: add support for genesis file

### DIFF
--- a/cmd/bnsd/app/init.go
+++ b/cmd/bnsd/app/init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iov-one/weave/x"
 	"github.com/iov-one/weave/x/namecoin"
 	"github.com/iov-one/weave/x/nft/blockchain"
+	"github.com/iov-one/weave/x/nft/ticker"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 )
@@ -87,6 +88,7 @@ func GenerateApp(home string, logger log.Logger, debug bool) (abci.Application, 
 	application.WithInit(app.ChainInitializers(
 		&namecoin.Initializer{},
 		&blockchain.Initializer{},
+		&ticker.Initializer{},
 	))
 
 	// set the logger and return

--- a/x/nft/ticker/init.go
+++ b/x/nft/ticker/init.go
@@ -1,0 +1,50 @@
+package ticker
+
+import (
+	"github.com/iov-one/weave"
+	"github.com/pkg/errors"
+)
+
+// Initializer fulfils the InitStater interface to load data from
+// the genesis file
+type Initializer struct {
+}
+
+var _ weave.Initializer = (*Initializer)(nil)
+
+// FromGenesis will parse initial tokens information from the genesis and
+// persist it in the database.
+func (i *Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
+	var nfts struct {
+		Tickers []genesisTickerToken `json:"tickers"`
+	}
+	if err := opts.ReadOptions("nfts", &nfts); err != nil {
+		return errors.Wrap(err, "read options")
+	}
+	return setTickerTokens(db, nfts.Tickers)
+}
+
+// keep it close to the TickerToken model definition
+type genesisTickerToken struct {
+	Details struct {
+		BlockchainID string `json:"blockchain_id"`
+	} `json:"details"`
+	Base struct {
+		ID    string `json:"id"`
+		Owner string `json:"owner"`
+	} `json:"base"`
+}
+
+func setTickerTokens(db weave.KVStore, tokens []genesisTickerToken) error {
+	bucket := NewBucket()
+	for _, t := range tokens {
+		obj, err := bucket.Create(db, weave.Address(t.Base.Owner), weave.Address(t.Base.ID), nil, []byte(t.Details.BlockchainID))
+		if err != nil {
+			return err
+		}
+		if err := bucket.Save(db, obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/x/nft/ticker/init_test.go
+++ b/x/nft/ticker/init_test.go
@@ -1,0 +1,61 @@
+package ticker
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/store"
+)
+
+func TestInitializer(t *testing.T) {
+	const genesis = `
+	{
+		"nfts": {
+			"tickers": [
+				{
+					"base": {
+						"id": "id-123",
+						"owner": "owner-12300000000000"
+					},
+					"details": {
+						"blockchain_id": "chain-123"
+					}
+				}
+			]
+		}
+	}
+	`
+	var opts weave.Options
+	if err := json.Unmarshal([]byte(genesis), &opts); err != nil {
+		t.Fatalf("cannot unmarshal JSON serialized genesis: %s", err)
+	}
+
+	var ini Initializer
+	db := store.MemStore()
+	if err := ini.FromGenesis(opts, db); err != nil {
+		t.Fatalf("cannot initialize from genesis: %+v", err)
+	}
+
+	bucket := NewBucket()
+	obj, err := bucket.Get(db, []byte("id-123"))
+	if err != nil {
+		t.Fatalf("cannot find token in the database: %s", err)
+	} else if obj == nil {
+		t.Fatal("cannot find token in the database: does not exist")
+	}
+	token, ok := obj.Value().(*TickerToken)
+	if !ok {
+		t.Fatalf("returned object is not a token: %T", obj.Value())
+	}
+
+	if want, got := "id-123", string(token.Base.Id); want != got {
+		t.Fatalf("want %q, got %q", want, got)
+	}
+	if want, got := "owner-12300000000000", string(token.Base.Owner); want != got {
+		t.Fatalf("want %q, got %q", want, got)
+	}
+	if want, got := "chain-123", string(token.Details.BlockchainID); want != got {
+		t.Fatalf("want %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
Implement bootstraping ticker state from genesis file. All ticker
instances must be declared under `nfts.tickers`, for example:
```json
  {
    "nfts": {
      "tickers": [
        {
          "base": {"id": "123", "owner": "owner-12300000000000"},
	  "details": {"blockchain_id": "chain-123"}
        }
      ]
    }
  }
```
resolve #204