### PR TITLE
Remove namecoin from bnsd

### DIFF
--- a/cmd/bnsd/app/app.go
+++ b/cmd/bnsd/app/app.go
@@ -39,6 +39,10 @@ func Authenticator() x.Authenticator {
 // Chain returns a chain of decorators, to handle authentication,
 // fees, logging, and recovery
 func Chain(minFee x.Coin, authFn x.Authenticator) app.Decorators {
+	// ctrl can be initialized with any implementation, but must be used
+	// consistently everywhere.
+	var ctrl cash.Controller = cash.NewController(cash.NewBucket())
+
 	return app.ChainDecorators(
 		utils.NewLogging(),
 		utils.NewRecovery(),
@@ -47,6 +51,7 @@ func Chain(minFee x.Coin, authFn x.Authenticator) app.Decorators {
 		utils.NewSavepoint().OnCheck(),
 		sigs.NewDecorator(),
 		multisig.NewDecorator(authFn),
+		cash.NewFeeDecorator(authFn, ctrl, minFee),
 		// cannot pay for fee with hashlock...
 		hashlock.NewDecorator(),
 		// batch commented out temporarily to minimize release features

--- a/cmd/bnsd/app/codec.proto
+++ b/cmd/bnsd/app/codec.proto
@@ -5,7 +5,6 @@ package app;
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 import "github.com/iov-one/weave/x/cash/codec.proto";
 import "github.com/iov-one/weave/x/escrow/codec.proto";
-import "github.com/iov-one/weave/x/namecoin/codec.proto";
 import "github.com/iov-one/weave/x/sigs/codec.proto";
 import "github.com/iov-one/weave/x/multisig/codec.proto";
 import "github.com/iov-one/weave/x/nft/codec.proto";
@@ -21,8 +20,6 @@ message Tx {
     // msg is a sum type over all allowed messages on this chain.
     oneof sum {
         cash.SendMsg send_msg = 1;
-        namecoin.NewTokenMsg new_token_msg = 2;
-        namecoin.SetWalletNameMsg set_name_msg = 3;
         // escrow actions
         escrow.CreateEscrowMsg create_escrow_msg = 4;
         escrow.ReleaseEscrowMsg release_escrow_msg = 5;
@@ -67,8 +64,6 @@ enum NftType {
 //    message Union {
 //        oneof sum {
 //            cash.SendMsg send_msg = 1;
-//            namecoin.NewTokenMsg new_token_msg = 2;
-//            namecoin.SetWalletNameMsg set_name_msg = 3;
 //            // escrow actions
 //            escrow.CreateEscrowMsg create_escrow_msg = 4;
 //            escrow.ReleaseEscrowMsg release_escrow_msg = 5;

--- a/cmd/bnsd/app/init.go
+++ b/cmd/bnsd/app/init.go
@@ -10,7 +10,7 @@ import (
 	"github.com/iov-one/weave/app"
 	"github.com/iov-one/weave/crypto"
 	"github.com/iov-one/weave/x"
-	"github.com/iov-one/weave/x/namecoin"
+	"github.com/iov-one/weave/x/cash"
 	"github.com/iov-one/weave/x/nft/blockchain"
 	"github.com/iov-one/weave/x/nft/ticker"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -45,10 +45,9 @@ func GenInitOptions(args []string) (json.RawMessage, error) {
 	}
 
 	opts := fmt.Sprintf(`{
-    "wallets": [
+    "cash": [
       {
         "address": "%s",
-        "name": "admin",
         "coins": [
           {
             "whole": 123456789,
@@ -57,17 +56,10 @@ func GenInitOptions(args []string) (json.RawMessage, error) {
         ]
       }
     ],
-    "tokens": [
-      {
-        "ticker": "%s",
-        "name": "Main token of this chain",
-        "sig_figs": 6
-      }
-    ],
     "nfts": {
       "blockchains": []
     }
-  }`, addr, ticker, ticker)
+  }`, addr, ticker)
 	return []byte(opts), nil
 }
 
@@ -86,7 +78,7 @@ func GenerateApp(home string, logger log.Logger, debug bool) (abci.Application, 
 		return nil, err
 	}
 	application.WithInit(app.ChainInitializers(
-		&namecoin.Initializer{},
+		&cash.Initializer{},
 		&blockchain.Initializer{},
 		&ticker.Initializer{},
 	))

--- a/cmd/bnsd/app/testdata/fixtures/app.go
+++ b/cmd/bnsd/app/testdata/fixtures/app.go
@@ -5,37 +5,31 @@ import (
 	"math/rand"
 
 	"github.com/iov-one/weave"
-	weave_app "github.com/iov-one/weave/app"
+	weaveApp "github.com/iov-one/weave/app"
 	"github.com/iov-one/weave/cmd/bnsd/app"
 	"github.com/iov-one/weave/crypto"
 	"github.com/iov-one/weave/x"
-	"github.com/iov-one/weave/x/namecoin"
+	"github.com/iov-one/weave/x/cash"
+	"github.com/iov-one/weave/x/nft/blockchain"
+	"github.com/iov-one/weave/x/nft/ticker"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 )
 
-const appState = `{
-        "wallets": [{
-            "name": "demote",
-            "address": "%s",
-            "coins": [{
-                "whole": 50000,
-                "ticker": "ETH"
-            },{
-                "whole": 1234,
-				"ticker": "FRNK"
-			}]
-		}],
-        "tokens": [{
-            "ticker": "ETH",
-            "name": "Smells like ethereum",
-            "sig_figs": 9
-        },{
-            "ticker": "FRNK",
-            "name": "Frankie",
-            "sig_figs": 3
-		}]
-	}`
+const appState = `
+  {
+    "cash": [
+      {
+        "name": "demote",
+        "address": "%s",
+        "coins": [
+          {"whole": 50000, "ticker": "ETH"},
+          {"whole": 1234, "ticker": "FRNK"}
+        ]
+      }
+    ]
+  }
+`
 
 type AppFixture struct {
 	Name              string
@@ -56,14 +50,18 @@ func NewApp() *AppFixture {
 	}
 }
 
-func (f AppFixture) Build() weave_app.BaseApp {
+func (f AppFixture) Build() weaveApp.BaseApp {
 	// setup app
 	stack := app.Stack(x.Coin{}, nil)
 	myApp, err := app.Application(f.Name, stack, app.TxDecoder, "", true)
 	if err != nil {
 		panic(err)
 	}
-	myApp.WithInit(namecoin.Initializer{})
+	myApp.WithInit(weaveApp.ChainInitializers(
+		&cash.Initializer{},
+		&blockchain.Initializer{},
+		&ticker.Initializer{},
+	))
 	myApp.WithLogger(log.NewNopLogger())
 	// load state
 

--- a/cmd/bnsd/client/client.go
+++ b/cmd/bnsd/client/client.go
@@ -388,40 +388,6 @@ func (b *BnsClient) GetWallet(addr weave.Address) (*WalletResponse, error) {
 	return &out, nil
 }
 
-// GetWalletByName will return a wallet given the wallet name
-func (b *BnsClient) GetWalletByName(name string) (*WalletResponse, error) {
-	// query by secondary index on name
-	resp, err := b.AbciQuery("/wallets/name", []byte(name))
-	if err != nil {
-		return nil, err
-	}
-	if len(resp.Models) == 0 { // empty list or nil
-		return nil, nil // no wallet
-	}
-	// assume only one result
-	model := resp.Models[0]
-
-	// make sure the return value is expected
-	acct := walletKeyToAddr(model.Key)
-	err = acct.Validate()
-	if err != nil {
-		return nil, errors.WithMessage(err, "Returned invalid Address")
-	}
-	out := WalletResponse{
-		Address: acct,
-		Height:  resp.Height,
-	}
-
-	// TODO: double parse this into result set???
-
-	// parse the value as wallet bytes
-	err = out.Wallet.Unmarshal(model.Value)
-	if err != nil {
-		return nil, err
-	}
-	return &out, nil
-}
-
 // key is the address prefixed with "wallet:"
 func walletKeyToAddr(key []byte) weave.Address {
 	return key[5:]

--- a/cmd/bnsd/client/client_test.go
+++ b/cmd/bnsd/client/client_test.go
@@ -5,13 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/iov-one/weave/x"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"github.com/tendermint/tendermint/rpc/client"
 	rpctest "github.com/tendermint/tendermint/rpc/test"
-
-	"github.com/iov-one/weave/x"
 )
 
 // blocks go by fast, no need to wait seconds....
@@ -40,8 +38,6 @@ func TestMainSetup(t *testing.T) {
 }
 
 func TestWalletQuery(t *testing.T) {
-	missing := GenPrivateKey().PublicKey().Address()
-
 	conn := NewLocalConnection(node)
 	bcp := NewClient(conn)
 	client.WaitForHeight(conn, 5, fastWaiter)
@@ -51,52 +47,24 @@ func TestWalletQuery(t *testing.T) {
 	assert.Error(t, err)
 
 	// missing account returns nothing
+	missing := GenPrivateKey().PublicKey().Address()
 	wallet, err := bcp.GetWallet(missing)
 	assert.NoError(t, err)
 	assert.Nil(t, wallet)
 
 	// genesis account returns something
-	money := faucet.PublicKey().Address()
-	wallet, err = bcp.GetWallet(money)
+	address := faucet.PublicKey().Address()
+	wallet, err = bcp.GetWallet(address)
 	assert.NoError(t, err)
 	require.NotNil(t, wallet)
 	// make sure we get some reasonable height
 	assert.True(t, wallet.Height > 4)
 	// ensure the key matches
-	assert.EqualValues(t, money, wallet.Address)
+	assert.EqualValues(t, address, wallet.Address)
 	// check the wallet
-	assert.Equal(t, "faucet", wallet.Wallet.Name)
 	require.Equal(t, 1, len(wallet.Wallet.Coins))
 	coin := wallet.Wallet.Coins[0]
 	assert.Equal(t, initBalance.Whole, coin.Whole)
-	assert.Equal(t, initBalance.Ticker, coin.Ticker)
-}
-
-func TestWalletNameQuery(t *testing.T) {
-	conn := NewLocalConnection(node)
-	bcp := NewClient(conn)
-	client.WaitForHeight(conn, 5, fastWaiter)
-
-	// missing account returns nothing
-	wallet, err := bcp.GetWalletByName("nobody")
-	assert.NoError(t, err)
-	assert.Nil(t, wallet)
-
-	// genesis account returns something
-	wallet, err = bcp.GetWalletByName("faucet")
-	assert.NoError(t, err)
-	require.NotNil(t, wallet)
-	// make sure we get some reasonable height
-	assert.True(t, wallet.Height > 4)
-	// ensure the key matches
-	assert.EqualValues(t, faucet.PublicKey().Address(),
-		wallet.Address)
-	// check the wallet
-	assert.Equal(t, "faucet", wallet.Wallet.Name)
-	require.Equal(t, 1, len(wallet.Wallet.Coins))
-	coin := wallet.Wallet.Coins[0]
-	// this may be reduced by other tests so no guarantees
-	assert.True(t, coin.Whole > 100000)
 	assert.Equal(t, initBalance.Ticker, coin.Ticker)
 }
 

--- a/cmd/bnsd/commands/init_test.go
+++ b/cmd/bnsd/commands/init_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,13 +10,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/tendermint/tendermint/libs/log"
-
+	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/cmd/bnsd/app"
 	"github.com/iov-one/weave/commands/server"
+	"github.com/iov-one/weave/x"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 func TestInit(t *testing.T) {
@@ -30,20 +31,29 @@ func TestInit(t *testing.T) {
 	// make sure we set proper data
 	genFile := filepath.Join(home, "config", "genesis.json")
 
-	var doc server.GenesisDoc
 	bz, err := ioutil.ReadFile(genFile)
 	require.NoError(t, err)
-	err = json.Unmarshal(bz, &doc)
-	require.NoError(t, err)
-	// keep old values, and add our values
-	assert.EqualValues(t, []byte(`"test-chain-LgVOZ0"`),
-		doc["chain_id"])
-	assert.NotEmpty(t, doc["validators"])
-	assert.NotEmpty(t, doc[server.AppStateKey])
-	assert.Contains(t, string(doc[server.AppStateKey]), `"ticker": "ETH"`)
-	assert.Contains(t, string(doc[server.AppStateKey]), `"name": "admin"`)
-	assert.Contains(t, string(doc[server.AppStateKey]), `"wallets":`)
-	assert.Contains(t, string(doc[server.AppStateKey]), `"tokens":`)
+
+	var genesis struct {
+		State struct {
+			Cash []struct {
+				Address weave.Address
+				Coins   x.Coins
+			}
+		} `json:"app_state"`
+	}
+	err = json.Unmarshal(bz, &genesis)
+	assert.NoErrorf(t, err, "cannot unmarshal genesis: %s", err)
+
+	if assert.Equal(t, 1, len(genesis.State.Cash), string(bz)) {
+		wallet := genesis.State.Cash[0]
+		want, err := hex.DecodeString(args[1])
+		assert.NoError(t, err)
+		assert.Equal(t, weave.Address(want), wallet.Address)
+		if assert.Equal(t, 1, len(wallet.Coins), "Genesis: %s", bz) {
+			assert.Equal(t, &x.Coin{Ticker: args[0], Whole: 123456789}, wallet.Coins[0])
+		}
+	}
 }
 
 // setupConfig creates a homedir to run inside,

--- a/cmd/bnsd/scenarios/main_test.go
+++ b/cmd/bnsd/scenarios/main_test.go
@@ -102,55 +102,33 @@ func initGenesis(filename string, addr weave.Address) (*tm.GenesisDoc, error) {
 	}
 
 	// set app state
-	appState := fmt.Sprintf(`{
-  "wallets": [
-    {
-      "name": "alice",
-      "address": "%s",
-      "coins": [
-        {
-          "whole": 123456789,
-          "ticker": "IOV"
-        },
-        {
-          "whole": 123456789,
-          "ticker": "CASH"
-        },
-        {
-          "whole": 123456789,
-          "ticker": "ALX"
-        },
-        {
-          "whole": 123456789,
-          "ticker": "PAJA"
-        }
-      ]
-    }
-  ],
-  "tokens": [
-    {
-      "ticker": "IOV",
-      "name": "Main token of this chain",
-      "sig_figs": 6
-    },
-    {
-      "ticker": "CASH",
-      "name": "Second token of this chain",
-      "sig_figs": 6
-    },
-    {
-      "ticker": "ALX",
-      "name": "Third token of this chain",
-      "sig_figs": 6
-    },
-    {
-      "ticker": "PAJA",
-      "name": "Mightiest token of this chain",
-      "sig_figs": 9
-    }
-  ]
-}
-`, addr)
+	appState := fmt.Sprintf(`
+	{
+	  "cash": [
+	    {
+	      "address": "%s",
+	      "coins": [
+		{
+		  "whole": 123456789,
+		  "ticker": "IOV"
+		},
+		{
+		  "whole": 123456789,
+		  "ticker": "CASH"
+		},
+		{
+		  "whole": 123456789,
+		  "ticker": "ALX"
+		},
+		{
+		  "whole": 123456789,
+		  "ticker": "PAJA"
+		}
+	      ]
+	    }
+	  ]
+	}
+	`, addr)
 	doc.AppState = []byte(appState)
 	// save file
 	return doc, doc.SaveAs(filename)


### PR DESCRIPTION
`x/namecoin` usage was removed from bnsd. Instead, `x/cash` is used to
provide wallet functionality.

- wallets no longer have a name
- tickets registration is no longer available
- wallet initialization via genesis is done via `x/cash`, using `cash`
  key, for example:
```
    {
      "cash": [
        {
          "address": "ABCD12345677890",
          "coins": [{"whole": 123456789, "ticker": "DOGE"}]
        }
      ]
    }
```