### PR TITLE
refactor tests using tendermint server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
 - GORACE="halt_on_error=1"
   BUILD_VERSION=$(echo ${TRAVIS_COMMIT} | cut -c 1-10)
   TM_VERSION=v0.25.0
+  FORCE_TM_TEST=1
 
 install:
 - make deps

--- a/cmd/bcpd/commands/start_test.go
+++ b/cmd/bcpd/commands/start_test.go
@@ -1,20 +1,17 @@
 package commands
 
 import (
-	"fmt"
+	"context"
+	"errors"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/tendermint/tendermint/libs/log"
-
 	"github.com/iov-one/weave/cmd/bcpd/app"
 	"github.com/iov-one/weave/commands/server"
+	"github.com/iov-one/weave/tmtest"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 func TestStartStandAlone(t *testing.T) {
@@ -40,41 +37,6 @@ func TestStartStandAlone(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestStartWithTendermint(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping Tendermint integration test")
-	}
-
-	home := setupConfig(t)
-	defer os.RemoveAll(home)
-
-	const runTime = 5     // how many seconds to run both processes
-	const startupTime = 2 // how many seconds to let tendermint startup
-
-	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).
-		With("module", "test-cmd")
-	err := server.InitCmd(app.GenInitOptions, logger, home, nil)
-	require.NoError(t, err)
-
-	// start up tendermint process in the background...
-	// this will block 2 seconds and ensure tendermint lives
-	// at least 3 seconds after we run StartCmd
-	runTendermint(t, home, startupTime, runTime)
-
-	// set up app and start up
-	args := []string{"-bind", "localhost:46658"}
-	runStart := func() error {
-		return server.StartCmd(app.GenerateApp, logger, home, args)
-	}
-	timeout := time.Duration(runTime+1) * time.Second
-	err = runOrTimeout(runStart, timeout)
-	require.NoError(t, err)
-
-	// give time for tendermint to shut down
-	fmt.Println(">>> Waiting for tendermint to shut down")
-	time.Sleep(time.Second + time.Second)
-}
-
 func runOrTimeout(cmd func() error, timeout time.Duration) error {
 	done := make(chan error)
 	go func(out chan<- error) {
@@ -83,7 +45,7 @@ func runOrTimeout(cmd func() error, timeout time.Duration) error {
 		if err != nil {
 			out <- err
 		}
-		out <- fmt.Errorf("start died for unknown reasons")
+		out <- errors.New("start died for unknown reasons")
 	}(done)
 
 	timer := time.NewTimer(timeout)
@@ -95,41 +57,39 @@ func runOrTimeout(cmd func() error, timeout time.Duration) error {
 	}
 }
 
-// wait startupDelay before returning
-// fails if tendermint doesn't run at least startupDelay + timeout
-func runTendermint(t *testing.T, home string, startupDelay, timeout int64) {
-	tmBin := filepath.Join(
-		os.ExpandEnv("$GOPATH"), "bin", "tendermint")
-
-	// runTM should take longer than startupDelay and timeout...
-	runTm := func() error {
-		killTime := time.Duration(startupDelay + timeout + 2)
-
-		cmd := exec.Command(tmBin, "node", "--home", home)
-		fmt.Println(">>> Running tendermint...")
-
-		// log tendermint output for verbose debugging....
-		// cmd.Stdout = os.Stdout
-		// cmd.Stderr = os.Stdout
-
-		// run it
-		err := cmd.Start()
-		if err != nil {
-			return err
-		}
-
-		// after the given time, kill the process...
-		time.Sleep(killTime * time.Second)
-		fmt.Println("Killing tendermint...")
-		cmd.Process.Kill()
-		return nil
+func TestStartWithTendermint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping Tendermint integration test")
 	}
 
-	runTime := time.Duration(timeout + startupDelay)
-	go func(t *testing.T) {
-		err := runOrTimeout(runTm, runTime*time.Second)
-		assert.NoError(t, err)
-	}(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
 
-	time.Sleep(time.Duration(startupDelay) * time.Second)
+	home := setupConfig(t)
+	defer os.RemoveAll(home)
+
+	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).
+		With("module", "test-cmd")
+	if err := server.InitCmd(app.GenInitOptions, logger, home, nil); err != nil {
+		t.Fatalf("cannot initialize application: %s", err)
+	}
+
+	defer tmtest.RunTendermint(ctx, t, home)()
+
+	done := make(chan error, 1)
+	go func() {
+		args := []string{
+			"-bind", "localhost:46658",
+		}
+		done <- server.StartCmd(app.GenerateApp, logger, home, args)
+	}()
+
+	select {
+	case <-ctx.Done():
+		t.Logf("context cancelled before application finished")
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("application failed: %s", err)
+		}
+	}
 }

--- a/cmd/bnsd/commands/start_test.go
+++ b/cmd/bnsd/commands/start_test.go
@@ -1,20 +1,17 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/tendermint/tendermint/libs/log"
-
 	"github.com/iov-one/weave/cmd/bnsd/app"
 	"github.com/iov-one/weave/commands/server"
+	"github.com/iov-one/weave/tmtest"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 func TestStartStandAlone(t *testing.T) {
@@ -40,41 +37,6 @@ func TestStartStandAlone(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestStartWithTendermint(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping Tendermint integration test")
-	}
-
-	home := setupConfig(t)
-	defer os.RemoveAll(home)
-
-	const runTime = 5     // how many seconds to run both processes
-	const startupTime = 2 // how many seconds to let tendermint startup
-
-	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).
-		With("module", "test-cmd")
-	err := server.InitCmd(app.GenInitOptions, logger, home, nil)
-	require.NoError(t, err)
-
-	// start up tendermint process in the background...
-	// this will block 2 seconds and ensure tendermint lives
-	// at least 3 seconds after we run StartCmd
-	runTendermint(t, home, startupTime, runTime)
-
-	// set up app and start up
-	args := []string{"-bind", "localhost:46658"}
-	runStart := func() error {
-		return server.StartCmd(app.GenerateApp, logger, home, args)
-	}
-	timeout := time.Duration(runTime+1) * time.Second
-	err = runOrTimeout(runStart, timeout)
-	require.NoError(t, err)
-
-	// give time for tendermint to shut down
-	fmt.Println(">>> Waiting for tendermint to shut down")
-	time.Sleep(time.Second + time.Second)
-}
-
 func runOrTimeout(cmd func() error, timeout time.Duration) error {
 	done := make(chan error)
 	go func(out chan<- error) {
@@ -95,41 +57,38 @@ func runOrTimeout(cmd func() error, timeout time.Duration) error {
 	}
 }
 
-// wait startupDelay before returning
-// fails if tendermint doesn't run at least startupDelay + timeout
-func runTendermint(t *testing.T, home string, startupDelay, timeout int64) {
-	tmBin := filepath.Join(
-		os.ExpandEnv("$GOPATH"), "bin", "tendermint")
-
-	// runTM should take longer than startupDelay and timeout...
-	runTm := func() error {
-		killTime := time.Duration(startupDelay + timeout + 2)
-
-		cmd := exec.Command(tmBin, "node", "--home", home)
-		fmt.Println(">>> Running tendermint...")
-
-		// log tendermint output for verbose debugging....
-		// cmd.Stdout = os.Stdout
-		// cmd.Stderr = os.Stdout
-
-		// run it
-		err := cmd.Start()
-		if err != nil {
-			return err
-		}
-
-		// after the given time, kill the process...
-		time.Sleep(killTime * time.Second)
-		fmt.Println("Killing tendermint...")
-		cmd.Process.Kill()
-		return nil
+func TestStartWithTendermint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping Tendermint integration test")
 	}
 
-	runTime := time.Duration(timeout + startupDelay)
-	go func(t *testing.T) {
-		err := runOrTimeout(runTm, runTime*time.Second)
-		assert.NoError(t, err)
-	}(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
 
-	time.Sleep(time.Duration(startupDelay) * time.Second)
+	home := setupConfig(t)
+	defer os.RemoveAll(home)
+
+	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).
+		With("module", "test-cmd")
+	err := server.InitCmd(app.GenInitOptions, logger, home, nil)
+	require.NoError(t, err)
+
+	defer tmtest.RunTendermint(ctx, t, home)()
+
+	done := make(chan error, 1)
+	go func() {
+		args := []string{
+			"-bind", "localhost:46658",
+		}
+		done <- server.StartCmd(app.GenerateApp, logger, home, args)
+	}()
+
+	select {
+	case <-ctx.Done():
+		t.Logf("context cancelled before application finished")
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("application failed: %s", err)
+		}
+	}
 }

--- a/examples/mycoind/commands/start_test.go
+++ b/examples/mycoind/commands/start_test.go
@@ -1,20 +1,17 @@
 package commands
 
 import (
-	"fmt"
+	"context"
+	"errors"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/tendermint/tendermint/libs/log"
-
 	"github.com/iov-one/weave/commands/server"
 	"github.com/iov-one/weave/examples/mycoind/app"
+	"github.com/iov-one/weave/tmtest"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 func TestStartStandAlone(t *testing.T) {
@@ -40,10 +37,33 @@ func TestStartStandAlone(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func runOrTimeout(cmd func() error, timeout time.Duration) error {
+	done := make(chan error)
+	go func(out chan<- error) {
+		// we assume cmd should block (RunForever)
+		err := cmd()
+		if err != nil {
+			out <- err
+		}
+		out <- errors.New("start died for unknown reasons")
+	}(done)
+
+	timer := time.NewTimer(timeout)
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		return nil
+	}
+}
+
 func TestStartWithTendermint(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping Tendermint integration test")
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
 
 	home := setupConfig(t)
 	defer os.RemoveAll(home)
@@ -56,80 +76,22 @@ func TestStartWithTendermint(t *testing.T) {
 	err := server.InitCmd(app.GenInitOptions, logger, home, []string{"-all=f"})
 	require.NoError(t, err)
 
-	// start up tendermint process in the background...
-	// this will block 2 seconds and ensure tendermint lives
-	// at least 3 seconds after we run StartCmd
-	runTendermint(t, home, startupTime, runTime)
+	tmtest.RunTendermint(ctx, t, home)
 
-	// set up app and start up
-	args := []string{"-bind", "localhost:46658"}
-	runStart := func() error {
-		return server.StartCmd(app.GenerateApp, logger, home, args)
-	}
-	timeout := time.Duration(runTime+1) * time.Second
-	err = runOrTimeout(runStart, timeout)
-	require.NoError(t, err)
-
-	// give time for tendermint to shut down
-	fmt.Println(">>> Waiting for tendermint to shut down")
-	time.Sleep(time.Second + time.Second)
-}
-
-func runOrTimeout(cmd func() error, timeout time.Duration) error {
-	done := make(chan error)
-	go func(out chan<- error) {
-		// we assume cmd should block (RunForever)
-		err := cmd()
-		if err != nil {
-			out <- err
+	done := make(chan error, 1)
+	go func() {
+		args := []string{
+			"-bind", "localhost:46658",
 		}
-		out <- fmt.Errorf("start died for unknown reasons")
-	}(done)
+		done <- server.StartCmd(app.GenerateApp, logger, home, args)
+	}()
 
-	timer := time.NewTimer(timeout)
 	select {
+	case <-ctx.Done():
+		t.Logf("context cancelled before application finished")
 	case err := <-done:
-		return err
-	case <-timer.C:
-		return nil
-	}
-}
-
-// wait startupDelay before returning
-// fails if tendermint doesn't run at least startupDelay + timeout
-func runTendermint(t *testing.T, home string, startupDelay, timeout int64) {
-	tmBin := filepath.Join(
-		os.ExpandEnv("$GOPATH"), "bin", "tendermint")
-
-	// runTM should take longer than startupDelay and timeout...
-	runTm := func() error {
-		killTime := time.Duration(startupDelay + timeout + 2)
-
-		cmd := exec.Command(tmBin, "node", "--home", home)
-		fmt.Println(">>> Running tendermint...")
-
-		// log tendermint output for verbose debugging....
-		// cmd.Stdout = os.Stdout
-		// cmd.Stderr = os.Stdout
-
-		// run it
-		err := cmd.Start()
 		if err != nil {
-			return err
+			t.Fatalf("application failed: %s", err)
 		}
-
-		// after the given time, kill the process...
-		time.Sleep(killTime * time.Second)
-		fmt.Println("Killing tendermint...")
-		cmd.Process.Kill()
-		return nil
 	}
-
-	runTime := time.Duration(timeout + startupDelay)
-	go func(t *testing.T) {
-		err := runOrTimeout(runTm, runTime*time.Second)
-		assert.NoError(t, err)
-	}(t)
-
-	time.Sleep(time.Duration(startupDelay) * time.Second)
 }

--- a/tmtest/tmtest.go
+++ b/tmtest/tmtest.go
@@ -1,0 +1,50 @@
+/*
+
+Package tmtest provides helpers for testing using tendermint server.
+
+*/
+package tmtest
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// RunTendermint starts a tendermit process. Returned cleanup function will
+// ensure the process has stopped and will block until.
+//
+// Set FORCE_TM_TEST=1 environment variable to fail the test if the binary is
+// not available. This might be desired when running tests by CI.
+func RunTendermint(ctx context.Context, t *testing.T, home string) (cleanup func()) {
+	t.Helper()
+
+	tmpath, err := exec.LookPath("tendermint")
+	if err != nil {
+		if os.Getenv("FORCE_TM_TEST") != "1" {
+			t.Skip("Tendermint binary not found. Set FORCE_TM_TEST=1 to fail this test.")
+		} else {
+			t.Fatalf("Tendermint binary not found. Do not set FORCE_TM_TEST=1 to skip this test.")
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, tmpath, "node", "--home", home)
+	// log tendermint output for verbose debugging....
+	// cmd.Stdout = os.Stdout
+	// cmd.Stderr = os.Stdout
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Tendermint process failed: %s", err)
+	}
+
+	// Give tendermint time to setup.
+	time.Sleep(2 * time.Second)
+	t.Logf("Running %s pid=%d", tmpath, cmd.Process.Pid)
+
+	// Return a cleanup function, that will wait for the tendermint to stop.
+	return func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}
+}


### PR DESCRIPTION
Refactor tests that are using tendermint server to skip the test if the
tendermint binary is not available.

resolve #220