### PR TITLE
refactor ErrInvalidObject error use

### DIFF
--- a/x/currency/errors.go
+++ b/x/currency/errors.go
@@ -9,21 +9,13 @@ import (
 
 const (
 	CodeInvalidToken = 2000
-
-	CodeInvalidObject = 1100 // TODO: this is the same as in x/namecoin
 )
 
 var (
-	errInvalidObject    = stderrors.New("Wrong object type for this bucket")
 	errInvalidTokenName = stderrors.New("Invalid token name")
 	errInvalidSigFigs   = stderrors.New("Invalid significant figures")
 	errDuplicateToken   = stderrors.New("Token with that ticker already exists")
 )
-
-func ErrInvalidObject(obj interface{}) error {
-	msg := fmt.Sprintf("%T", obj)
-	return errors.WithLog(msg, errInvalidObject, CodeInvalidObject)
-}
 
 func ErrInvalidSigFigs(figs int32) error {
 	msg := fmt.Sprintf("%d", figs)

--- a/x/currency/model.go
+++ b/x/currency/model.go
@@ -61,7 +61,7 @@ func (b *TokenInfoBucket) Get(db weave.KVStore, ticker string) (orm.Object, erro
 
 func (b *TokenInfoBucket) Save(db weave.KVStore, obj orm.Object) error {
 	if _, ok := obj.Value().(*TokenInfo); !ok {
-		return ErrInvalidObject(obj.Value())
+		return orm.ErrInvalidObject(obj.Value())
 	}
 	if n := string(obj.Key()); !x.IsCC(n) {
 		return x.ErrInvalidCurrency(n)

--- a/x/namecoin/errors.go
+++ b/x/namecoin/errors.go
@@ -13,8 +13,6 @@ const (
 	CodeInvalidToken  = 1000
 	CodeInvalidIndex  = 1001
 	CodeInvalidWallet = 1002
-
-	CodeInvalidObject = 1100 // TODO: move into weave
 )
 
 var (
@@ -25,14 +23,7 @@ var (
 	errInvalidWalletName = fmt.Errorf("Invalid name for a wallet")
 	errChangeWalletName  = fmt.Errorf("Wallet already has a name")
 	errNoSuchWallet      = fmt.Errorf("No wallet exists with this address")
-
-	errInvalidObject = fmt.Errorf("Wrong object type for this bucket")
 )
-
-func ErrInvalidObject(obj interface{}) error {
-	msg := fmt.Sprintf("%T", obj)
-	return errors.WithLog(msg, errInvalidObject, CodeInvalidObject)
-}
 
 func ErrInvalidTokenName(name string) error {
 	return errors.WithLog(name, errInvalidTokenName, CodeInvalidToken)

--- a/x/namecoin/token.go
+++ b/x/namecoin/token.go
@@ -96,7 +96,7 @@ func (b TokenBucket) Get(db weave.KVStore, ticker string) (orm.Object, error) {
 // Save enforces the proper type
 func (b TokenBucket) Save(db weave.KVStore, obj orm.Object) error {
 	if _, ok := obj.Value().(*Token); !ok {
-		return ErrInvalidObject(obj.Value())
+		return orm.ErrInvalidObject(obj.Value())
 	}
 	name := string(obj.Key())
 	if !x.IsCC(name) {

--- a/x/namecoin/wallet.go
+++ b/x/namecoin/wallet.go
@@ -138,7 +138,7 @@ func (b WalletBucket) GetByName(db weave.KVStore, name string) (orm.Object, erro
 // Save enforces the proper type
 func (b WalletBucket) Save(db weave.KVStore, obj orm.Object) error {
 	if _, ok := obj.Value().(*Wallet); !ok {
-		return ErrInvalidObject(obj.Value())
+		return orm.ErrInvalidObject(obj.Value())
 	}
 	return b.Bucket.Save(db, obj)
 }


### PR DESCRIPTION
Instead of defining custom invalid object error in each extension, use
the one defined in orm package.

resolve #240