### PR TITLE
remove print from tests

### DIFF
--- a/cmd/bcpd/commands/init_test.go
+++ b/cmd/bcpd/commands/init_test.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -62,12 +61,12 @@ func TestInit(t *testing.T) {
 func setupConfig(t *testing.T) string {
 	rootDir, err := ioutil.TempDir("", "mock-sdk-cmd")
 	require.NoError(t, err)
-	err = copyConfigFiles(rootDir)
+	err = copyConfigFiles(t, rootDir)
 	require.NoError(t, err)
 	return rootDir
 }
 
-func copyConfigFiles(rootDir string) error {
+func copyConfigFiles(t *testing.T, rootDir string) error {
 	// make the output dir
 	outDir := filepath.Join(rootDir, "config")
 	err := os.Mkdir(outDir, 0755)
@@ -87,7 +86,7 @@ func copyConfigFiles(rootDir string) error {
 		}
 		input := filepath.Join(inDir, f.Name())
 		output := filepath.Join(outDir, f.Name())
-		fmt.Printf("Copying %s to %s\n", input, output)
+		t.Logf("Copying %s to %s", input, output)
 		err = fileCopy(input, output, f.Mode())
 		if err != nil {
 			return err

--- a/cmd/bnsd/commands/init_test.go
+++ b/cmd/bnsd/commands/init_test.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -64,12 +63,12 @@ func TestInit(t *testing.T) {
 func setupConfig(t *testing.T) string {
 	rootDir, err := ioutil.TempDir("", "mock-sdk-cmd")
 	require.NoError(t, err)
-	err = copyConfigFiles(rootDir)
+	err = copyConfigFiles(t, rootDir)
 	require.NoError(t, err)
 	return rootDir
 }
 
-func copyConfigFiles(rootDir string) error {
+func copyConfigFiles(t *testing.T, rootDir string) error {
 	// make the output dir
 	outDir := filepath.Join(rootDir, "config")
 	err := os.Mkdir(outDir, 0755)
@@ -89,7 +88,7 @@ func copyConfigFiles(rootDir string) error {
 		}
 		input := filepath.Join(inDir, f.Name())
 		output := filepath.Join(outDir, f.Name())
-		fmt.Printf("Copying %s to %s\n", input, output)
+		t.Logf("Copying %s to %s", input, output)
 		err = fileCopy(input, output, f.Mode())
 		if err != nil {
 			return err

--- a/examples/mycoind/commands/init_test.go
+++ b/examples/mycoind/commands/init_test.go
@@ -10,13 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/tendermint/tendermint/libs/log"
-
 	"github.com/iov-one/weave/commands/server"
 	"github.com/iov-one/weave/examples/mycoind/app"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 func TestInit(t *testing.T) {
@@ -86,7 +84,6 @@ func copyConfigFiles(rootDir string) error {
 		}
 		input := filepath.Join(inDir, f.Name())
 		output := filepath.Join(outDir, f.Name())
-		fmt.Printf("Copying %s to %s\n", input, output)
 		err = fileCopy(input, output, f.Mode())
 		if err != nil {
 			return err

--- a/x/nft/base/handler_test.go
+++ b/x/nft/base/handler_test.go
@@ -2,7 +2,6 @@ package base_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/iov-one/weave"
@@ -208,7 +207,7 @@ func TestApprovalOpsHandler(t *testing.T) {
 
 				//TODO: Should we allow approved to remove their own approvals? :)
 				Convey("By approved", func() {
-					fmt.Println(alice.Address())
+					t.Logf("alice address: %s", alice.Address())
 					handler = base.NewApprovalOpsHandler(helpers.Authenticate(alice), nil, d)
 					tx := helpers.MockTx(msg)
 					_, err := handler.Check(ctx, db, tx)


### PR DESCRIPTION
Instead of using printing to stdout in tests use test logger. This
results is buffered logging and proper test resports.

fix #234