### PR TITLE
simplyfy cmd/lsc output

### DIFF
--- a/cmd/lsc/lsc.go
+++ b/cmd/lsc/lsc.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"flag"
 	"fmt"
 	"io"
@@ -50,22 +49,12 @@ func printAddresses(out io.Writer, header bool, limit, offset int) {
 	defer w.Flush()
 
 	if header {
-		fmt.Fprintln(w, "index\taddress\tjson repr\thex repr")
+		fmt.Fprintln(w, "index\taddress")
 	}
 	for i := offset; i < limit+offset; i++ {
 		addr := multisig.MultiSigCondition(seq(i)).Address()
-		jsonAddr, err := addr.MarshalJSON()
-		hexAddr := hex.EncodeToString(addr)
-		if err != nil {
-			fatalf("cannot serialize address: %s", err)
-		}
-		fmt.Fprintf(w, "%d\t%s\t%s\t%s\n", i, addr, jsonAddr[1:len(jsonAddr)-1], hexAddr)
+		fmt.Fprintf(w, "%d\t%s\n", i, addr.String())
 	}
-}
-
-func fatalf(format string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, format, args...)
-	os.Exit(1)
 }
 
 // seq returns binary representation of a sequence number.


### PR DESCRIPTION
All 3 formats are producting the same characters. Leave only one,
bacause they are all redundant.

Now the output is

```
weave $ go run cmd/lsc/lsc.go -limit 4
index  address
1      5AE2C58796B0AD48FFE7602EAC3353488C859A2B
2      1369E8BBB1384C964CBB3303696F5D3B179033A3
3      084430510E07F109B9ACF8BC62EF853A66BD8754
4      26E3C3612C28BA356DAF336370299DBBD5C8A77A
```