### PR TITLE
Initial global configuration package implementation

### DIFF
--- a/gconf/doc.go
+++ b/gconf/doc.go
@@ -1,0 +1,15 @@
+/*
+
+Package gconf implements a configuration store intended to be used as a global,
+in-database configuration.
+
+This package allows to load configuration from a genesis file and access it via
+set of helper functions (`String`, `Int`, `Duration` etc).
+
+Not being able to get a configuration value is a critical condition for the
+application and there is no recovery path for the client. Application must be
+terminated and configured correctly. This is why any failure results in a
+panic.
+
+*/
+package gconf

--- a/gconf/gconf.go
+++ b/gconf/gconf.go
@@ -2,7 +2,7 @@ package gconf
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"time"
 
 	"github.com/iov-one/weave"
@@ -52,10 +52,14 @@ func loadInto(confStore Store, propName string, dest interface{}) {
 	key := []byte("gconf:" + propName)
 	raw := confStore.Get(key)
 	if raw == nil {
-		log.Printf("cannot load %q configuration: not found", propName)
+		fail(fmt.Sprintf("cannot load %q configuration: not found", propName))
 		return
 	}
 	if err := json.Unmarshal(raw, dest); err != nil {
-		log.Printf("cannot load %q configuration: %s", propName, err)
+		fail(fmt.Sprintf("cannot load %q configuration: %s", propName, err))
 	}
+}
+
+var fail = func(msg string) {
+	panic(msg)
 }

--- a/gconf/gconf.go
+++ b/gconf/gconf.go
@@ -1,0 +1,61 @@
+package gconf
+
+import (
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/iov-one/weave"
+)
+
+type Store interface {
+	Get([]byte) []byte
+}
+
+func Int(confStore Store, propName string) int {
+	var value int
+	loadInto(confStore, propName, &value)
+	return value
+}
+
+func Duration(confStore Store, propName string) time.Duration {
+	var value time.Duration
+	loadInto(confStore, propName, &value)
+	return value
+}
+
+func String(confStore Store, propName string) string {
+	var value string
+	loadInto(confStore, propName, &value)
+	return value
+}
+
+func Strings(confStore Store, propName string) []string {
+	var value []string
+	loadInto(confStore, propName, &value)
+	return value
+}
+
+func Address(confStore Store, propName string) weave.Address {
+	var value weave.Address
+	loadInto(confStore, propName, &value)
+	return value
+}
+
+func Bytes(confStore Store, propName string) []byte {
+	value := make([]byte, 0, 128)
+	loadInto(confStore, propName, &value)
+	return value
+}
+
+func loadInto(confStore Store, propName string, dest interface{}) {
+	key := []byte("gconf:" + propName)
+	raw := confStore.Get(key)
+	if raw == nil {
+		log.Printf("cannot load %q configuration: not found", propName)
+		return
+	}
+	if err := json.Unmarshal(raw, dest); err != nil {
+		log.Printf("cannot load %q configuration: %s", propName, err)
+	}
+}

--- a/gconf/gconf.go
+++ b/gconf/gconf.go
@@ -12,36 +12,48 @@ type Store interface {
 	Get([]byte) []byte
 }
 
+// Int returns an integer value stored under given name.
+// This function panics if configuration cannot be acquired.
 func Int(confStore Store, propName string) int {
 	var value int
 	loadInto(confStore, propName, &value)
 	return value
 }
 
+// Duration returns a duration value stored under given name.
+// This function panics if configuration cannot be acquired.
 func Duration(confStore Store, propName string) time.Duration {
 	var value time.Duration
 	loadInto(confStore, propName, &value)
 	return value
 }
 
+// String returns a string value stored under given name.
+// This function panics if configuration cannot be acquired.
 func String(confStore Store, propName string) string {
 	var value string
 	loadInto(confStore, propName, &value)
 	return value
 }
 
+// Strings returns an array of string value stored under given name.
+// This function panics if configuration cannot be acquired.
 func Strings(confStore Store, propName string) []string {
 	var value []string
 	loadInto(confStore, propName, &value)
 	return value
 }
 
+// Address returns an address value stored under given name.
+// This function panics if configuration cannot be acquired.
 func Address(confStore Store, propName string) weave.Address {
 	var value weave.Address
 	loadInto(confStore, propName, &value)
 	return value
 }
 
+// Bytes returns a bytes value stored under given name.
+// This function panics if configuration cannot be acquired.
 func Bytes(confStore Store, propName string) []byte {
 	value := make([]byte, 0, 128)
 	loadInto(confStore, propName, &value)
@@ -52,14 +64,9 @@ func loadInto(confStore Store, propName string, dest interface{}) {
 	key := []byte("gconf:" + propName)
 	raw := confStore.Get(key)
 	if raw == nil {
-		fail(fmt.Sprintf("cannot load %q configuration: not found", propName))
-		return
+		panic(fmt.Sprintf("cannot load %q configuration: not found", propName))
 	}
 	if err := json.Unmarshal(raw, dest); err != nil {
-		fail(fmt.Sprintf("cannot load %q configuration: %s", propName, err))
+		panic(fmt.Sprintf("cannot load %q configuration: %s", propName, err))
 	}
-}
-
-var fail = func(msg string) {
-	panic(msg)
 }

--- a/gconf/gconf_test.go
+++ b/gconf/gconf_test.go
@@ -1,0 +1,75 @@
+package gconf
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/iov-one/weave"
+)
+
+func TestString(t *testing.T) {
+	store := confStore(`"foobar"`)
+	if want, got := "foobar", String(store, "a"); got != want {
+		t.Fatalf("want %q, got %q", want, got)
+	}
+}
+
+func TestInt(t *testing.T) {
+	store := confStore(`123`)
+	if want, got := 123, Int(store, "a"); got != want {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}
+
+func TestDuration(t *testing.T) {
+	store := confStore(`123`)
+	if want, got := 123*time.Nanosecond, Duration(store, "a"); got != want {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}
+
+func TestStrings(t *testing.T) {
+	store := confStore(`["a", "b", "c"]`)
+	if want, got := []string{"a", "b", "c"}, Strings(store, "a"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}
+
+func TestAddress(t *testing.T) {
+	store := confStore(`"6161616161616161616161616161616161616161"`)
+	if want, got := weave.Address(`aaaaaaaaaaaaaaaaaaaa`), Address(store, "a"); !got.Equals(want) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}
+
+func TestBytes(t *testing.T) {
+	store := confStore(`"YWJjZA=="`)
+	if want, got := []byte("abcd"), Bytes(store, "a"); !bytes.Equal(got, want) {
+		t.Fatalf("want %q, got %q", want, got)
+	}
+}
+
+func TestLoadingUnknownValuePanics(t *testing.T) {
+	var recovered bool
+	func() {
+		defer func() {
+			err := recover()
+			recovered = err != nil
+			t.Logf("recover(): %+v", err)
+		}()
+
+		loadInto(confStore(nil), "this-value-does-not-exist", nil)
+	}()
+
+	if !recovered {
+		t.Fatal("expected loadInto call to panic")
+	}
+}
+
+type confStore []byte
+
+func (cs confStore) Get([]byte) []byte {
+	return cs
+}

--- a/gconf/genesis.go
+++ b/gconf/genesis.go
@@ -17,7 +17,7 @@ var _ weave.Initializer = Initializer{}
 // and save it to the database
 func (Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
 	conf := make(map[string]interface{})
-	err := opts.ReadOptions("gconfig", &conf)
+	err := opts.ReadOptions("gconf", &conf)
 	if err != nil {
 		return err
 	}

--- a/gconf/genesis.go
+++ b/gconf/genesis.go
@@ -17,7 +17,7 @@ var _ weave.Initializer = Initializer{}
 // and save it to the database
 func (Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
 	conf := make(map[string]interface{})
-	err := opts.ReadOptions("gconfig", &accts)
+	err := opts.ReadOptions("gconfig", &conf)
 	if err != nil {
 		return err
 	}

--- a/gconf/genesis.go
+++ b/gconf/genesis.go
@@ -1,0 +1,35 @@
+package gconf
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/iov-one/weave"
+)
+
+// Initializer fulfils the InitStater interface to load data from
+// the genesis file
+type Initializer struct{}
+
+var _ weave.Initializer = Initializer{}
+
+// FromGenesis will parse initial account info from genesis
+// and save it to the database
+func (Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
+	conf := make(map[string]interface{})
+	err := opts.ReadOptions("gconfig", &accts)
+	if err != nil {
+		return err
+	}
+
+	for name, value := range conf {
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return fmt.Errorf("cannot serialize %s: %s", name, err)
+		}
+		key := []byte("gconf:" + name)
+		db.Set(key, raw)
+	}
+
+	return nil
+}

--- a/gconf/genesis_test.go
+++ b/gconf/genesis_test.go
@@ -1,0 +1,38 @@
+package gconf
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/store"
+)
+
+func TestGenesisInitializer(t *testing.T) {
+	const genesis = `
+		{
+			"gconf": {
+				"a-string": "hello",
+				"an-int": 321
+			}
+		}
+	`
+
+	var opts weave.Options
+	if err := json.Unmarshal([]byte(genesis), &opts); err != nil {
+		t.Fatalf("cannot unmarshal genesis: %s", err)
+	}
+
+	db := store.MemStore()
+	var ini Initializer
+	if err := ini.FromGenesis(opts, db); err != nil {
+		t.Fatalf("cannot load genesis: %s", err)
+	}
+
+	if got := String(db, "a-string"); got != "hello" {
+		t.Fatalf("unexpected value: %v", got)
+	}
+	if got := Int(db, "an-int"); got != 321 {
+		t.Fatalf("unexpected value: %v", got)
+	}
+}


### PR DESCRIPTION
:warning: Please do not merge :warning: 

`gconf` package implements a set of operations on a global
configuration.

Configuration is stored in a database with an interface compatible with
`weave.KVStore`. Each value stored by configration is serialized using
JSON.

To load a configuration value, use one of the provided functions (`Int`,
`String`, etc.). In case of parsing issues they log an error and return
empty value for given type. This should not happen, unless database was
manually altered.

Next step is to add a support for runtime configuration update via
message sending.

resolve #202 

Please have a look and if this is the right direction, I will add tests and documentation.