### PR TITLE
Add install target to makefile

### DIFF
--- a/cmd/bcpd/Makefile
+++ b/cmd/bcpd/Makefile
@@ -22,6 +22,9 @@ image:
 test:
 	go test -race ./...
 
+install:
+	go install $(BUILD_FLAGS) .
+
 # Test fast
 tf:
 	go test -short ./...

--- a/cmd/bnsd/Makefile
+++ b/cmd/bnsd/Makefile
@@ -22,6 +22,9 @@ image:
 test:
 	go test -race ./...
 
+install:
+	go install $(BUILD_FLAGS) .
+
 # Test fast
 tf:
 	go test -short ./...


### PR DESCRIPTION
This fixes the `install` target in the project makefile which delegates to the sub-project's makefiles.