### PR TITLE
Add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+## Expected Behavior
+
+## Actual Behavior
+Links to the relevant code, snippets
+
+## Steps to Reproduce the Problem
+
+Environment, commands
+
+1.  
+2.  
+3.  
+4.  
+
+## Additional info
+Add any other context about the problem here (e.g. screenshots, links)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+Describe alternative solutions or workarounds you've considered. 
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Following github's guidelines for "Building a strong community"

> With issue and pull request templates, you can customize and standardize the information you'd like contributors to include when they open issues and pull requests in your repository.

https://help.github.com/articles/about-issue-and-pull-request-templates/