### PR TITLE
Extend validator CLI tool to support multisig.

### DIFF
--- a/cmd/validators/main.go
+++ b/cmd/validators/main.go
@@ -35,9 +35,9 @@ func main() {
 		printUsage(os.Stderr)
 		os.Exit(2)
 	}
-	// Cut out command from the parameters, so that the flag module parse correctly.
-	os.Args = append([]string{os.Args[0]}, os.Args[2:]...)
-	if err := cmd(); err != nil {
+	// Cut out program name and the command from the parameters, so that
+	// the flag module parse correctly.
+	if err := cmd(os.Stdin, os.Stdout, os.Args[2:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -59,34 +59,36 @@ Available commands: %s
 
 // commands is a global register of all commands provided by this program. Each
 // command should use flag package to support options and provide help text.
-var commands = map[string]func() error{
-	"list":            cmdList(os.Stdout),
+var commands = map[string]func(input io.Reader, output io.Writer, args []string) error{
+	"list":            cmdList,
 	"add":             cmdAdd,
-	"multisig-new":    cmdMultisigNew(os.Stdout),
-	"multisig-sign":   cmdMultisigSign(os.Stdin, os.Stdout),
-	"multisig-view":   cmdMultisigView(os.Stdin, os.Stdout),
-	"multisig-submit": cmdMultisigSubmit(os.Stdin),
+	"multisig-new":    cmdMultisigNew,
+	"multisig-sign":   cmdMultisigSign,
+	"multisig-view":   cmdMultisigView,
+	"multisig-submit": cmdMultisigSubmit,
 }
 
-func cmdList(out io.Writer) func() error {
-	return func() error {
-		fl := flag.NewFlagSet("", flag.ExitOnError)
-		var (
-			tmAddrFl = fl.String("tm", "https://bns.NETWORK.iov.one:443", "Tendermint node address. Use proper NETWORK name.")
-		)
-		fl.Parse(os.Args[1:])
+func cmdList(
+	input io.Reader,
+	output io.Writer,
+	args []string,
+) error {
+	fl := flag.NewFlagSet("", flag.ExitOnError)
+	var (
+		tmAddrFl = fl.String("tm", "https://bns.NETWORK.iov.one:443", "Tendermint node address. Use proper NETWORK name.")
+	)
+	fl.Parse(args)
 
-		info, err := listValidators(*tmAddrFl)
-		if err != nil {
-			return fmt.Errorf("cannot list validators: %s\n", err)
-		}
-		b, err := json.MarshalIndent(info, "", "\t")
-		if err != nil {
-			return fmt.Errorf("cannot serialize: %s", err)
-		}
-		_, err = out.Write(b)
-		return err
+	info, err := listValidators(*tmAddrFl)
+	if err != nil {
+		return fmt.Errorf("cannot list validators: %s\n", err)
 	}
+	b, err := json.MarshalIndent(info, "", "\t")
+	if err != nil {
+		return fmt.Errorf("cannot serialize: %s", err)
+	}
+	_, err = output.Write(b)
+	return err
 }
 
 func listValidators(nodeURL string) ([]*validatorInfo, error) {
@@ -128,159 +130,169 @@ type pubKeyInfo struct {
 	Value string `json:"value"`
 }
 
-func cmdMultisigNew(out io.Writer) func() error {
-	return func() error {
-		fl := flag.NewFlagSet("", flag.ExitOnError)
-		fl.Usage = func() {
-			fmt.Fprint(flag.CommandLine.Output(), `
+func cmdMultisigNew(
+	input io.Reader,
+	output io.Writer,
+	args []string,
+) error {
+	fl := flag.NewFlagSet("", flag.ExitOnError)
+	fl.Usage = func() {
+		fmt.Fprint(flag.CommandLine.Output(), `
 Create a new validator update request with multi signature authentication.
 Created request is binary serialized and written to standard output.
 
 Returned request must be signed by other parties before it can be submitted.
 
 `)
-			fl.PrintDefaults()
-		}
-		var (
-			pubKeyFl       = fl.String("pubkey", "", "Base64 encoded, ed25519 public key.")
-			multisigAddrFl = fl.String("multisig", "", "Address of the multisig contract that this request will authenticate with.")
-			powerFl        = fl.Int64("power", 10, "Validator node power. Set to 0 to delete a node.")
-		)
-		fl.Parse(os.Args[1:])
-
-		if *pubKeyFl == "" {
-			return errors.New("public key is required")
-		}
-		pubkey, err := base64.StdEncoding.DecodeString(*pubKeyFl)
-		if err != nil {
-			return fmt.Errorf("cannot base64 decode public key: %s", err)
-		}
-
-		if *multisigAddrFl == "" {
-			return errors.New("multisig address is required")
-		}
-
-		addValidatorTx := client.SetValidatorTx(
-			&validators.ValidatorUpdate{
-				Pubkey: validators.Pubkey{
-					Type: "ed25519",
-					Data: pubkey,
-				},
-				Power: *powerFl,
-			},
-		)
-
-		raw, err := addValidatorTx.Marshal()
-		if err != nil {
-			return fmt.Errorf("cannot serialize transaction: %s", err)
-		}
-		_, err = out.Write(raw)
-		return err
+		fl.PrintDefaults()
 	}
+	var (
+		pubKeyFl       = fl.String("pubkey", "", "Base64 encoded, ed25519 public key.")
+		multisigAddrFl = fl.String("multisig", "", "Address of the multisig contract that this request will authenticate with.")
+		powerFl        = fl.Int64("power", 10, "Validator node power. Set to 0 to delete a node.")
+	)
+	fl.Parse(args)
+
+	if *pubKeyFl == "" {
+		return errors.New("public key is required")
+	}
+	pubkey, err := base64.StdEncoding.DecodeString(*pubKeyFl)
+	if err != nil {
+		return fmt.Errorf("cannot base64 decode public key: %s", err)
+	}
+
+	if *multisigAddrFl == "" {
+		return errors.New("multisig address is required")
+	}
+
+	addValidatorTx := client.SetValidatorTx(
+		&validators.ValidatorUpdate{
+			Pubkey: validators.Pubkey{
+				Type: "ed25519",
+				Data: pubkey,
+			},
+			Power: *powerFl,
+		},
+	)
+
+	raw, err := addValidatorTx.Marshal()
+	if err != nil {
+		return fmt.Errorf("cannot serialize transaction: %s", err)
+	}
+	_, err = output.Write(raw)
+	return err
+
 }
 
-func cmdMultisigView(in io.Reader, out io.Writer) func() error {
-	return func() error {
-		fl := flag.NewFlagSet("", flag.ExitOnError)
-		fl.Usage = func() {
-			fmt.Fprint(flag.CommandLine.Output(), `
+func cmdMultisigView(
+	input io.Reader,
+	output io.Writer,
+	args []string,
+) error {
+	fl := flag.NewFlagSet("", flag.ExitOnError)
+	fl.Usage = func() {
+		fmt.Fprint(flag.CommandLine.Output(), `
 Decode and display transaction summary. This command is helpful when reciving a
 binary representation of a transaction. Before signing you should check what
 kind of operation are you authorizing.
 `)
-			fl.PrintDefaults()
-		}
-		fl.Parse(os.Args[1:])
-
-		raw, err := ioutil.ReadAll(in)
-		if err != nil {
-			return fmt.Errorf("cannot read transaction: %s", err)
-		}
-		if len(raw) == 0 {
-			return errors.New("no stdin data")
-		}
-
-		var tx app.Tx
-		if err := tx.Unmarshal(raw); err != nil {
-			return fmt.Errorf("cannot deserialize transaction: %s", err)
-		}
-
-		// Protobuf compiler is exposing all attributes as JSON as
-		// well. This will produce a beautiful summary.
-		pretty, err := json.MarshalIndent(tx, "", "\t")
-		if err != nil {
-			return fmt.Errorf("cannot JSON serialize: %s", err)
-		}
-		_, err = out.Write(pretty)
-		return err
+		fl.PrintDefaults()
 	}
+	fl.Parse(args)
+
+	raw, err := ioutil.ReadAll(input)
+	if err != nil {
+		return fmt.Errorf("cannot read transaction: %s", err)
+	}
+	if len(raw) == 0 {
+		return errors.New("no input data")
+	}
+
+	var tx app.Tx
+	if err := tx.Unmarshal(raw); err != nil {
+		return fmt.Errorf("cannot deserialize transaction: %s", err)
+	}
+
+	// Protobuf compiler is exposing all attributes as JSON as
+	// well. This will produce a beautiful summary.
+	pretty, err := json.MarshalIndent(tx, "", "\t")
+	if err != nil {
+		return fmt.Errorf("cannot JSON serialize: %s", err)
+	}
+	_, err = output.Write(pretty)
+	return err
 }
 
-func cmdMultisigSign(in io.Reader, out io.Writer) func() error {
-	return func() error {
-		fl := flag.NewFlagSet("", flag.ExitOnError)
-		fl.Usage = func() {
-			fmt.Fprint(flag.CommandLine.Output(), `
+func cmdMultisigSign(
+	input io.Reader,
+	output io.Writer,
+	args []string,
+) error {
+	fl := flag.NewFlagSet("", flag.ExitOnError)
+	fl.Usage = func() {
+		fmt.Fprint(flag.CommandLine.Output(), `
 Sign given transaction. This is decoding a transaction data from standard
 input, adds a signature and writes back to standard output signed transaction
 content.
 
 `)
-			fl.PrintDefaults()
-		}
-		var (
-			tmAddrFl = fl.String("tm", "https://bns.NETWORK.iov.one:443", "Tendermint node address. Use proper NETWORK name.")
-			keyFl    = fl.String("key", "", "Hex encoded, private key that transaction should be signed with.")
-		)
-		fl.Parse(os.Args[1:])
-
-		if *keyFl == "" {
-			return errors.New("private key is required")
-		}
-		key, err := decodePrivateKey(*keyFl)
-		if err != nil {
-			return fmt.Errorf("cannot decode private key: %s", err)
-		}
-
-		raw, err := ioutil.ReadAll(in)
-		if err != nil {
-			return fmt.Errorf("cannot read transaction: %s", err)
-		}
-		if len(raw) == 0 {
-			return errors.New("no stdin data")
-		}
-		var tx app.Tx
-		if err := tx.Unmarshal(raw); err != nil {
-			return fmt.Errorf("cannot deserialize transaction: %s", err)
-		}
-
-		genesis, err := fetchGenesis(*tmAddrFl)
-		if err != nil {
-			return fmt.Errorf("cannot fetch genesis: %s", err)
-		}
-
-		bnsClient := client.NewClient(client.NewHTTPConnection(*tmAddrFl))
-		aNonce := client.NewNonce(bnsClient, key.PublicKey().Address())
-		if seq, err := aNonce.Next(); err != nil {
-			return fmt.Errorf("cannot get the next sequence number: %s", err)
-		} else {
-			client.SignTx(&tx, key, genesis.ChainID, seq)
-		}
-
-		if raw, err := tx.Marshal(); err != nil {
-			return fmt.Errorf("cannot serialize transaction: %s", err)
-		} else {
-			_, err = out.Write(raw)
-		}
-		return err
+		fl.PrintDefaults()
 	}
+	var (
+		tmAddrFl = fl.String("tm", "https://bns.NETWORK.iov.one:443", "Tendermint node address. Use proper NETWORK name.")
+		keyFl    = fl.String("key", "", "Hex encoded, private key that transaction should be signed with.")
+	)
+	fl.Parse(args)
+
+	if *keyFl == "" {
+		return errors.New("private key is required")
+	}
+	key, err := decodePrivateKey(*keyFl)
+	if err != nil {
+		return fmt.Errorf("cannot decode private key: %s", err)
+	}
+
+	raw, err := ioutil.ReadAll(input)
+	if err != nil {
+		return fmt.Errorf("cannot read transaction: %s", err)
+	}
+	if len(raw) == 0 {
+		return errors.New("no input data")
+	}
+	var tx app.Tx
+	if err := tx.Unmarshal(raw); err != nil {
+		return fmt.Errorf("cannot deserialize transaction: %s", err)
+	}
+
+	genesis, err := fetchGenesis(*tmAddrFl)
+	if err != nil {
+		return fmt.Errorf("cannot fetch genesis: %s", err)
+	}
+
+	bnsClient := client.NewClient(client.NewHTTPConnection(*tmAddrFl))
+	aNonce := client.NewNonce(bnsClient, key.PublicKey().Address())
+	if seq, err := aNonce.Next(); err != nil {
+		return fmt.Errorf("cannot get the next sequence number: %s", err)
+	} else {
+		client.SignTx(&tx, key, genesis.ChainID, seq)
+	}
+
+	if raw, err := tx.Marshal(); err != nil {
+		return fmt.Errorf("cannot serialize transaction: %s", err)
+	} else {
+		_, err = output.Write(raw)
+	}
+	return err
 }
 
-func cmdMultisigSubmit(in io.Reader) func() error {
-	return func() error {
-		fl := flag.NewFlagSet("", flag.ExitOnError)
-		fl.Usage = func() {
-			fmt.Fprint(flag.CommandLine.Output(), `
+func cmdMultisigSubmit(
+	input io.Reader,
+	output io.Writer,
+	args []string,
+) error {
+	fl := flag.NewFlagSet("", flag.ExitOnError)
+	fl.Usage = func() {
+		fmt.Fprint(flag.CommandLine.Output(), `
 Read binary serialized validator change transaction from standard input and
 submit it.
 
@@ -288,34 +300,38 @@ This command is intended to be used to submit multisig authenticated requests.
 Make sure to collect enough signatures before submitting.
 
 `)
-			fl.PrintDefaults()
-		}
-		var (
-			tmAddrFl = fl.String("tm", "https://bns.NETWORK.iov.one:443", "Tendermint node address. Use proper NETWORK name.")
-		)
-		fl.Parse(os.Args[1:])
-
-		raw, err := ioutil.ReadAll(in)
-		if err != nil {
-			return fmt.Errorf("cannot read transaction from stdin: %s", err)
-		}
-		if len(raw) == 0 {
-			return errors.New("no stdin data")
-		}
-		var tx app.Tx
-		if err := tx.Unmarshal(raw); err != nil {
-			return fmt.Errorf("cannot deserialize transaction: %s", err)
-		}
-		bnsClient := client.NewClient(client.NewHTTPConnection(*tmAddrFl))
-
-		if err := bnsClient.BroadcastTx(&tx).IsError(); err != nil {
-			return fmt.Errorf("cannot broadcast transaction: %s", err)
-		}
-		return nil
+		fl.PrintDefaults()
 	}
+	var (
+		tmAddrFl = fl.String("tm", "https://bns.NETWORK.iov.one:443", "Tendermint node address. Use proper NETWORK name.")
+	)
+	fl.Parse(args)
+
+	raw, err := ioutil.ReadAll(input)
+	if err != nil {
+		return fmt.Errorf("cannot read transaction from input: %s", err)
+	}
+	if len(raw) == 0 {
+		return errors.New("no input data")
+	}
+	var tx app.Tx
+	if err := tx.Unmarshal(raw); err != nil {
+		return fmt.Errorf("cannot deserialize transaction: %s", err)
+	}
+	bnsClient := client.NewClient(client.NewHTTPConnection(*tmAddrFl))
+
+	if err := bnsClient.BroadcastTx(&tx).IsError(); err != nil {
+		return fmt.Errorf("cannot broadcast transaction: %s", err)
+	}
+	return nil
+
 }
 
-func cmdAdd() error {
+func cmdAdd(
+	input io.Reader,
+	output io.Writer,
+	args []string,
+) error {
 	fl := flag.NewFlagSet("", flag.ExitOnError)
 	var (
 		tmAddrFl = fl.String("tm", "https://bns.NETWORK.iov.one:443", "Tendermint node address. Use proper NETWORK name.")
@@ -323,7 +339,7 @@ func cmdAdd() error {
 		hexKeyFl = fl.String("key", "", "Hex encoded, private key of the validator that is to be added/updated.")
 		powerFl  = fl.Int64("power", 10, "Validator node power. Set to 0 to delete a node.")
 	)
-	fl.Parse(os.Args[1:])
+	fl.Parse(args)
 
 	if *pubKeyFl == "" {
 		return errors.New("public key is required")
@@ -368,6 +384,7 @@ func cmdAdd() error {
 		return fmt.Errorf("cannot broadcast transaction: %s", err)
 	}
 	return nil
+
 }
 
 func decodePrivateKey(hexSeed string) (*crypto.PrivateKey, error) {

--- a/cmd/validators/main_test.go
+++ b/cmd/validators/main_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMultisig(t *testing.T) {
+	// Create, sign, view and submit a multisignature request flow. This is
+	// not a unit test neither an integration test. It is nevertheless
+	// helpful.
+	tm := newTendermintServer(t)
+	defer tm.Close()
+
+	var out bytes.Buffer
+	args := []string{
+		"-power", "7",
+		"-pubkey", "j4JRVstX",
+		"-multisig", "5AE2C58796B0AD48FFE7602EAC3353488C859A2B",
+	}
+	if err := cmdMultisigNew(nil, &out, args); err != nil {
+		t.Fatalf("cannot create a multisig request: %s", err)
+	}
+	unsignedReq := out.Bytes()
+	out.Reset()
+	if err := cmdMultisigView(bytes.NewReader(unsignedReq), &out, nil); err != nil {
+		t.Fatalf("cannot view a multisig request: %s", err)
+	}
+	t.Logf("unsigned request: %s", out.String())
+
+	out.Reset()
+	args = []string{
+		"-tm", tm.URL,
+		"-key", "d34c1970ae90acf3405f2d99dcaca16d0c7db379f4beafcfdf667b9d69ce350d27f5fb440509dfa79ec883a0510bc9a9614c3d44188881f0c5e402898b4bf3c9",
+	}
+	if err := cmdMultisigSign(bytes.NewReader(unsignedReq), &out, args); err != nil {
+		t.Fatalf("cannot sign a multisig request: %s", err)
+	}
+
+	signedReq := out.Bytes()
+	out.Reset()
+	if err := cmdMultisigView(bytes.NewReader(signedReq), &out, nil); err != nil {
+		t.Fatalf("cannot view a multisig request: %s", err)
+	}
+	t.Logf("signed request: %s", out.String())
+
+	out.Reset()
+	args = []string{
+		"-tm", tm.URL,
+	}
+	if err := cmdMultisigSubmit(bytes.NewReader(signedReq), &out, args); err != nil {
+		t.Fatalf("cannot submit a multisig request: %s", err)
+	}
+}
+
+func newTendermintServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if *logRequestFl {
+			b, _ := ioutil.ReadAll(r.Body)
+			r.Body = ioutil.NopCloser(bytes.NewReader(b))
+			t.Logf("tendermint request: %s %s: %s", r.Method, r.URL.Path, string(b))
+		}
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/genesis":
+			io.WriteString(w, `
+				{
+					"jsonrpc": "2.0",
+					"id": "",
+					"result": {
+						"genesis": {
+							"chain_id": "test-chain-ZIYjN0",
+							"validators": [],
+							"app_state": {
+								"gconf": {
+									"cash:minimal_fee": {},
+									"cash:collector_address": "0000000000000000000000000000000000000000"
+								},
+								"update_validators": {
+									"addresses": [
+										"b1ca7e78f74423ae01da3b51e676934d9105f282",
+										"E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0"
+									]
+								},
+								"multisig": [
+								{
+									"sigs": [
+										"b1ca7e78f74423ae01da3b51e676934d9105f282",
+										"E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0"
+									],
+									"admin_threshold": 2,
+									"activation_threshold": 1
+								}
+								]
+							}
+						}
+					}
+				}
+			`)
+		case r.Method == "POST" && r.URL.Path == "/":
+			// This is an RPC call - response always depends on the
+			// submitted content. For our tests it does not matter
+			// that much what is returned.
+			io.WriteString(w, `
+				{
+					"jsonrpc": "2.0",
+					"id": "jsonrpc-client",
+					"result": {"response": {"height": "12345"}}
+				}
+			`)
+
+		default:
+			http.Error(w, "not implemented", http.StatusNotImplemented)
+		}
+	}))
+}
+
+var logRequestFl = flag.Bool("logrequest", false, "Log all requests send to tendermint mock server. This is useful when writing new test. Use curl to send the same request to a real tendermint node and record the response.")


### PR DESCRIPTION
An example flow:

1. Create a transaction that configures a validator. This transaction
points to a multisig contract as an authentication method:
```
    ./validators multisig-new \
        -power 7 \
	-pubkey HsEV3BeuXBHWmpdLkdk8R43kGzZYeVhUspqrIYacJUw= \
	-multisig 5AE2C58796B0AD48FFE7602EAC3353488C859A2B \
	> request.tx
```
2. Send the `request.tx` around and ask people to sign it:
```
    ./validators multisig-sign \
        -tm http://127.0.0.1:22345 \
	-key d34c1970ae90acf3405f2d99dcaca16d0c7db379f4beafcfdf667b9d69ce350d27f5fb440509dfa79ec883a0510bc9a9614c3d44188881f0c5e402898b4bf3c9 \
	< request.tx \
	> request_signed_1.tx
```
3. Once enough signatures are collected, submit the transaction:
```
    ./validators multisig-submit \
        -tm http://127.0.0.1:22345 \
	< request.signed_1.tx
```
Multisig addresses: https://github.com/iov-one/ops/wiki/MulitiSig-contract-addresses

resolve #269