### PR TITLE
Add protobuf linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,16 @@ deps: tools
 tools:
 	@go get github.com/golang/dep/cmd/dep
 
+lint: prototool-bin
+	prototool lint
+
+prototool-bin:
+ifndef $(shell command -v prototool help > /dev/null)
+	@@curl -sSL https://github.com/uber/prototool/releases/download/v1.3.0/prototool-$(shell uname -s)-$(shell uname -m) -o $(HOME)/.bin/prototool
+	@@chmod +x $(HOME)/.bin/prototool
+endif
+
+
 protoc:
 	protoc --gogofaster_out=. app/*.proto
 	protoc --gogofaster_out=. crypto/*.proto

--- a/prototool.yaml
+++ b/prototool.yaml
@@ -1,0 +1,28 @@
+excludes:
+  - ./vendor
+
+protoc:
+  # The Protobuf version to use from https://github.com/protocolbuffers/protobuf/releases.
+  # By default use 3.6.1.
+  # You probably want to set this to make your builds completely reproducible.
+  version: 3.6.1
+
+  # Additional paths to include with -I to protoc.
+  # By default, the directory of the config file is included,
+  # or the current directory if there is no config file.
+  includes:
+    - ./vendor
+    - ../../..
+
+
+  # If not set, compile will fail if there are unused imports.
+  # Setting this will ignore unused imports.
+  allow_unused_imports: false
+
+lint:
+  rules:
+    remove:
+      - FILE_OPTIONS_REQUIRE_JAVA_MULTIPLE_FILES
+      - FILE_OPTIONS_REQUIRE_JAVA_OUTER_CLASSNAME
+      - FILE_OPTIONS_REQUIRE_JAVA_PACKAGE
+      - FILE_OPTIONS_REQUIRE_GO_PACKAGE


### PR DESCRIPTION
Add `make lint` that will run protobuf linter on our codebase.

After finishing https://github.com/iov-one/weave/issues/262 all linter
errors should be gone and we can add `make lint` to our CI.

resolve #302