### PR TITLE
Replay tool

### DIFF
--- a/cmd/bnsd/app/init.go
+++ b/cmd/bnsd/app/init.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -73,18 +74,21 @@ func GenInitOptions(args []string) (json.RawMessage, error) {
 
 // GenerateApp is used to create a stub for server/start.go command
 func GenerateApp(home string, logger log.Logger, debug bool) (abci.Application, error) {
-	// db goes in a subdir, but "" -> "" for memdb
+	// db goes in a subdir, but "" stays "" to use memdb
 	var dbPath string
 	if home != "" {
 		dbPath = filepath.Join(home, "bns.db")
 	}
-
-	// TODO: anyone can make a token????
 	stack := Stack(nil)
 	application, err := Application("bnsd", stack, TxDecoder, dbPath, debug)
 	if err != nil {
 		return nil, err
 	}
+	return DecorateApp(application, logger), nil
+}
+
+// DecorateApp adds initializers and Logger to an Application
+func DecorateApp(application app.BaseApp, logger log.Logger) app.BaseApp {
 	application.WithInit(app.ChainInitializers(
 		&gconf.Initializer{},
 		&multisig.Initializer{},
@@ -94,10 +98,18 @@ func GenerateApp(home string, logger log.Logger, debug bool) (abci.Application, 
 		&ticker.Initializer{},
 		&validators.Initializer{},
 	))
-
-	// set the logger and return
 	application.WithLogger(logger)
-	return application, nil
+	return application
+}
+
+// InlineApp will take a previously prepared CommitStore and return a complete Application
+func InlineApp(kv weave.CommitKVStore, logger log.Logger, debug bool) abci.Application {
+	stack := Stack(nil)
+	ctx := context.Background()
+	RegisterNft()
+	store := app.NewStoreApp("bnsd", kv, QueryRouter(), ctx)
+	base := app.NewBaseApp(store, TxDecoder, stack, nil, debug)
+	return DecorateApp(base, logger)
 }
 
 type output struct {

--- a/cmd/bnsd/main.go
+++ b/cmd/bnsd/main.go
@@ -65,7 +65,7 @@ func main() {
 	case "getblock":
 		err = server.GetBlockCmd(logger, *varHome, rest)
 	case "retry":
-		err = server.RetryCmd(logger, *varHome, rest)
+		err = server.RetryCmd(app.InlineApp, logger, *varHome, rest)
 	case "testgen":
 		err = commands.TestGenCmd(app.Examples(), rest)
 	case "version":

--- a/cmd/bnsd/main.go
+++ b/cmd/bnsd/main.go
@@ -26,13 +26,14 @@ func init() {
 }
 
 func helpMessage() {
-	fmt.Println("bns")
-	fmt.Println("        Blockchain of Value node")
+	fmt.Println("bnsd")
+	fmt.Println("          Blockchain Name Service node")
 	fmt.Println("")
-	fmt.Println("help    Print this message")
-	fmt.Println("init    Initialize app options in genesis file")
-	fmt.Println("start   Run the abci server")
-	fmt.Println("version Print the app version")
+	fmt.Println("help      Print this message")
+	fmt.Println("init      Initialize app options in genesis file")
+	fmt.Println("start     Run the abci server")
+	fmt.Println("getblock  Extract a block from blockchain.db")
+	fmt.Println("version   Print the app version")
 	fmt.Println(`
   -home string
         directory to store files under (default "$HOME/.bns")`)
@@ -60,6 +61,8 @@ func main() {
 		err = server.InitCmd(app.GenInitOptions, logger, *varHome, rest)
 	case "start":
 		err = server.StartCmd(app.GenerateApp, logger, *varHome, rest)
+	case "getblock":
+		err = server.GetBlockCmd(logger, *varHome, rest)
 	case "testgen":
 		err = commands.TestGenCmd(app.Examples(), rest)
 	case "version":

--- a/cmd/bnsd/main.go
+++ b/cmd/bnsd/main.go
@@ -33,6 +33,7 @@ func helpMessage() {
 	fmt.Println("init      Initialize app options in genesis file")
 	fmt.Println("start     Run the abci server")
 	fmt.Println("getblock  Extract a block from blockchain.db")
+	fmt.Println("retry     Run last block again to ensure it produces same result")
 	fmt.Println("version   Print the app version")
 	fmt.Println(`
   -home string
@@ -63,6 +64,8 @@ func main() {
 		err = server.StartCmd(app.GenerateApp, logger, *varHome, rest)
 	case "getblock":
 		err = server.GetBlockCmd(logger, *varHome, rest)
+	case "retry":
+		err = server.RetryCmd(logger, *varHome, rest)
 	case "testgen":
 		err = commands.TestGenCmd(app.Examples(), rest)
 	case "version":

--- a/cmd/bnsd/scenarios/nft_test.go
+++ b/cmd/bnsd/scenarios/nft_test.go
@@ -15,9 +15,10 @@ import (
 )
 
 func TestIssueNfts(t *testing.T) {
-	// ID must be at least 3 characters, so ensure it's never less than 100.
+	// Ensure suffix is never less than 100, but never more than 10000 (3 or 4 chars)
+	// as there were test failures with eg. 10089
 	// Min length is defined in x/nft helpers.
-	uniqueSuffix := rand.New(rand.NewSource(time.Now().UnixNano())).Intn(9999) + 100
+	uniqueSuffix := rand.New(rand.NewSource(time.Now().UnixNano())).Intn(8999) + 100
 	myBlockchainID := []byte(fmt.Sprintf("aliceChain%d", uniqueSuffix))
 	myTicker := []byte(fmt.Sprint(uniqueSuffix))
 	myUserName := []byte(fmt.Sprintf("alice-%d@example.com", uniqueSuffix))

--- a/commands/server/getblock.go
+++ b/commands/server/getblock.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	amino "github.com/tendermint/go-amino"
+	"github.com/tendermint/tendermint/blockchain"
+	dbm "github.com/tendermint/tendermint/libs/db"
+	"github.com/tendermint/tendermint/libs/log"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+)
+
+const (
+	flagHeight = "height"
+)
+
+var cdc = amino.NewCodec()
+
+func init() {
+	ctypes.RegisterAmino(cdc)
+}
+
+func parseArgs(args []string) (string, int64, error) {
+	if len(args) == 0 {
+		return "", 0, fmt.Errorf("Usage: cmd getblock <path to blockstore.db> [-height=H]")
+	}
+	var height int
+	getBlockFlags := flag.NewFlagSet("getblock", flag.ExitOnError)
+	getBlockFlags.IntVar(&height, flagHeight, 0, "height of the block to extract (default latest)")
+	err := getBlockFlags.Parse(args[1:])
+	return args[0], int64(height), err
+}
+
+// GetBlockCmd extracts a block from a blockstore.db and outputs as json
+// It takes the last block unless -height is explicitly specified
+// It writes the json to stdout
+func GetBlockCmd(logger log.Logger, home string, args []string) error {
+	dbPath, height, err := parseArgs(args)
+	if err != nil {
+		return err
+	}
+	db, err := openDb(dbPath)
+	if err != nil {
+		return err
+	}
+	store := blockchain.NewBlockStore(db)
+	if height == 0 {
+		height = store.Height()
+	}
+	return printBlock(store, height)
+}
+
+func openDb(dir string) (dbm.DB, error) {
+	if strings.HasSuffix(dir, ".db") {
+		dir = dir[:len(dir)-3]
+	} else if strings.HasSuffix(dir, ".db/") {
+		dir = dir[:len(dir)-4]
+	} else {
+		return nil, fmt.Errorf("Database directory must end with .db")
+	}
+	// TODO: doesn't work on windows!
+	cut := strings.LastIndex(dir, "/")
+	if cut == -1 {
+		return nil, fmt.Errorf("Cannot cut paths on %s", dir)
+	}
+	name := dir[cut+1:]
+	db, err := dbm.NewGoLevelDB(name, dir[:cut])
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+func printBlock(store *blockchain.BlockStore, height int64) error {
+	block := store.LoadBlock(height)
+	if block == nil {
+		return fmt.Errorf("No block for height: %d", height)
+	}
+	js, err := cdc.MarshalJSONIndent(block, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(js))
+	return nil
+}

--- a/commands/server/getblock.go
+++ b/commands/server/getblock.go
@@ -22,7 +22,7 @@ func init() {
 	ctypes.RegisterAmino(cdc)
 }
 
-func parseArgs(args []string) (string, int64, error) {
+func parseGetBlockArgs(args []string) (string, int64, error) {
 	if len(args) == 0 {
 		return "", 0, fmt.Errorf("Usage: cmd getblock <path to blockstore.db> [-height=H]")
 	}
@@ -37,7 +37,7 @@ func parseArgs(args []string) (string, int64, error) {
 // It takes the last block unless -height is explicitly specified
 // It writes the json to stdout
 func GetBlockCmd(logger log.Logger, home string, args []string) error {
-	dbPath, height, err := parseArgs(args)
+	dbPath, height, err := parseGetBlockArgs(args)
 	if err != nil {
 		return err
 	}

--- a/commands/server/retry.go
+++ b/commands/server/retry.go
@@ -113,7 +113,7 @@ func retryBlock(builder appBuilder, tree *iavl.MutableTree, block *types.Block, 
 		return err
 	}
 
-	if same && untilError && maxTries > 0 {
+	for same && untilError && maxTries > 0 {
 		maxTries--
 		same, err = rerunBlock(builder, tree, block)
 		if err != nil {

--- a/commands/server/retry.go
+++ b/commands/server/retry.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/tendermint/iavl"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/types"
+)
+
+const (
+	flagUntilError = "error"
+	flagMaxTries   = "max"
+)
+
+type retryArgs struct {
+	dbPath     string
+	blockPath  string
+	debug      bool
+	untilError bool
+	maxTries   int
+}
+
+func parseRetryArgs(args []string) (retryArgs, error) {
+	if len(args) < 2 {
+		return retryArgs{}, fmt.Errorf("Usage: cmd retry <path to abci.db> <path to block.json> [-debug] [-error] [-max=N]")
+	}
+	res := retryArgs{
+		dbPath:    args[0],
+		blockPath: args[1],
+	}
+	getBlockFlags := flag.NewFlagSet("retry", flag.ExitOnError)
+	getBlockFlags.BoolVar(&res.debug, flagDebug, false, "print out debug info")
+	getBlockFlags.BoolVar(&res.untilError, flagUntilError, false, "retry multiple times until an error appears")
+	getBlockFlags.IntVar(&res.maxTries, flagMaxTries, 10, "maximum number of times to retry if -error is passed")
+	err := getBlockFlags.Parse(args[2:])
+	return res, err
+}
+
+// RetryCmd takes the app state and the last block from the file system
+// It verifies that they match, then rolls back one block and re-runs the given block
+// It will output the new hash after running.
+//
+// If -error is passed, then it will try -max times until a different app hash results
+func RetryCmd(logger log.Logger, home string, args []string) error {
+	flags, err := parseRetryArgs(args)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("--> Loading Block")
+	blockJSON, err := ioutil.ReadFile(flags.blockPath)
+	if err != nil {
+		return err
+	}
+	var block *types.Block
+	err = cdc.UnmarshalJSON(blockJSON, &block)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("--> Loading Database")
+	_, ver, err := readTree(flags.dbPath, 0)
+	if err != nil {
+		return fmt.Errorf("error reading abci data: %s", err)
+	}
+
+	if ver != block.Header.Height {
+		return fmt.Errorf("Height mismatch - block=%d, abcistore=%d", block.Header.Height, ver)
+	}
+
+	return nil
+}
+
+func readTree(dir string, version int) (*iavl.MutableTree, int64, error) {
+	db, err := openDb(dir)
+	if err != nil {
+		return nil, 0, err
+	}
+	tree := iavl.NewMutableTree(db, 10000) // cache size 10000
+	ver, err := tree.LoadVersion(int64(version))
+	if ver == 0 {
+		return nil, 0, fmt.Errorf("iavl tree is empty")
+	}
+	return tree, ver, err
+}

--- a/store/btree.go
+++ b/store/btree.go
@@ -35,6 +35,19 @@ func MemStore() CacheableKVStore {
 	return NewBTreeCacheWrap(e, e.NewBatch(), nil)
 }
 
+// ShowOpser returns an ordered list of all operations performed
+type ShowOpser interface {
+	ShowOps() []Op
+}
+
+// LogableStore will return a store, along with insight into all operations that were run on it
+func LogableStore() (CacheableKVStore, ShowOpser) {
+	e := EmptyKVStore{}
+	b := NewNonAtomicBatch(e)
+	kv := NewBTreeCacheWrap(e, b, nil)
+	return kv, b
+}
+
 ///////////////////////////////////////////////
 // Actual CacheWrap implementation
 

--- a/store/helpers.go
+++ b/store/helpers.go
@@ -123,6 +123,16 @@ func (o Op) Apply(out SetDeleter) {
 	}
 }
 
+// IsSetOp returns true if it is setting (false implies delete)
+func (o Op) IsSetOp() bool {
+	return o.kind == setKind
+}
+
+// Key returns a copy of the Key
+func (o Op) Key() []byte {
+	return append([]byte(nil), o.key...)
+}
+
 // SetOp is a helper to create a set operation
 func SetOp(key, value []byte) Op {
 	return Op{
@@ -185,4 +195,14 @@ func (b *NonAtomicBatch) Write() {
 		Op.Apply(b.out)
 	}
 	b.ops = nil
+}
+
+// ShowOps is instrumentation for testing,
+// it returns a copy of the internal Ops list
+func (b *NonAtomicBatch) ShowOps() []Op {
+	ops := make([]Op, len(b.ops))
+	for i, op := range b.ops {
+		ops[i] = op
+	}
+	return ops
 }

--- a/store/iavl/adapter.go
+++ b/store/iavl/adapter.go
@@ -36,6 +36,12 @@ func NewCommitStore(path, name string) CommitStore {
 	return commit
 }
 
+// NewCommitStoreFromTree accepts a preloaded MutableTree and wraps it
+// Mainly designed for test code... or devs who want full control
+func NewCommitStoreFromTree(tree *iavl.MutableTree) CommitStore {
+	return CommitStore{tree, DefaultHistory}
+}
+
 // MockCommitStore creates a new in-memory store for testing
 func MockCommitStore() CommitStore {
 	var db dbm.DB = dbm.NewMemDB()


### PR DESCRIPTION
Note: this is currently forked from 0.11.1 tag to ensure complete compatibility with the test case that failed.

Adds two new subcommands to `bnsd` to support forensic work:

* `bnsd getblock <file> [-height=H]` will extract a json block from a blockstore.db
* `bnsd retry <abci.db> <block.json>` will rollback the database one step and run the last block again. Multiple runs can detect non-determinism