### PR TITLE
Add stacktrace to new errors code

### DIFF
--- a/errors/doc.go
+++ b/errors/doc.go
@@ -15,5 +15,18 @@ Package errors implements custom error interfaces for weave.
 
  Also, error package defines a convenient Is helper to compare errors, also each Error defines an Is
  helper to compare errors directly to that type.
+
+ There is also support for stacktraces. Please ensure you create the custom error using
+ ErrXyz.New("...") or errors.Wrap(err, "...") at the point of creation to ensure we attach
+ a stacktrace. If you wrap multiple times, we only record the first wrap with the stacktrace.
+ (And don't do this as a global `var ErrFoo = errors.ErrInternal.New("foo")` or you will get a
+ useless stacktrace).
+
+ Once you have an error, you can use `fmt.Printf/Sprintf` to get more context for the error
+   %s is just the error message
+   %+v is the full stack trace
+   %v appends a compressed [filename:line] where the error was created
+(source is wrappedError.Format)
+Or call `err.StackTrace()` to get the raw call stack of the creation point
 */
 package errors

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -257,6 +257,9 @@ func matchesFile(f errors.Frame, substrs ...string) bool {
 }
 
 func fileLine(f errors.Frame) (string, int) {
+	// this looks a bit like magic, but follows example here:
+	// https://github.com/pkg/errors/blob/v0.8.1/stack.go#L14-L27
+	// as this is where we get the Frames
 	pc := uintptr(f) - 1
 	fn := runtime.FuncForPC(pc)
 	if fn == nil {
@@ -300,6 +303,8 @@ func writeSimpleFrame(s io.Writer, f errors.Frame) {
 // %+v is the full stack trace
 // %v appends a compressed [filename:line] where the error
 //    was created
+//
+// Inspired by https://github.com/pkg/errors/blob/v0.8.1/errors.go#L162-L176
 func (e *wrappedError) Format(s fmt.State, verb rune) {
 	// normal output here....
 	if verb != 'v' {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -148,6 +148,14 @@ func Wrap(err error, description string) TMError {
 	if err == nil {
 		return nil
 	}
+	// this will not fire on wrapping a wrappedError,
+	// but only on wrapping a registered Error, or stdlib error
+	//
+	// TODO
+	// Note: we need to grab the abci code and message as well....
+	// if _, ok := err.(stackTracer); !ok {
+	// 	err = errors.WithStack(err)
+	// }
 	return &wrappedError{
 		Parent: err,
 		Msg:    description,
@@ -166,9 +174,12 @@ type coder interface {
 }
 
 func (e *wrappedError) StackTrace() errors.StackTrace {
-	// TODO: this is either to be implemented or expectation of it being
-	// present removed completely. As this is an early stage of
-	// refactoring, this is left unimplemented for now.
+	if e.Parent == nil {
+		return nil
+	}
+	if s, ok := e.Parent.(stackTracer); ok {
+		return s.StackTrace()
+	}
 	return nil
 }
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -313,6 +313,6 @@ func (e *wrappedError) Format(s fmt.State, verb rune) {
 		fmt.Fprintf(s, e.ABCILog())
 	} else {
 		fmt.Fprintf(s, e.ABCILog())
-		writeSimpleFrame(s, e.StackTrace()[0])
+		writeSimpleFrame(s, stack[0])
 	}
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -186,10 +186,7 @@ func (e *wrappedError) StackTrace() errors.StackTrace {
 	if e.parent == nil {
 		return nil
 	}
-	if s, ok := e.parent.(stackTracer); ok {
-		return s.StackTrace()
-	}
-	return nil
+	return e.parent.StackTrace()
 }
 
 func (e *wrappedError) Error() string {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -233,6 +233,16 @@ func TestStackTrace(t *testing.T) {
 			assert.False(t, strings.Contains(debug, wrap))
 			assert.False(t, strings.Contains(debug, errNew))
 			assert.False(t, strings.Contains(debug, runtime))
+
+			// verify printing with %v gives minimal info
+			medium := fmt.Sprintf("%v", tc.err)
+			fmt.Println(medium)
+			// include the log message
+			assert.True(t, strings.HasPrefix(medium, tc.log))
+			// only one line
+			assert.False(t, strings.Contains(medium, "\n"))
+			// contains a link to where it started
+			assert.True(t, strings.Contains(medium, "[iov-one/weave/errors/"))
 		})
 	}
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -177,6 +177,10 @@ func TestWrapEmpty(t *testing.T) {
 	}
 }
 
+func doWrap(err error) error {
+	return Wrap(err, "do the do")
+}
+
 func TestStackTrace(t *testing.T) {
 	cases := map[string]struct {
 		err error
@@ -199,6 +203,11 @@ func TestStackTrace(t *testing.T) {
 			err:      Wrap(errors.New("bar"), "pkg"),
 			log:      "pkg: bar",
 			withWrap: false,
+		},
+		"Wrapping inside another function is still clean": {
+			err:      doWrap(fmt.Errorf("indirect")),
+			log:      "do the do: indirect",
+			withWrap: true,
 		},
 	}
 
@@ -236,13 +245,12 @@ func TestStackTrace(t *testing.T) {
 
 			// verify printing with %v gives minimal info
 			medium := fmt.Sprintf("%v", tc.err)
-			fmt.Println(medium)
 			// include the log message
 			assert.True(t, strings.HasPrefix(medium, tc.log))
 			// only one line
 			assert.False(t, strings.Contains(medium, "\n"))
-			// contains a link to where it started
-			assert.True(t, strings.Contains(medium, "[iov-one/weave/errors/"))
+			// contains a link to where it was created, which must be here, not the Wrap() function
+			assert.True(t, strings.Contains(medium, "[iov-one/weave/errors/errors_test.go"))
 		})
 	}
 }

--- a/errors/main.go
+++ b/errors/main.go
@@ -2,9 +2,6 @@ package errors
 
 import (
 	"fmt"
-	"io"
-	"runtime"
-	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -79,36 +76,6 @@ type stackTracer interface {
 // causer from pkg/errors
 type causer interface {
 	Cause() error
-}
-
-func matchesFile(f errors.Frame, substrs ...string) bool {
-	file, _ := fileLine(f)
-	for _, sub := range substrs {
-		if strings.Contains(file, sub) {
-			return true
-		}
-	}
-	return false
-}
-
-func fileLine(f errors.Frame) (string, int) {
-	pc := uintptr(f) - 1
-	fn := runtime.FuncForPC(pc)
-	if fn == nil {
-		return "unknown", 0
-	}
-	return fn.FileLine(pc)
-}
-
-func writeSimpleFrame(s io.Writer, f errors.Frame) {
-	file, line := fileLine(f)
-	// cut file at "github.com/"
-	// TODO: generalize better for other hosts?
-	chunks := strings.SplitN(file, "github.com/", 2)
-	if len(chunks) == 2 {
-		file = chunks[1]
-	}
-	fmt.Fprintf(s, " [%s:%d]", file, line)
 }
 
 // Format works like pkg/errors, with additions.

--- a/x/cash/decorator.go
+++ b/x/cash/decorator.go
@@ -63,7 +63,7 @@ func (d FeeDecorator) Check(ctx weave.Context, store weave.KVStore, tx weave.Tx,
 
 	// verify we have access to the money
 	if !d.auth.HasAddress(ctx, finfo.Payer) {
-		return res, errors.ErrUnauthorized
+		return res, errors.ErrUnauthorized.New("Fee payer signature missing")
 	}
 	// and have enough
 	collector := gconf.Address(store, GconfCollectorAddress)
@@ -97,7 +97,7 @@ func (d FeeDecorator) Deliver(ctx weave.Context, store weave.KVStore, tx weave.T
 
 	// verify we have access to the money
 	if !d.auth.HasAddress(ctx, finfo.Payer) {
-		return res, errors.ErrUnauthorized
+		return res, errors.ErrUnauthorized.New("Fee payer signature missing")
 	}
 	// and subtract it from the account
 	collector := gconf.Address(store, GconfCollectorAddress)

--- a/x/cash/handler.go
+++ b/x/cash/handler.go
@@ -58,7 +58,7 @@ func (h SendHandler) Check(ctx weave.Context, store weave.KVStore,
 
 	// make sure we have permission from the sender
 	if !h.auth.HasAddress(ctx, msg.Src) {
-		return res, errors.ErrUnauthorized
+		return res, errors.ErrUnauthorized.New("Account owner signature missing")
 	}
 
 	// return cost
@@ -89,7 +89,7 @@ func (h SendHandler) Deliver(ctx weave.Context, store weave.KVStore,
 
 	// make sure we have permission from the sender
 	if !h.auth.HasAddress(ctx, msg.Src) {
-		return res, errors.ErrUnauthorized
+		return res, errors.ErrUnauthorized.New("Account owner signature missing")
 	}
 
 	// move the money....

--- a/x/coin.go
+++ b/x/coin.go
@@ -52,7 +52,7 @@ func (c Coin) Divide(pieces int64) (Coin, Coin, error) {
 	// This is an invalid use of the method.
 	if pieces <= 0 {
 		zero := Coin{Ticker: c.Ticker}
-		return zero, zero, errors.Wrap(errors.ErrHuman, "pieces must be greater than zero")
+		return zero, zero, errors.ErrHuman.New("pieces must be greater than zero")
 	}
 
 	// When dividing whole and there is a leftover then convert it to

--- a/x/currency/handler.go
+++ b/x/currency/handler.go
@@ -65,7 +65,7 @@ func (h *TokenInfoHandler) validate(ctx weave.Context, db weave.KVStore, tx weav
 
 	// Ensure we have permission if the issuer is provided.
 	if h.issuer != nil && !h.auth.HasAddress(ctx, h.issuer) {
-		return nil, errors.ErrUnauthorized
+		return nil, errors.ErrUnauthorized.Newf("Token only issued by %s", h.issuer)
 	}
 
 	// Token can be registered only once and must not be updated.

--- a/x/multisig/handlers.go
+++ b/x/multisig/handlers.go
@@ -64,7 +64,7 @@ func (h CreateContractMsgHandler) validate(ctx weave.Context, db weave.KVStore, 
 	// Retrieve tx main signer in this context
 	sender := x.MainSigner(ctx, h.auth)
 	if sender == nil {
-		return nil, errors.ErrUnauthorized
+		return nil, errors.ErrUnauthorized.New("No signer")
 	}
 
 	msg, err := tx.GetMsg()

--- a/x/namecoin/handler.go
+++ b/x/namecoin/handler.go
@@ -116,7 +116,7 @@ func (h TokenHandler) validate(ctx weave.Context, db weave.KVStore,
 
 	// make sure we have permission if the issuer is set
 	if h.issuer != nil && !h.auth.HasAddress(ctx, h.issuer) {
-		return nil, errors.ErrUnauthorized
+		return nil, errors.ErrUnauthorized.Newf("Token only issued by %s", h.issuer)
 	}
 
 	// make sure no token there yet
@@ -202,7 +202,7 @@ func (h SetNameHandler) validate(ctx weave.Context, db weave.KVStore,
 
 	// only wallet owner can set the name
 	if !h.auth.HasAddress(ctx, msg.Address) {
-		return nil, errors.ErrUnauthorized
+		return nil, errors.ErrUnauthorized.New("Not wallet owner")
 	}
 
 	return msg, nil

--- a/x/namecoin/init.go
+++ b/x/namecoin/init.go
@@ -70,7 +70,7 @@ func setWallets(db weave.KVStore, gens []GenesisAccount) error {
 	bucket := NewWalletBucket()
 	for _, gen := range gens {
 		if len(gen.Address) != weave.AddressLength {
-			return errors.ErrInvalidInput.Newf("address: %v", gen.Address)
+			return errors.ErrInvalidInput.Newf("address: %s", gen.Address)
 		}
 		wallet, err := WalletWith(gen.Address, gen.Name, gen.Wallet.Coins...)
 		if err != nil {

--- a/x/nft/base/handler.go
+++ b/x/nft/base/handler.go
@@ -94,7 +94,7 @@ func (h *ApprovalOpsHandler) Deliver(ctx weave.Context, store weave.KVStore, tx 
 
 	actor := nft.FindActor(h.auth, ctx, t, nft.UpdateApprovals)
 	if actor == nil {
-		return res, errors.ErrUnauthorized
+		return res, errors.ErrUnauthorized.New("Needs update approval")
 	}
 
 	switch v := msg.(type) {

--- a/x/validators/controller.go
+++ b/x/validators/controller.go
@@ -40,6 +40,9 @@ func (c BaseController) CanUpdateValidators(store weave.KVStore, checkAddress Ch
 
 	ok := HasPermission(AsWeaveAccounts(accts), checkAddress)
 	if !ok {
+		// TODO: improve this error message, so we use .New for stacktrace
+		// The current check flow seems convoluted to me, why pass functions into something else,
+		// rather than just pass an address/es and call the standard auth function
 		return nil, errors.ErrUnauthorized
 	}
 


### PR DESCRIPTION
Closes #311 

Adds the stacktrace on the first Wrap call, if it wasn't passed in (eg. from pkg/errors)
Future wraps just delegate `StackTrace()` to their parents.

`fmt.Printf("%s", err)` works just like always, returning `err.Error()`
Adds support for `"%+v"` working like pkg/errors, with full stack trace followed by the error message. Strips out boilerplate, such as errors.Wrap, errors.Error.New, runtime, etc to focus on the interesting lines.

Example:
```
github.com/iov-one/weave/errors.doWrap
        /home/ethan/go/src/github.com/iov-one/weave/errors/errors_test.go:181
github.com/iov-one/weave/errors.TestStackTrace
        /home/ethan/go/src/github.com/iov-one/weave/errors/errors_test.go:208
do the do: indirect
```

Also adds support for `"%v"` with minimal context, just the line number where error was created... 
~~this may need to be improved, as it will only refer to the Wrap function unless the original wrapped error was `pkg/errors` (but then have no abci code)~~

Example: `name: duplicate [iov-one/weave/errors/errors_test.go:189]`
