### PR TITLE
add coins normalize function

### DIFF
--- a/x/coins.go
+++ b/x/coins.go
@@ -193,30 +193,24 @@ func (cs Coins) Validate() error {
 	return nil
 }
 
-// normalize is a cleanup operation that merge and orders set of coin instances
+// NormalizeCoins is a cleanup operation that merge and orders set of coin instances
 // into a unified form. This includes merging coins of the same currency and
 // sorting coins according to the ticker name.
 // If given set of coins is normalized this operation return what was given.
 // Otherwise a new instance of a slice can be returned.
-func normalize(cs []*Coin) ([]*Coin, error) {
+func NormalizeCoins(cs Coins) (Coins, error) {
 	// If there is one or no coins, there is nothing to normalize.
 	switch len(cs) {
 	case 0:
 		return nil, nil
 	case 1:
-		if cs[0].IsZero() {
+		if cs[0] == nil || cs[0].IsZero() {
 			return nil, nil
 		}
 		return cs, nil
-	}
-
-	if isNormalized(cs) {
-		return cs, nil
-	}
-
-	// This is an another optimization. If there are only two coins then
-	// compare them directly.
-	if len(cs) == 2 {
+	case 2:
+		// This is an another optimization. If there are only two coins then
+		// compare them directly.
 		switch n := strings.Compare(cs[0].Ticker, cs[1].Ticker); {
 		case n == 0:
 			total, err := cs[0].Add(*cs[1])
@@ -232,6 +226,10 @@ func normalize(cs []*Coin) ([]*Coin, error) {
 		case n < 0:
 			return cs, nil
 		}
+	}
+
+	if isNormalized(cs) {
+		return cs, nil
 	}
 
 	set := make(map[string]Coin)
@@ -267,8 +265,8 @@ func normalize(cs []*Coin) ([]*Coin, error) {
 	return coins, nil
 }
 
-// isNormalized check if coins are in normalized form. This is a cheap
-// operation.
+// isNormalized check if coins collection is in a normalized form. This is a
+// cheap operation.
 func isNormalized(cs []*Coin) bool {
 	var prev *Coin
 	for _, c := range cs {

--- a/x/coins.go
+++ b/x/coins.go
@@ -204,7 +204,7 @@ func NormalizeCoins(cs Coins) (Coins, error) {
 	case 0:
 		return nil, nil
 	case 1:
-		if cs[0] == nil || cs[0].IsZero() {
+		if IsEmpty(cs[0]) {
 			return nil, nil
 		}
 		return cs, nil
@@ -270,14 +270,15 @@ func NormalizeCoins(cs Coins) (Coins, error) {
 func isNormalized(cs []*Coin) bool {
 	var prev *Coin
 	for _, c := range cs {
-		if c == nil {
-			return false
-		}
-		if c.IsZero() {
+		if IsEmpty(c) {
 			// Zero coins should not be a part of a collection
 			// because they carry no value.
 			return false
 		}
+
+		// This is a good place to call c.Validate() but because of
+		// huge performance impact, it is not called.
+
 		if prev != nil {
 			if prev.Ticker >= c.Ticker {
 				// Not ordered by the ticker or the ticker is

--- a/x/coins.go
+++ b/x/coins.go
@@ -210,6 +210,10 @@ func normalize(cs []*Coin) ([]*Coin, error) {
 		return cs, nil
 	}
 
+	if isNormalized(cs) {
+		return cs, nil
+	}
+
 	// This is an another optimization. If there are only two coins then
 	// compare them directly.
 	if len(cs) == 2 {
@@ -261,4 +265,29 @@ func normalize(cs []*Coin) ([]*Coin, error) {
 	})
 
 	return coins, nil
+}
+
+// isNormalized check if coins are in normalized form. This is a cheap
+// operation.
+func isNormalized(cs []*Coin) bool {
+	var prev *Coin
+	for _, c := range cs {
+		if c == nil {
+			return false
+		}
+		if c.IsZero() {
+			// Zero coins should not be a part of a collection
+			// because they carry no value.
+			return false
+		}
+		if prev != nil {
+			if prev.Ticker >= c.Ticker {
+				// Not ordered by the ticker or the ticker is
+				// duplicated.
+				return false
+			}
+		}
+		prev = c
+	}
+	return true
 }

--- a/x/coins_test.go
+++ b/x/coins_test.go
@@ -226,7 +226,7 @@ func TestCoinsNormalize(t *testing.T) {
 
 	cases := map[string]struct {
 		coins     Coins
-		wantCoins []*Coin
+		wantCoins Coins
 		wantErr   error
 	}{
 		"nil coins": {
@@ -418,7 +418,7 @@ func TestCoinsIsNormalized(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		coins []*Coin
+		coins Coins
 		want  bool
 	}{
 		"nil": {

--- a/x/coins_test.go
+++ b/x/coins_test.go
@@ -307,7 +307,7 @@ func TestCoinsNormalize(t *testing.T) {
 
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
-			got, err := normalize(tc.coins)
+			got, err := NormalizeCoins(tc.coins)
 			if !errors.Is(tc.wantErr, err) {
 				t.Fatalf("want %+v error, got %+v", tc.wantErr, err)
 			}
@@ -405,7 +405,7 @@ func BenchmarkCoinsNormalize(b *testing.B) {
 	for benchName, coins := range benchmarks {
 		b.Run(benchName, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				normalize(coins)
+				NormalizeCoins(coins)
 			}
 		})
 	}

--- a/x/distribution/handler.go
+++ b/x/distribution/handler.go
@@ -245,16 +245,16 @@ func distribute(db weave.KVStore, ctrl CashController, source weave.Address, rec
 	balance, err := ctrl.Balance(db, source)
 	switch {
 	case err == nil:
-		// All good.
+		balance, err = x.NormalizeCoins(balance)
+		if err != nil {
+			return errors.Wrap(err, "cannot normalize balance")
+		}
 	case errors.Is(errors.ErrNotFound, err):
 		// Account does not exist, so there is are no funds to split.
 		return nil
 	default:
 		return errors.Wrap(err, "cannot acquire revenue account balance")
 	}
-
-	// TODO normalize balance. There is no functionality that allows to
-	// normalize x.Coins right now (14 Feb 2019).
 
 	// For each currency, distribute the coins equally to the weight of
 	// each recipient. This can leave small amount of coins on the original


### PR DESCRIPTION
This functionality is not yet used anywhere.

part of #327

```
goos: linux
goarch: amd64
pkg: github.com/iov-one/weave/x
BenchmarkCoinsNormalize/nil_coins-4               500000000 3.69 ns/op
BenchmarkCoinsNormalize/zero_len_coins-4          500000000 3.70 ns/op
BenchmarkCoinsNormalize/two_unordered_coins-4     100000000 17.6 ns/op
BenchmarkCoinsNormalize/two_split_coins-4          10000000  187 ns/op
BenchmarkCoinsNormalize/four_normalized-4          50000000 32.6 ns/op
BenchmarkCoinsNormalize/six_not_normalized-4        1000000 1147 ns/op
BenchmarkCoinsNormalize/twelve_normalized-4        20000000 93.4 ns/op
BenchmarkCoinsNormalize/one_coin-4                300000000 5.66 ns/op
BenchmarkCoinsNormalize/two_normalized_coins-4    100000000 17.7 ns/op
BenchmarkCoinsNormalize/four_not_normalized-4       1000000 1100 ns/op
BenchmarkCoinsNormalize/six_normalized-4           30000000 50.0 ns/op
BenchmarkCoinsNormalize/twelve_not_normalized-4     1000000 2501 ns/op
```