### PR TITLE
Init escrow in genesis

### DIFF
--- a/cmd/bnsd/app/init.go
+++ b/cmd/bnsd/app/init.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/iov-one/weave/x/escrow"
+
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/app"
 	"github.com/iov-one/weave/cmd/bnsd/x/nft/username"
@@ -102,6 +104,7 @@ func DecorateApp(application app.BaseApp, logger log.Logger) app.BaseApp {
 		&currency.Initializer{},
 		&validators.Initializer{},
 		&distribution.Initializer{},
+		&escrow.Initializer{},
 	))
 	application.WithLogger(logger)
 	return application

--- a/cmd/bnsd/app/init.go
+++ b/cmd/bnsd/app/init.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/iov-one/weave/x/escrow"
-
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/app"
 	"github.com/iov-one/weave/cmd/bnsd/x/nft/username"
@@ -19,6 +17,7 @@ import (
 	"github.com/iov-one/weave/x/cash"
 	"github.com/iov-one/weave/x/currency"
 	"github.com/iov-one/weave/x/distribution"
+	"github.com/iov-one/weave/x/escrow"
 	"github.com/iov-one/weave/x/multisig"
 	"github.com/iov-one/weave/x/validators"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -104,7 +103,7 @@ func DecorateApp(application app.BaseApp, logger log.Logger) app.BaseApp {
 		&currency.Initializer{},
 		&validators.Initializer{},
 		&distribution.Initializer{},
-		&escrow.Initializer{},
+		&escrow.Initializer{Minter: cash.NewController(cash.NewBucket())},
 	))
 	application.WithLogger(logger)
 	return application

--- a/cmd/bnsd/client/client.go
+++ b/cmd/bnsd/client/client.go
@@ -190,7 +190,7 @@ func (b *BnsClient) TxSearch(query string, prove bool, page, perPage int) (*ctyp
 	return b.conn.TxSearch(query, prove, page, perPage)
 }
 
-// BroadcastTxResponse is the result of submitting a transaction
+// BroadcastTxResponse is the result of submitting a transaction.
 type BroadcastTxResponse struct {
 	Error    error                           // not-nil if there was an error sending
 	Response *ctypes.ResultBroadcastTxCommit // not-nil if we got response from node

--- a/cmd/bnsd/scenarios/escrow_test.go
+++ b/cmd/bnsd/scenarios/escrow_test.go
@@ -2,8 +2,68 @@ package scenarios
 
 import (
 	"testing"
+	"time"
+
+	"github.com/iov-one/weave/cmd/bnsd/app"
+	"github.com/iov-one/weave/cmd/bnsd/client"
+	"github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/x/escrow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestEscrow(t *testing.T) {
+func TestQueryEscrowExists(t *testing.T) {
+	walletResp, err := bnsClient.GetWallet(escrowContract.Address())
+	// then
+	require.NoError(t, err)
+	require.NotNil(t, walletResp)
+	require.Len(t, walletResp.Wallet.Coins, 1)
+	assert.True(t, walletResp.Wallet.Coins[0].Whole > 0)
+}
 
+func TestEscrowRelease(t *testing.T) {
+	// query distribution accounts start balance
+	walletResp, err := bnsClient.GetWallet(distrContractAddr)
+	require.NoError(t, err)
+	startBalance := coin.Coin{Ticker: "IOV"}
+	if walletResp != nil {
+		startBalance = *walletResp.Wallet.Coins[0]
+	}
+	aNonce := client.NewNonce(bnsClient, alice.PublicKey().Address())
+	// when releasing 1 IOV by the arbiter
+	_, _, escrowID, _ := escrowContract.Parse()
+
+	addValidatorTX := &app.Tx{
+		Sum: &app.Tx_ReleaseEscrowMsg{
+			&escrow.ReleaseEscrowMsg{
+				EscrowId: escrowID,
+				Amount:   []*coin.Coin{{Ticker: "IOV", Whole: 1}},
+			},
+		},
+	}
+	_, _, contractID, _ := multiSigContract.Parse()
+	addValidatorTX.Multisig = [][]byte{contractID}
+
+	seq, err := aNonce.Next()
+	require.NoError(t, err)
+	require.NoError(t, client.SignTx(addValidatorTX, alice, chainID, seq))
+	resp := bnsClient.BroadcastTx(addValidatorTX)
+
+	// then
+	require.NoError(t, resp.IsError())
+
+	// and check it was added to the distr account
+	for i := 0; 1 < 10; i++ {
+		walletResp, err = bnsClient.GetWallet(distrContractAddr)
+		require.NoError(t, err)
+		if walletResp.Height > resp.Response.Height {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	require.NotNil(t, walletResp)
+	require.True(t, walletResp.Height > resp.Response.Height)
+	require.True(t, len(walletResp.Wallet.Coins) == 1)
+	// new balance should be higher
+	assert.False(t, startBalance.IsGTE(*walletResp.Wallet.Coins[0]), "%s not > %s", *walletResp.Wallet.Coins[0], startBalance)
 }

--- a/cmd/bnsd/scenarios/escrow_test.go
+++ b/cmd/bnsd/scenarios/escrow_test.go
@@ -1,0 +1,9 @@
+package scenarios
+
+import (
+	"testing"
+)
+
+func TestEscrow(t *testing.T) {
+
+}

--- a/cmd/bnsd/scenarios/main_test.go
+++ b/cmd/bnsd/scenarios/main_test.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alpe/vendor_old/github.com/ethereum/go-ethereum/common/math"
+	"github.com/iov-one/weave/x/escrow"
+
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/cmd/bnsd/app"
 	"github.com/iov-one/weave/cmd/bnsd/client"
@@ -21,7 +24,7 @@ import (
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/log"
 	nm "github.com/tendermint/tendermint/node"
-	rpctest "github.com/tendermint/tendermint/rpc/test"
+	"github.com/tendermint/tendermint/rpc/test"
 	tm "github.com/tendermint/tendermint/types"
 )
 
@@ -33,14 +36,17 @@ const (
 )
 
 var (
-	tendermintAddress = flag.String("address", testLocalAddress, "destination address of tendermint rpc")
-	hexSeed           = flag.String("seed", "d34c1970ae90acf3405f2d99dcaca16d0c7db379f4beafcfdf667b9d69ce350d27f5fb440509dfa79ec883a0510bc9a9614c3d44188881f0c5e402898b4bf3c9", "private key seed in hex")
-	delay             = flag.Duration("delay", time.Duration(0), "duration to wait between test cases for rate limits")
-	derivationPath    = flag.String("derivation", "", "bip44 derivation path: \"m/4804438'/0'\"")
+	tendermintAddress   = flag.String("address", testLocalAddress, "destination address of tendermint rpc")
+	hexSeedAlice        = flag.String("seed-alice", "d34c1970ae90acf3405f2d99dcaca16d0c7db379f4beafcfdf667b9d69ce350d27f5fb440509dfa79ec883a0510bc9a9614c3d44188881f0c5e402898b4bf3c9", "private key seed in hex")
+	hexSeedBert         = flag.String("seed-bert", "e36af7e8f7297c9dfdfd66302ba2cc1768f07d326dc1438f2e5cbd6b48eb447c67762ee351bb283dba1189b81b192e3f18de838b16f199bd7f426c3b7e4f28a7", "private key seed in hex")
+	delay               = flag.Duration("delay", time.Duration(0), "duration to wait between test cases for rate limits")
+	derivationPathAlice = flag.String("derivation-alice", "", "bip44 derivation path: \"m/4804438'/0'\"")
+	derivationPathBert  = flag.String("derivation-bert", "", "bip44 derivation path: \"m/4804438'/0'\"")
 )
 
 var (
 	alice                *client.PrivateKey
+	bert                 *client.PrivateKey
 	node                 *nm.Node
 	logger               = log.NewTMLogger(os.Stdout) //log.NewNopLogger()
 	bnsClient            *client.BnsClient
@@ -48,42 +54,25 @@ var (
 	rpcAddress           string
 	multiSigContractID   = make([]byte, 8) // first contractID
 	multiSigContractAddr weave.Address     // results to: "5AE2C58796B0AD48FFE7602EAC3353488C859A2B"
+	escrowContractID     = make([]byte, 8) // first contractID
+	escrowContractAddr   weave.Address     // results to: "????"
 )
 
 func TestMain(m *testing.M) {
 	flag.Parse()
 	binary.BigEndian.PutUint64(multiSigContractID, 1)
 	multiSigContractAddr = multisig.MultiSigCondition(multiSigContractID).Address()
-	var err error
-	aliceHexSeed := *hexSeed
-	if len(*derivationPath) != 0 {
-		b, err := hex.DecodeString(*hexSeed)
-		if err != nil {
-			logger.Error("Failed to decode private key", "cause", err)
-			os.Exit(1)
-		}
-		k, err := derivation.DeriveForPath(*derivationPath, b)
-		if err != nil {
-			logger.Error("Failed to derive private key", "cause", err, "derivationPath", *derivationPath)
-			os.Exit(1)
-		}
-		pubKey, err := k.PublicKey()
-		if err != nil {
-			logger.Error("Failed to derive public key", "cause", err)
-			os.Exit(1)
-		}
-		aliceHexSeed = hex.EncodeToString(append(k.Key, pubKey...))
-	}
+	binary.BigEndian.PutUint64(escrowContractID, 1)
+	escrowContractAddr = escrow.Condition(multiSigContractID).Address()
 
-	alice, err = client.DecodePrivateKeyFromSeed(aliceHexSeed)
-	if err != nil {
-		logger.Error("Failed to decode private key", "cause", err)
-		os.Exit(1)
-	}
+	alice = derivePrivateKey(*hexSeedAlice, *derivationPathAlice)
 	logger.Error("Loaded Alice key", "addressID", alice.PublicKey().Address())
+	bert = derivePrivateKey(*hexSeedBert, *derivationPathBert)
+	logger.Error("Loaded Bert's key", "addressID", bert.PublicKey().Address())
 
 	if *tendermintAddress != testLocalAddress {
 		bnsClient = client.NewClient(client.NewHTTPConnection(*tendermintAddress))
+		var err error
 		chainID, err = bnsClient.ChainID()
 		if err != nil {
 			logger.Error("Failed to fetch chain id", "cause", err)
@@ -114,6 +103,34 @@ func TestMain(m *testing.M) {
 	node.Stop()
 	node.Wait()
 	os.Exit(code)
+}
+
+// derivePrivateKey derive a private key from hex and given path. Path can be empty to not derive.
+func derivePrivateKey(hexSeed, path string) *client.PrivateKey {
+	if len(path) != 0 {
+		b, err := hex.DecodeString(path)
+		if err != nil {
+			logger.Error("Failed to decode private key", "cause", err)
+			os.Exit(1)
+		}
+		k, err := derivation.DeriveForPath(path, b)
+		if err != nil {
+			logger.Error("Failed to derive private key", "cause", err, "path", path)
+			os.Exit(1)
+		}
+		pubKey, err := k.PublicKey()
+		if err != nil {
+			logger.Error("Failed to derive public key", "cause", err)
+			os.Exit(1)
+		}
+		hexSeed = hex.EncodeToString(append(k.Key, pubKey...))
+	}
+	pk, err := client.DecodePrivateKeyFromSeed(hexSeed)
+	if err != nil {
+		logger.Error("Failed to decode private key", "cause", err)
+		os.Exit(1)
+	}
+	return pk
 }
 
 func delayForRateLimits() {
@@ -183,6 +200,19 @@ func initGenesis(filename string, addr weave.Address) (*tm.GenesisDoc, error) {
 				"admin_threshold":      1,
 			},
 		},
+		"escrow": []interface{}{
+			dict{
+				"sender":    "0000000000000000000000000000000000000000",
+				"arbiter":   alice.PublicKey().Condition(),
+				"recipient": bert.PublicKey().Address(),
+				"amount": []interface{}{
+					dict{
+						"whole":  123456789,
+						"ticker": "IOV",
+					}},
+				"timeout": math.MaxInt64,
+			},
+		},
 		"gconf": map[string]interface{}{
 			cash.GconfCollectorAddress: hex.EncodeToString(addr),
 			cash.GconfMinimalFee:       coin.Coin{}, // no fee
@@ -191,7 +221,6 @@ func initGenesis(filename string, addr weave.Address) (*tm.GenesisDoc, error) {
 	if err != nil {
 		panic(err)
 	}
-
 	doc.AppState = appState
 	// save file
 	return doc, doc.SaveAs(filename)

--- a/cmd/bnsd/scenarios/validator_test.go
+++ b/cmd/bnsd/scenarios/validator_test.go
@@ -24,7 +24,7 @@ func TestQueryValidatorUpdateSigner(t *testing.T) {
 	var accounts validators.Accounts
 	require.NoError(t, accounts.Unmarshal(r.Models[0].Value))
 	require.Len(t, accounts.Addresses, 1)
-	assert.Contains(t, accounts.Addresses, []byte(multiSigContractAddr))
+	assert.Contains(t, accounts.Addresses, []byte(multiSigContract.Address()), "multisig address not found")
 }
 
 func TestUpdateValidatorSet(t *testing.T) {
@@ -45,7 +45,8 @@ func TestUpdateValidatorSet(t *testing.T) {
 			Power: 1,
 		},
 	)
-	addValidatorTX.Multisig = [][]byte{multiSigContractID}
+	_, _, contractID, _ := multiSigContract.Parse()
+	addValidatorTX.Multisig = [][]byte{contractID}
 
 	seq, err := aNonce.Next()
 	require.NoError(t, err)
@@ -72,7 +73,7 @@ func TestUpdateValidatorSet(t *testing.T) {
 			Power: 0, // 0 for delete
 		},
 	)
-	delValidatorTX.Multisig = [][]byte{multiSigContractID}
+	delValidatorTX.Multisig = [][]byte{contractID}
 
 	// then
 	seq, err = aNonce.Next()

--- a/cmd/bnsd/x/nft/username/bucket.go
+++ b/cmd/bnsd/x/nft/username/bucket.go
@@ -2,6 +2,7 @@ package username
 
 import (
 	"bytes"
+
 	"github.com/iov-one/weave/errors"
 
 	"github.com/iov-one/weave"

--- a/cmd/bnsd/x/nft/username/bucket.go
+++ b/cmd/bnsd/x/nft/username/bucket.go
@@ -2,7 +2,6 @@ package username
 
 import (
 	"bytes"
-
 	"github.com/iov-one/weave/errors"
 
 	"github.com/iov-one/weave"

--- a/conditions_test.go
+++ b/conditions_test.go
@@ -93,39 +93,19 @@ func TestConditionUnmarshalJSON(t *testing.T) {
 		wantCondition weave.Condition
 	}{
 		"default decoding": {
-			json:          `"666F6F2F6261722F636F6E646974696F6E64617461"`,
-			wantCondition: weave.NewCondition("foo", "bar", []byte("conditiondata")),
-		},
-		"hex decoding": {
-			json:          `"hex:666F6F2F6261722F636F6E646974696F6E64617461"`,
-			wantCondition: weave.NewCondition("foo", "bar", []byte("conditiondata")),
-		},
-		"cond decoding": {
-			json:          `"cond:foo/bar/636f6e646974696f6e64617461"`,
+			json:          `"foo/bar/636f6e646974696f6e64617461"`,
 			wantCondition: weave.NewCondition("foo", "bar", []byte("conditiondata")),
 		},
 		"invalid condition format": {
-			json:    `"cond:foo/636f6e646974696f6e64617461"`,
+			json:    `"foo/636f6e646974696f6e64617461"`,
 			wantErr: errors.ErrInvalidInput,
 		},
 		"invalid condition data": {
-			json:    `"cond:foo/bar/zzzzz"`,
+			json:    `"foo/bar/zzzzz"`,
 			wantErr: errors.ErrInvalidInput,
-		},
-		"unknown format": {
-			json:    `"foobar:xxx"`,
-			wantErr: errors.ErrInvalidType,
 		},
 		"zero address": {
 			json:          `""`,
-			wantCondition: nil,
-		},
-		"zero hex address": {
-			json:          `"hex:"`,
-			wantCondition: nil,
-		},
-		"zero cond address": {
-			json:          `"cond:"`,
 			wantCondition: nil,
 		},
 	}
@@ -151,11 +131,11 @@ func TestConditionMarshalJSON(t *testing.T) {
 	}{
 		"cond encoding": {
 			source:   weave.NewCondition("foo", "bar", []byte("conditiondata")),
-			wantJson: `"cond:foo/bar/636F6E646974696F6E64617461"`,
+			wantJson: `"foo/bar/636F6E646974696F6E64617461"`,
 		},
 		"nil encoding": {
 			source:   nil,
-			wantJson: `"cond:"`,
+			wantJson: `""`,
 		},
 	}
 	for testName, tc := range cases {

--- a/x/cash/controller.go
+++ b/x/cash/controller.go
@@ -15,9 +15,9 @@ type CoinMover interface {
 
 // CoinMinter is an interface to create new coins.
 type CoinMinter interface {
-	// IssueCoins increase the number of funds on given accouunt by a
+	// CoinMint increase the number of funds on given accouunt by a
 	// specified amount.
-	IssueCoins(weave.KVStore, weave.Address, coin.Coin) error
+	CoinMint(weave.KVStore, weave.Address, coin.Coin) error
 }
 
 // Controller is the functionality needed by cash.Handler and cash.Decorator.
@@ -102,12 +102,12 @@ func (c BaseController) MoveCoins(store weave.KVStore,
 	return c.bucket.Save(store, recipient)
 }
 
-// IssueCoins attempts to add the given amount of coins to
+// CoinMint attempts to add the given amount of coins to
 // the destination address. Fails if it overflows the wallet.
 //
 // Note the amount may also be negative:
 // "the lord giveth and the lord taketh away"
-func (c BaseController) IssueCoins(store weave.KVStore,
+func (c BaseController) CoinMint(store weave.KVStore,
 	dest weave.Address, amount coin.Coin) error {
 
 	recipient, err := c.bucket.GetOrCreate(store, dest)

--- a/x/cash/controller.go
+++ b/x/cash/controller.go
@@ -13,15 +13,19 @@ type CoinMover interface {
 	MoveCoins(store weave.KVStore, src weave.Address, dest weave.Address, amount coin.Coin) error
 }
 
+// CoinMinter is an interface to create new coins.
+type CoinMinter interface {
+	// IssueCoins increase the number of funds on given accouunt by a
+	// specified amount.
+	IssueCoins(weave.KVStore, weave.Address, coin.Coin) error
+}
+
 // Controller is the functionality needed by cash.Handler and cash.Decorator.
 // BaseController should work plenty fine, but you can add other logic if so
 // desired
 type Controller interface {
 	CoinMover
-
-	// IssueCoins increase the number of funds on given accouunt by a
-	// specified amount.
-	IssueCoins(weave.KVStore, weave.Address, coin.Coin) error
+	CoinMinter
 
 	// Balance returns the amount of funds stored under given account address.
 	Balance(weave.KVStore, weave.Address) (coin.Coins, error)

--- a/x/cash/controller_test.go
+++ b/x/cash/controller_test.go
@@ -106,7 +106,7 @@ func TestIssueCoins(t *testing.T) {
 			kv := store.MemStore()
 
 			for j, issue := range tc.issue {
-				err := controller.IssueCoins(kv, issue.addr, issue.amount)
+				err := controller.CoinMint(kv, issue.addr, issue.amount)
 				if issue.isErr {
 					require.Error(t, err, "%d", j)
 				} else {
@@ -216,7 +216,7 @@ func TestMoveCoins(t *testing.T) {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
 			kv := store.MemStore()
 
-			err := controller.IssueCoins(kv, tc.issue.addr, tc.issue.amount)
+			err := controller.CoinMint(kv, tc.issue.addr, tc.issue.amount)
 			if tc.issue.isErr {
 				require.Error(t, err)
 			} else {
@@ -254,17 +254,17 @@ func TestBalance(t *testing.T) {
 
 	addr1 := weavetest.NewCondition().Address()
 	coin1 := coin.NewCoin(1, 20, "BTC")
-	if err := ctrl.IssueCoins(store, addr1, coin1); err != nil {
+	if err := ctrl.CoinMint(store, addr1, coin1); err != nil {
 		t.Fatalf("cannot issue coins: %s", err)
 	}
 
 	addr2 := weavetest.NewCondition().Address()
 	coin2_1 := coin.NewCoin(3, 40, "ETH")
 	coin2_2 := coin.NewCoin(5, 0, "DOGE")
-	if err := ctrl.IssueCoins(store, addr2, coin2_1); err != nil {
+	if err := ctrl.CoinMint(store, addr2, coin2_1); err != nil {
 		t.Fatalf("cannot issue coins: %s", err)
 	}
-	if err := ctrl.IssueCoins(store, addr2, coin2_2); err != nil {
+	if err := ctrl.CoinMint(store, addr2, coin2_2); err != nil {
 		t.Fatalf("cannot issue coins: %s", err)
 	}
 

--- a/x/distribution/handler_test.go
+++ b/x/distribution/handler_test.go
@@ -319,7 +319,7 @@ func TestHandlers(t *testing.T) {
 
 			for _, a := range tc.prepareAccounts {
 				for _, c := range a.coins {
-					if err := ctrl.IssueCoins(db, a.address, *c); err != nil {
+					if err := ctrl.CoinMint(db, a.address, *c); err != nil {
 						t.Fatalf("cannot issue %q to %s: %s", c, a.address, err)
 					}
 				}

--- a/x/escrow/controller.go
+++ b/x/escrow/controller.go
@@ -2,17 +2,17 @@ package escrow
 
 import (
 	"github.com/iov-one/weave"
-	coin "github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/orm"
 	"github.com/iov-one/weave/x/cash"
 )
 
 type controller struct {
-	cash   cash.Controller
+	cash   cash.CoinMover
 	bucket Bucket
 }
 
-func NewController(cash cash.Controller, bucket Bucket) *controller {
+func NewController(cash cash.CoinMover, bucket Bucket) *controller {
 	return &controller{
 		cash:   cash,
 		bucket: bucket,

--- a/x/escrow/init.go
+++ b/x/escrow/init.go
@@ -53,7 +53,7 @@ func (i *Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
 		}
 		escAddr := Condition(obj.Key()).Address()
 		for _, c := range e.Amount {
-			if err := i.Minter.IssueCoins(db, escAddr, *c); err != nil {
+			if err := i.Minter.CoinMint(db, escAddr, *c); err != nil {
 				return errors.Wrap(err, "failed to issue coins")
 			}
 		}

--- a/x/escrow/init.go
+++ b/x/escrow/init.go
@@ -1,0 +1,53 @@
+package escrow
+
+import (
+	"encoding/hex"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/coin"
+	"github.com/pkg/errors"
+)
+
+var _ weave.Initializer = (*Initializer)(nil)
+var burnAddress, _ = hex.DecodeString("0000000000000000000000000000000000000000")
+
+// Initializer fulfils the Initializer interface to load data from the genesis file
+type Initializer struct{}
+
+// FromGenesis will parse initial escrow  info from genesis and save it in the database.
+func (*Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
+	var escrows []struct {
+		Sender    weave.Address   `json:"sender"`
+		Arbiter   weave.Condition `json:"arbiter"`
+		Recipient weave.Address   `json:"recipient"`
+		Timeout   int64           `json:"timeout"`
+		Amount    []*coin.Coin    `json:"amount"`
+	}
+
+	if err := opts.ReadOptions("escrow", &escrows); err != nil {
+		return err
+	}
+
+	bucket := NewBucket()
+	for i, e := range escrows {
+		escr := Escrow{
+			Sender:    e.Sender,
+			Arbiter:   e.Arbiter,
+			Recipient: e.Recipient,
+			Timeout:   e.Timeout,
+			Amount:    e.Amount,
+		}
+		if err := escr.Validate(); err != nil {
+			return errors.Wrapf(err, "invalid escrow at position: %d ", i)
+		}
+		if !weave.Address(escr.Sender).Equals(burnAddress) {
+			// prevent any other address to not generate new money for an existing account (on timeout)
+			return errors.New("genesis escrows must have burn address sender")
+		}
+		obj := bucket.Build(db, &escr)
+		if err := bucket.Save(db, obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/x/escrow/init.go
+++ b/x/escrow/init.go
@@ -1,8 +1,6 @@
 package escrow
 
 import (
-	"encoding/hex"
-
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/x/cash"
@@ -10,7 +8,6 @@ import (
 )
 
 var _ weave.Initializer = (*Initializer)(nil)
-var burnAddress, _ = hex.DecodeString("0000000000000000000000000000000000000000")
 
 // Initializer fulfils the Initializer interface to load data from the genesis file
 type Initializer struct {
@@ -42,10 +39,6 @@ func (i *Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
 		}
 		if err := escr.Validate(); err != nil {
 			return errors.Wrapf(err, "invalid escrow at position: %d ", j)
-		}
-		if !weave.Address(escr.Sender).Equals(burnAddress) {
-			// prevent any other address to not generate new money for an existing account (on timeout)
-			return errors.New("genesis escrows must have burn address sender")
 		}
 		obj := bucket.Build(db, &escr)
 		if err := bucket.Save(db, obj); err != nil {

--- a/x/escrow/init_test.go
+++ b/x/escrow/init_test.go
@@ -30,7 +30,7 @@ func TestGenesisKey(t *testing.T) {
           "whole": 123456789
         }
       ],
-      "arbiter": "bXVsdGlzaWcvdXNhZ2UvAAAAAAAAAAE=",
+      "arbiter": "cond:foo/bar/636f6e646974696f6e64617461",
       "recipient": "C30A2424104F542576EF01FECA2FF558F5EAA61A",
       "sender": "0000000000000000000000000000000000000000",
       "timeout": 9223372036854775807
@@ -62,7 +62,7 @@ func TestGenesisKey(t *testing.T) {
 	assert.Equal(t, "c30a2424104f542576ef01feca2ff558f5eaa61a", hex.EncodeToString(e.Recipient))
 	assert.Equal(t, "0000000000000000000000000000000000000000", hex.EncodeToString(e.Sender))
 
-	expArbiter := weave.NewCondition("multisig", "usage", seq(1))
+	expArbiter := weave.NewCondition("foo", "bar", []byte("conditiondata"))
 	assert.Equal(t, expArbiter, weave.Condition(e.Arbiter))
 
 	balance, err := cashCtrl.Balance(db, Condition(obj.Key()).Address())
@@ -70,7 +70,6 @@ func TestGenesisKey(t *testing.T) {
 	require.Len(t, e.Amount, 2)
 	assert.Equal(t, coin.Coin{Ticker: "ALX", Whole: 987654321}, *balance[0])
 	assert.Equal(t, coin.Coin{Ticker: "IOV", Whole: 123456789}, *balance[1])
-
 }
 
 // seq returns encoded sequence number as implemented in orm/sequence.go

--- a/x/escrow/init_test.go
+++ b/x/escrow/init_test.go
@@ -1,0 +1,72 @@
+package escrow
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/store"
+)
+
+func TestGenesisKey(t *testing.T) {
+	const genesis = `
+{
+  "escrow": [
+    {
+      "amount": [
+        {
+          "ticker": "IOV",
+          "whole": 123456789
+        }
+      ],
+      "arbiter": "c2lncy9lZDI1NTE5Lyf1+0QFCd+nnsiDoFELyalhTD1EGIiB8MXkAomLS/PJ",
+      "recipient": "C30A2424104F542576EF01FECA2FF558F5EAA61A",
+      "sender": "0000000000000000000000000000000000000000",
+      "timeout": 9223372036854775807
+    }
+  ]}`
+
+	var opts weave.Options
+	if err := json.Unmarshal([]byte(genesis), &opts); err != nil {
+		t.Fatalf("cannot unmarshal genesis: %s", err)
+	}
+
+	db := store.MemStore()
+	var ini Initializer
+	if err := ini.FromGenesis(opts, db); err != nil {
+		t.Fatalf("cannot load genesis: %s", err)
+	}
+
+	bucket := NewBucket()
+	obj, err := bucket.Get(db, seq(1))
+	if err != nil {
+		t.Fatalf("cannot fetch contract information: %s", err)
+	}
+	if obj == nil {
+		t.Fatal("contract information not found")
+	}
+	_, ok := obj.Value().(*Escrow)
+	if !ok {
+		t.Errorf("invalid object stored: %T", obj)
+	}
+
+	// TODO: check results
+}
+
+// seq returns encoded sequence number as implemented in orm/sequence.go
+func seq(val int64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(val))
+	return b
+}
+
+func fromHex(t *testing.T, s string) []byte {
+	t.Helper()
+	raw, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("cannot decode %q hex encoded data: %s", s, err)
+	}
+	return raw
+}

--- a/x/escrow/init_test.go
+++ b/x/escrow/init_test.go
@@ -30,7 +30,7 @@ func TestGenesisKey(t *testing.T) {
           "whole": 123456789
         }
       ],
-      "arbiter": "cond:foo/bar/636f6e646974696f6e64617461",
+      "arbiter": "foo/bar/636f6e646974696f6e64617461",
       "recipient": "C30A2424104F542576EF01FECA2FF558F5EAA61A",
       "sender": "0000000000000000000000000000000000000000",
       "timeout": 9223372036854775807


### PR DESCRIPTION
This adds an escrow initializer and tests to create an escrow contract via genesis. The sender address must be set to the burn address to destroy the coins when not used by the escrow.

See: #310