### PR TITLE
Refactor errors Is function

### DIFF
--- a/coin/coin_test.go
+++ b/coin/coin_test.go
@@ -158,7 +158,7 @@ func TestAddCoin(t *testing.T) {
 	cases := map[string]struct {
 		a, b    Coin
 		wantRes Coin
-		wantErr error
+		wantErr *errors.Error
 	}{
 		"plus and minus equals 0": {
 			a:       base,
@@ -207,11 +207,11 @@ func TestAddCoin(t *testing.T) {
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
 			res, err := tc.a.Add(tc.b)
-			if !errors.Is(tc.wantErr, err) {
+			if !tc.wantErr.Is(err) {
 				t.Fatalf("got error: %v", err)
 			}
-			if tc.wantErr == nil {
-				assert.Equal(t, tc.wantRes, res)
+			if tc.wantErr == nil && !tc.wantRes.Equals(res) {
+				t.Fatalf("unexepcted result: %v", res)
 			}
 		})
 	}
@@ -288,7 +288,7 @@ func TestCoinDivide(t *testing.T) {
 		pieces   int64
 		wantOne  Coin
 		wantRest Coin
-		wantErr  error
+		wantErr  *errors.Error
 	}{
 		"split into one piece": {
 			total:    NewCoin(7, 11, "BTC"),
@@ -351,7 +351,7 @@ func TestCoinDivide(t *testing.T) {
 			if !gotRest.Equals(tc.wantRest) {
 				t.Errorf("got rest %v", gotRest)
 			}
-			if !errors.Is(tc.wantErr, err) {
+			if !tc.wantErr.Is(err) {
 				t.Errorf("got err %+v", err)
 			}
 		})
@@ -363,7 +363,7 @@ func TestCoinMultiply(t *testing.T) {
 		coin    Coin
 		times   int64
 		want    Coin
-		wantErr error
+		wantErr *errors.Error
 	}{
 		"zero value coin": {
 			coin:  NewCoin(0, 0, "DOGE"),
@@ -429,14 +429,12 @@ func TestCoinMultiply(t *testing.T) {
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
 			got, err := tc.coin.Multiply(tc.times)
-			if !errors.Is(tc.wantErr, err) {
+			if !tc.wantErr.Is(err) {
 				t.Logf("got coin: %+v", got)
 				t.Fatalf("got error %v", err)
 			}
-			if tc.wantErr == nil {
-				if !got.Equals(tc.want) {
-					t.Fatalf("got %v", got)
-				}
+			if !got.Equals(tc.want) {
+				t.Fatalf("got %v", got)
 			}
 		})
 	}

--- a/coin/coins_test.go
+++ b/coin/coins_test.go
@@ -196,7 +196,7 @@ func TestCoinsNormalize(t *testing.T) {
 	cases := map[string]struct {
 		coins     Coins
 		wantCoins Coins
-		wantErr   error
+		wantErr   *errors.Error
 	}{
 		"nil coins": {
 			coins:     nil,
@@ -277,7 +277,7 @@ func TestCoinsNormalize(t *testing.T) {
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
 			got, err := NormalizeCoins(tc.coins)
-			if !errors.Is(tc.wantErr, err) {
+			if !tc.wantErr.Is(err) {
 				t.Fatalf("want %+v error, got %+v", tc.wantErr, err)
 			}
 			if tc.wantErr == nil {

--- a/conditions_test.go
+++ b/conditions_test.go
@@ -3,14 +3,14 @@ package weave_test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
 
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddressPrinting(t *testing.T) {
@@ -31,7 +31,7 @@ func TestAddressPrinting(t *testing.T) {
 func TestAddressUnmarshalJSON(t *testing.T) {
 	cases := map[string]struct {
 		json     string
-		wantErr  error
+		wantErr  *errors.Error
 		wantAddr weave.Address
 	}{
 		"default decoding": {
@@ -76,7 +76,7 @@ func TestAddressUnmarshalJSON(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			var a weave.Address
 			err := json.Unmarshal([]byte(tc.json), &a)
-			if !errors.Is(tc.wantErr, err) {
+			if !tc.wantErr.Is(err) {
 				t.Fatalf("got error: %+v", err)
 			}
 			if err == nil && !reflect.DeepEqual(a, tc.wantAddr) {
@@ -89,7 +89,7 @@ func TestAddressUnmarshalJSON(t *testing.T) {
 func TestConditionUnmarshalJSON(t *testing.T) {
 	cases := map[string]struct {
 		json          string
-		wantErr       error
+		wantErr       *errors.Error
 		wantCondition weave.Condition
 	}{
 		"default decoding": {
@@ -114,7 +114,7 @@ func TestConditionUnmarshalJSON(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			var got weave.Condition
 			err := json.Unmarshal([]byte(tc.json), &got)
-			if !errors.Is(tc.wantErr, err) {
+			if !tc.wantErr.Is(err) {
 				t.Fatalf("got error: %+v", err)
 			}
 			if err == nil && !got.Equals(tc.wantCondition) {

--- a/errors/doc.go
+++ b/errors/doc.go
@@ -1,32 +1,30 @@
-/**
+/*
 Package errors implements custom error interfaces for weave.
 
- The idea is to reuse as many errors from this package as possible and define custom package
- errors when absolutely necessary. It is best to define a new error here if you feel it's going to
- be somewhat package-agnostic.
+The idea is to reuse as many errors from this package as possible and define custom package
+errors when absolutely necessary. It is best to define a new error here if you feel it's going to
+be somewhat package-agnostic.
 
- x/multisig is a good package to take a look at in terms of usage with predefined strings with/without formatting.
- x/validators and x/sigs define some custom errors.
+x/multisig is a good package to take a look at in terms of usage with predefined strings with/without formatting.
+x/validators and x/sigs define some custom errors.
 
- If you want to register a custom error - use Register(code, description).
- For reusing errors - use Errxxx.New and Errxxx.Newf.
- Code stands for ABCI error code, which allows to distinguish types of errors
- on the client side and act accordingly.
+If you want to register a custom error - use Register(code, description).
+For reusing errors - use Errxxx.New and Errxxx.Newf.
+Code stands for ABCI error code, which allows to distinguish types of errors
+on the client side and act accordingly.
 
- Also, error package defines a convenient Is helper to compare errors, also each Error defines an Is
- helper to compare errors directly to that type.
+There is also support for stacktraces. Please ensure you create the custom error using
+ErrXyz.New("...") or errors.Wrap(err, "...") at the point of creation to ensure we attach
+a stacktrace. If you wrap multiple times, we only record the first wrap with the stacktrace.
+(And don't do this as a global `var ErrFoo = errors.ErrInternal.New("foo")` or you will get a
+useless stacktrace).
 
- There is also support for stacktraces. Please ensure you create the custom error using
- ErrXyz.New("...") or errors.Wrap(err, "...") at the point of creation to ensure we attach
- a stacktrace. If you wrap multiple times, we only record the first wrap with the stacktrace.
- (And don't do this as a global `var ErrFoo = errors.ErrInternal.New("foo")` or you will get a
- useless stacktrace).
-
- Once you have an error, you can use `fmt.Printf/Sprintf` to get more context for the error
-   %s is just the error message
-   %+v is the full stack trace
-   %v appends a compressed [filename:line] where the error was created
-(source is wrappedError.Format)
+Once you have an error, you can use `fmt.Printf/Sprintf` to get more context for the error
+	%s is just the error message
+	%+v is the full stack trace
+	%v appends a compressed [filename:line] where the error was created
+	(source is wrappedError.Format)
 Or call `err.StackTrace()` to get the raw call stack of the creation point
 */
+
 package errors

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -126,13 +126,13 @@ type Error struct {
 }
 
 // Error returns the stored description
-func (e *Error) Error() string { return e.desc }
+func (e Error) Error() string { return e.desc }
 
 // ABCILog returns the stored description, same as Error()
-func (e *Error) ABCILog() string { return e.desc }
+func (e Error) ABCILog() string { return e.desc }
 
 // ABCICode returns the associated ABCICode
-func (e *Error) ABCICode() uint32 { return e.code }
+func (e Error) ABCICode() uint32 { return e.code }
 
 // New returns a new error. Returned instance is having the root cause set to
 // this error. Below two lines are equal

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -175,15 +175,6 @@ func (kind *Error) Is(err error) bool {
 		if c, ok := err.(causer); ok {
 			err = c.Cause()
 		} else {
-
-			// As a last check, figure out if what we compare is an
-			// internal error with a non weave error.
-			if kind == ErrInternal {
-				if _, ok := err.(*Error); !ok {
-					return true
-				}
-			}
-
 			return false
 		}
 	}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -180,6 +180,26 @@ func TestErrorIs(t *testing.T) {
 			b:      errors.Wrap(fmt.Errorf("stdlib error"), "w-rap"),
 			wantIs: true,
 		},
+		"nil is nil": {
+			a:      nil,
+			b:      nil,
+			wantIs: true,
+		},
+		"nil is any error nil": {
+			a:      nil,
+			b:      (*customError)(nil),
+			wantIs: true,
+		},
+		"nil is not not-nil": {
+			a:      nil,
+			b:      ErrNotFound,
+			wantIs: false,
+		},
+		"not-nil is not nil": {
+			a:      ErrNotFound,
+			b:      nil,
+			wantIs: false,
+		},
 	}
 
 	for testName, tc := range cases {
@@ -189,6 +209,13 @@ func TestErrorIs(t *testing.T) {
 			}
 		})
 	}
+}
+
+type customError struct {
+}
+
+func (customError) Error() string {
+	return "custom error"
 }
 
 func TestWrapEmpty(t *testing.T) {
@@ -272,34 +299,5 @@ func TestStackTrace(t *testing.T) {
 			// contains a link to where it was created, which must be here, not the Wrap() function
 			assert.True(t, strings.Contains(medium, "[iov-one/weave/errors/errors_test.go"))
 		})
-	}
-}
-
-// CheckErr is the type of all the check functions here
-type CheckErr func(error) bool
-
-// NoErr is useful for test cases when you want to fulfil the CheckErr type
-func NoErr(err error) bool {
-	return err == nil
-}
-
-// TestChecks make sure the Is and Err methods match
-func TestChecks(t *testing.T) {
-	cases := []struct {
-		err   error
-		check CheckErr
-		match bool
-	}{
-
-		// make sure lots of things match ErrInternal, but not everything
-		{Wrap(fmt.Errorf("internal"), "wrapped"),
-			func(err error) bool { return !Is(err, ErrInternal.New("wrapped")) }, true},
-		{nil, NoErr, true},
-		{Wrap(nil, "asd"), NoErr, true},
-	}
-
-	for i, tc := range cases {
-		match := tc.check(tc.err)
-		assert.Equal(t, tc.match, match, "%d", i)
 	}
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -170,15 +170,15 @@ func TestErrorIs(t *testing.T) {
 			b:      errors.Wrap(fmt.Errorf("stdlib error"), "wrapped"),
 			wantIs: false,
 		},
-		"internal error is equal to a stdlib error": {
+		"internal error is not equal to a stdlib error": {
 			a:      ErrInternal,
 			b:      fmt.Errorf("stdlib error"),
-			wantIs: true,
+			wantIs: false,
 		},
-		"internal error is equal to a wrapped stdlib error": {
+		"internal error is not equal to a wrapped stdlib error": {
 			a:      ErrInternal,
 			b:      errors.Wrap(fmt.Errorf("stdlib error"), "w-rap"),
-			wantIs: true,
+			wantIs: false,
 		},
 		"nil is nil": {
 			a:      nil,

--- a/weavetest/decorators_test.go
+++ b/weavetest/decorators_test.go
@@ -31,12 +31,12 @@ func TestDecoratorWithError(t *testing.T) {
 	var handler weave.Handler = nil
 
 	_, err := d.Check(nil, nil, nil, handler)
-	if want := errors.ErrUnauthorized; !errors.Is(want, err) {
+	if want := errors.ErrUnauthorized; !want.Is(err) {
 		t.Errorf("want %q, got %q", want, err)
 	}
 
 	_, err = d.Deliver(nil, nil, nil, handler)
-	if want := errors.ErrNotFound; !errors.Is(want, err) {
+	if want := errors.ErrNotFound; !want.Is(err) {
 		t.Errorf("want %q, got %q", want, err)
 	}
 }

--- a/weavetest/handlers_test.go
+++ b/weavetest/handlers_test.go
@@ -15,12 +15,12 @@ func TestHandlerWithError(t *testing.T) {
 	}
 
 	_, err := h.Check(nil, nil, nil)
-	if want := errors.ErrUnauthorized; !errors.Is(want, err) {
+	if want := errors.ErrUnauthorized; !want.Is(err) {
 		t.Errorf("want %q, got %q", want, err)
 	}
 
 	_, err = h.Deliver(nil, nil, nil)
-	if want := errors.ErrNotFound; !errors.Is(want, err) {
+	if want := errors.ErrNotFound; !want.Is(err) {
 		t.Errorf("want %q, got %q", want, err)
 	}
 }

--- a/x/cash/controller_test.go
+++ b/x/cash/controller_test.go
@@ -271,7 +271,7 @@ func TestBalance(t *testing.T) {
 	cases := map[string]struct {
 		addr      weave.Address
 		wantCoins coin.Coins
-		wantErr   error
+		wantErr   *errors.Error
 	}{
 		"non exising account": {
 			addr:    weavetest.NewCondition().Address(),
@@ -292,7 +292,7 @@ func TestBalance(t *testing.T) {
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
 			coins, err := ctrl.Balance(store, tc.addr)
-			if !errors.Is(tc.wantErr, err) {
+			if !tc.wantErr.Is(err) {
 				t.Fatalf("want %q error, got %q", tc.wantErr, err)
 			}
 			if !tc.wantCoins.Equals(coins) {

--- a/x/cash/dynamicfee_test.go
+++ b/x/cash/dynamicfee_test.go
@@ -38,9 +38,9 @@ func TestDynamicFeeDecorator(t *testing.T) {
 		// Wallet state applied after running Check but before running Deliver
 		updateWallets []orm.Object
 
-		wantCheckErr     error
+		wantCheckErr     *errors.Error
 		wantCheckTxFee   coin.Coin
-		wantDeliverErr   error
+		wantDeliverErr   *errors.Error
 		wantDeliverTxFee coin.Coin
 		wantGasPayment   int64
 	}{
@@ -189,7 +189,7 @@ func TestDynamicFeeDecorator(t *testing.T) {
 			cache := db.CacheWrap()
 
 			cRes, err := h.Check(nil, cache, tx, tc.handler)
-			if !errors.Is(tc.wantCheckErr, err) {
+			if !tc.wantCheckErr.Is(err) {
 				t.Fatalf("got check error: %v", err)
 			}
 			if tc.wantGasPayment != cRes.GasPayment {
@@ -207,7 +207,7 @@ func TestDynamicFeeDecorator(t *testing.T) {
 
 			cache.Discard()
 
-			if _, err = h.Deliver(nil, cache, tx, tc.handler); !errors.Is(tc.wantDeliverErr, err) {
+			if _, err = h.Deliver(nil, cache, tx, tc.handler); !tc.wantDeliverErr.Is(err) {
 				t.Fatalf("got deliver error: %v", err)
 			}
 
@@ -243,7 +243,7 @@ func assertCharged(t *testing.T, db weave.KVStore, ctrl Controller, want coin.Co
 		if !wantTx.Equals(chargedFee) {
 			t.Errorf("charged fee: %v", chargedFee)
 		}
-	case errors.Is(errors.ErrNotFound, err):
+	case errors.ErrNotFound.Is(err):
 		if minimumFee.IsZero() {
 			// Minimal fee is zero so the collector account is zero
 			// as well (not even created). All good.

--- a/x/currency/handler_test.go
+++ b/x/currency/handler_test.go
@@ -20,8 +20,8 @@ func TestNewTokenInfoHandler(t *testing.T) {
 		issuer          weave.Address
 		initState       []orm.Object
 		msg             weave.Msg
-		wantCheckErr    errors.Error
-		wantDeliverErr  errors.Error
+		wantCheckErr    *errors.Error
+		wantDeliverErr  *errors.Error
 		query           string
 		wantQueryResult orm.Object
 	}{

--- a/x/distribution/handler.go
+++ b/x/distribution/handler.go
@@ -250,7 +250,7 @@ func distribute(db weave.KVStore, ctrl CashController, source weave.Address, rec
 		if err != nil {
 			return errors.Wrap(err, "cannot normalize balance")
 		}
-	case errors.Is(errors.ErrNotFound, err):
+	case errors.ErrNotFound.Is(err):
 		// Account does not exist, so there is are no funds to split.
 		return nil
 	default:

--- a/x/distribution/model.go
+++ b/x/distribution/model.go
@@ -26,7 +26,7 @@ func (rev *Revenue) Validate() error {
 // having it abstracted saves repeating validation code.
 // Model validation returns different class of error than message validation,
 // that is why require base error class to be given.
-func validateRecipients(rs []*Recipient, baseErr errors.Error) error {
+func validateRecipients(rs []*Recipient, baseErr *errors.Error) error {
 	switch n := len(rs); {
 	case n == 0:
 		return baseErr.New("no recipients")

--- a/x/distribution/model_test.go
+++ b/x/distribution/model_test.go
@@ -14,7 +14,7 @@ func TestRevenueValidate(t *testing.T) {
 
 	cases := map[string]struct {
 		model   Revenue
-		wantErr error
+		wantErr *errors.Error
 	}{
 		"valid model": {
 			model: Revenue{
@@ -63,7 +63,7 @@ func TestRevenueValidate(t *testing.T) {
 
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
-			if err := tc.model.Validate(); !errors.Is(tc.wantErr, err) {
+			if err := tc.model.Validate(); !tc.wantErr.Is(err) {
 				t.Logf("want %q", tc.wantErr)
 				t.Logf("got %q", err)
 				t.Fatal("unexpected validation result")
@@ -76,7 +76,7 @@ func TestValidRecipients(t *testing.T) {
 	cases := map[string]struct {
 		recipients []*Recipient
 		baseErr    *errors.Error
-		want       error
+		want       *errors.Error
 	}{
 		"all good": {
 			recipients: []*Recipient{
@@ -110,7 +110,7 @@ func TestValidRecipients(t *testing.T) {
 
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
-			if err := validateRecipients(tc.recipients, tc.baseErr); !errors.Is(tc.want, err) {
+			if err := validateRecipients(tc.recipients, tc.baseErr); !tc.want.Is(err) {
 				t.Fatalf("%+v", err)
 			}
 		})

--- a/x/distribution/model_test.go
+++ b/x/distribution/model_test.go
@@ -75,7 +75,7 @@ func TestRevenueValidate(t *testing.T) {
 func TestValidRecipients(t *testing.T) {
 	cases := map[string]struct {
 		recipients []*Recipient
-		baseErr    errors.Error
+		baseErr    *errors.Error
 		want       error
 	}{
 		"all good": {

--- a/x/msgfee/decorator_test.go
+++ b/x/msgfee/decorator_test.go
@@ -15,9 +15,9 @@ func TestFeeDecorator(t *testing.T) {
 		InitFees       []MsgFee
 		Tx             weave.Tx
 		Handler        weave.Handler
-		WantCheckErr   error
+		WantCheckErr   *errors.Error
 		WantCheckFee   coin.Coin
-		WantDeliverErr error
+		WantDeliverErr *errors.Error
 		WantDeliverFee coin.Coin
 	}{
 		"message fee with no previous fee": {
@@ -100,7 +100,7 @@ func TestFeeDecorator(t *testing.T) {
 			}
 
 			cres, err := decorator.Check(nil, db, tc.Tx, tc.Handler)
-			if !errors.Is(tc.WantCheckErr, err) {
+			if !tc.WantCheckErr.Is(err) {
 				t.Fatalf("check returned an unexpected error: %v", err)
 			}
 			if !tc.WantCheckFee.Equals(cres.RequiredFee) {
@@ -108,7 +108,7 @@ func TestFeeDecorator(t *testing.T) {
 			}
 
 			dres, err := decorator.Deliver(nil, db, tc.Tx, tc.Handler)
-			if !errors.Is(tc.WantDeliverErr, err) {
+			if !tc.WantDeliverErr.Is(err) {
 				t.Fatalf("deliver returned an unexpected error: %v", err)
 			}
 			if !tc.WantDeliverFee.Equals(dres.RequiredFee) {

--- a/x/msgfee/model_test.go
+++ b/x/msgfee/model_test.go
@@ -11,7 +11,7 @@ import (
 func TestMsgFeeValidate(t *testing.T) {
 	cases := map[string]struct {
 		mf      MsgFee
-		wantErr error
+		wantErr *errors.Error
 	}{
 		"all good": {
 			mf: MsgFee{
@@ -46,7 +46,7 @@ func TestMsgFeeValidate(t *testing.T) {
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
 			err := tc.mf.Validate()
-			if !errors.Is(tc.wantErr, err) {
+			if !tc.wantErr.Is(err) {
 				t.Fatalf("got %v", err)
 			}
 		})

--- a/x/multisig/handlers_test.go
+++ b/x/multisig/handlers_test.go
@@ -167,7 +167,7 @@ func TestUpdateContractMsgHandler(t *testing.T) {
 		name    string
 		msg     *UpdateContractMsg
 		signers []weave.Condition
-		err     error
+		err     *errors.Error
 	}{
 		{
 			name: "authorized",
@@ -189,7 +189,7 @@ func TestUpdateContractMsgHandler(t *testing.T) {
 				AdminThreshold:      5,
 			},
 			signers: []weave.Condition{a},
-			err:     errors.ErrUnauthorized.Newf("contract=%X", mutableID),
+			err:     errors.ErrUnauthorized,
 		},
 		{
 			name: "immutable",
@@ -200,7 +200,7 @@ func TestUpdateContractMsgHandler(t *testing.T) {
 				AdminThreshold:      5,
 			},
 			signers: []weave.Condition{a, b, c, d, e},
-			err:     errors.ErrUnauthorized.Newf("contract=%X", immutableID),
+			err:     errors.ErrUnauthorized,
 		},
 		{
 			name: "bad change threshold",
@@ -211,7 +211,7 @@ func TestUpdateContractMsgHandler(t *testing.T) {
 				AdminThreshold:      0,
 			},
 			signers: []weave.Condition{a, b, c, d, e},
-			err:     errors.ErrInvalidMsg.New(invalidThreshold),
+			err:     errors.ErrInvalidMsg,
 		},
 	}
 
@@ -224,7 +224,7 @@ func TestUpdateContractMsgHandler(t *testing.T) {
 		if test.err == nil {
 			require.NoError(t, err, test.name)
 		} else {
-			require.True(t, errors.Is(err, test.err), test.name)
+			require.True(t, test.err.Is(err), test.name)
 		}
 
 		_, err = handler.Deliver(ctx, db, &weavetest.Tx{Msg: msg})
@@ -236,7 +236,7 @@ func TestUpdateContractMsgHandler(t *testing.T) {
 				contract,
 				test.name)
 		} else {
-			require.EqualError(t, err, test.err.Error(), test.name)
+			require.True(t, test.err.Is(err), test.name)
 		}
 	}
 }

--- a/x/paychan/handler_test.go
+++ b/x/paychan/handler_test.go
@@ -279,7 +279,7 @@ func TestPaymentChannelHandlers(t *testing.T) {
 						Memo:         "start",
 					},
 					blocksize:      100,
-					wantDeliverErr: errors.ErrInsufficientAmount.New("funds"),
+					wantDeliverErr: errors.ErrInsufficientAmount,
 				},
 			},
 		},
@@ -482,7 +482,7 @@ func TestPaymentChannelHandlers(t *testing.T) {
 
 			for i, a := range tc.actions {
 				cache := db.CacheWrap()
-				if _, err := rt.Check(a.ctx(), cache, a.tx()); !errors.Is(err, a.wantCheckErr) {
+				if _, err := rt.Check(a.ctx(), cache, a.tx()); !a.wantCheckErr.Is(err) {
 					t.Logf("want: %+v", a.wantCheckErr)
 					t.Logf(" got: %+v", err)
 					t.Fatalf("action %d check (%T)", i, a.msg)
@@ -493,7 +493,7 @@ func TestPaymentChannelHandlers(t *testing.T) {
 					continue
 				}
 
-				if _, err := rt.Deliver(a.ctx(), db, a.tx()); !errors.Is(err, a.wantDeliverErr) {
+				if _, err := rt.Deliver(a.ctx(), db, a.tx()); !a.wantDeliverErr.Is(err) {
 					t.Logf("want: %+v", a.wantDeliverErr)
 					t.Logf(" got: %+v", err)
 					t.Fatalf("action %d delivery (%T)", i, a.msg)
@@ -516,8 +516,8 @@ type action struct {
 	conditions     []weave.Condition
 	msg            weave.Msg
 	blocksize      int64
-	wantCheckErr   error
-	wantDeliverErr error
+	wantCheckErr   *errors.Error
+	wantDeliverErr *errors.Error
 }
 
 func (a *action) tx() weave.Tx {

--- a/x/validators/controller_test.go
+++ b/x/validators/controller_test.go
@@ -51,17 +51,17 @@ func TestController(t *testing.T) {
 				bucket.Delete(kv, []byte(Key))
 				//bucket.Save(kv, orm.NewSimpleObj([]byte(Key), set))
 				_, err = ctrl.CanUpdateValidators(kv, checkAddress, diff)
-				So(errors.Is(err, errors.ErrNotFound), ShouldBeTrue)
+				So(errors.ErrNotFound.Is(err), ShouldBeTrue)
 			})
 
 			Convey("No permission", func() {
 				_, err = ctrl.CanUpdateValidators(kv, checkAddress2, diff)
-				So(errors.Is(err, errors.ErrUnauthorized), ShouldBeTrue)
+				So(errors.ErrUnauthorized.Is(err), ShouldBeTrue)
 			})
 
 			Convey("Empty diff", func() {
 				_, err := ctrl.CanUpdateValidators(kv, checkAddress, emptyDiff)
-				So(errors.Is(err, ErrEmptyDiff), ShouldBeTrue)
+				So(ErrEmptyDiff.Is(err), ShouldBeTrue)
 			})
 
 			Convey("Accounts type is wrong", func() {
@@ -70,14 +70,14 @@ func TestController(t *testing.T) {
 				bucket.Delete(kv, []byte(Key))
 				kv.Set([]byte(Key), []byte(set.String()))
 				_, err = ctrl.CanUpdateValidators(kv, checkAddress, diff)
-				So(errors.Is(err, errors.ErrNotFound), ShouldBeTrue)
+				So(errors.ErrNotFound.Is(err), ShouldBeTrue)
 			})
 		})
 
 		Convey("When init didn't happen", func() {
 			Convey("Error on GetAccounts", func() {
 				_, err = ctrl.CanUpdateValidators(kv, checkAddress, diff)
-				So(errors.Is(err, errors.ErrNotFound), ShouldBeTrue)
+				So(errors.ErrNotFound.Is(err), ShouldBeTrue)
 			})
 		})
 	})

--- a/x/validators/handler_test.go
+++ b/x/validators/handler_test.go
@@ -55,10 +55,10 @@ func TestHandler(t *testing.T) {
 				handler := NewUpdateHandler(auth2, ctrl, authCheckAddress)
 
 				_, err := handler.Deliver(nil, kv, tx)
-				So(errors.Is(err, errors.ErrUnauthorized), ShouldBeTrue)
+				So(errors.ErrUnauthorized.Is(err), ShouldBeTrue)
 
 				_, err = handler.Check(nil, kv, tx)
-				So(errors.Is(err, errors.ErrUnauthorized), ShouldBeTrue)
+				So(errors.ErrUnauthorized.Is(err), ShouldBeTrue)
 			})
 
 			Convey("With an invalid message", func() {


### PR DESCRIPTION
Change the implementation of `errors.Error.Is` and remove `errors.Is` function. Instead of using `ABCICode` to compare errors, use instance comparison and unwrapping. 
All cases are covered by the tests.

Existing code was updated as required.



This change does not implement `Is` method for the `Wrap` function result. Below is not possible.

> Our error instances are global and therefore comparable as instances. Using the above mechanism would also allow to "inherit" errors. Below can be true.