### PR TITLE
remove Error.New and Errors.Newf

### DIFF
--- a/app/commit.go
+++ b/app/commit.go
@@ -79,11 +79,11 @@ func loadChainID(kv weave.KVStore) string {
 // Returns error if already set, or invalid name
 func saveChainID(kv weave.KVStore, chainID string) error {
 	if !weave.IsValidChainID(chainID) {
-		return errors.ErrInvalidInput.Newf("chain id: %v", chainID)
+		return errors.Wrapf(errors.ErrInvalidInput, "chain id: %v", chainID)
 	}
 	k := []byte(chainIDKey)
 	if kv.Has(k) {
-		return errors.ErrUnauthorized.New("can't modify chain id after genesis init")
+		return errors.Wrap(errors.ErrUnauthorized, "can't modify chain id after genesis init")
 	}
 	kv.Set(k, []byte(chainID))
 	return nil

--- a/app/router.go
+++ b/app/router.go
@@ -66,7 +66,7 @@ func (r Router) Check(ctx weave.Context, store weave.KVStore,
 
 	msg, _ := tx.GetMsg()
 	if msg == nil {
-		return weave.CheckResult{}, errors.ErrInvalidInput.New("unable to decode")
+		return weave.CheckResult{}, errors.Wrap(errors.ErrInvalidInput, "unable to decode")
 	}
 	path := msg.Path()
 	h := r.Handler(path)
@@ -79,7 +79,7 @@ func (r Router) Deliver(ctx weave.Context, store weave.KVStore,
 
 	msg, _ := tx.GetMsg()
 	if msg == nil {
-		return weave.DeliverResult{}, errors.ErrInvalidInput.New("unable to decode")
+		return weave.DeliverResult{}, errors.Wrap(errors.ErrInvalidInput, "unable to decode")
 	}
 	path := msg.Path()
 	h := r.Handler(path)
@@ -98,12 +98,12 @@ var _ weave.Handler = noSuchPathHandler{}
 func (h noSuchPathHandler) Check(ctx weave.Context, store weave.KVStore,
 	tx weave.Tx) (weave.CheckResult, error) {
 
-	return weave.CheckResult{}, errors.ErrNotFound.Newf("path: %s", h.path)
+	return weave.CheckResult{}, errors.Wrapf(errors.ErrNotFound, "path: %s", h.path)
 }
 
 // Deliver always returns ErrNoSuchPath
 func (h noSuchPathHandler) Deliver(ctx weave.Context, store weave.KVStore,
 	tx weave.Tx) (weave.DeliverResult, error) {
 
-	return weave.DeliverResult{}, errors.ErrNotFound.Newf("path: %s", h.path)
+	return weave.DeliverResult{}, errors.Wrapf(errors.ErrNotFound, "path: %s", h.path)
 }

--- a/app/store.go
+++ b/app/store.go
@@ -111,7 +111,7 @@ func (s *StoreApp) parseAppState(data []byte, chainID string, init weave.Initial
 	var appState weave.Options
 	err := json.Unmarshal(data, &appState)
 	if err != nil {
-		return errors.ErrInvalidState.New(err.Error())
+		return errors.Wrap(errors.ErrInvalidState, err.Error())
 	}
 
 	err = s.storeChainID(chainID)

--- a/cmd/bnsd/x/nft/username/bucket.go
+++ b/cmd/bnsd/x/nft/username/bucket.go
@@ -2,9 +2,9 @@ package username
 
 import (
 	"bytes"
-	"github.com/iov-one/weave/errors"
 
 	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/orm"
 	"github.com/iov-one/weave/x/nft"
 )
@@ -39,7 +39,7 @@ func (b Bucket) Create(db weave.KVStore, owner weave.Address, id []byte, approva
 	case err != nil:
 		return nil, err
 	case obj != nil:
-		return nil, errors.ErrDuplicate.New("id exists already")
+		return nil, errors.Wrap(errors.ErrDuplicate, "id exists already")
 	}
 	obj = NewUsernameToken(id, owner, approvals)
 	humanAddress, err := AsUsername(obj)
@@ -52,11 +52,11 @@ func (b Bucket) Create(db weave.KVStore, owner weave.Address, id []byte, approva
 
 func chainAddressIndexer(obj orm.Object) ([][]byte, error) {
 	if obj == nil {
-		return nil, orm.ErrInvalidIndex.New("nil")
+		return nil, errors.Wrap(orm.ErrInvalidIndex, "nil")
 	}
 	u, err := AsUsername(obj)
 	if err != nil {
-		return nil, orm.ErrInvalidIndex.New("unsupported type")
+		return nil, errors.Wrap(orm.ErrInvalidIndex, "unsupported type")
 	}
 	idx := make([][]byte, 0, len(u.GetChainAddresses()))
 	for _, addr := range u.GetChainAddresses() {

--- a/cmd/bnsd/x/nft/username/handler.go
+++ b/cmd/bnsd/x/nft/username/handler.go
@@ -82,11 +82,11 @@ func (h IssueHandler) validate(ctx weave.Context, tx weave.Tx) (*IssueTokenMsg, 
 	// check permissions
 	if h.issuer != nil {
 		if !h.auth.HasAddress(ctx, h.issuer) {
-			return nil, errors.ErrUnauthorized.New("")
+			return nil, errors.Wrap(errors.ErrUnauthorized, "")
 		}
 	} else {
 		if !h.auth.HasAddress(ctx, msg.Owner) {
-			return nil, errors.ErrUnauthorized.New("")
+			return nil, errors.Wrap(errors.ErrUnauthorized, "")
 		}
 	}
 	return msg, nil
@@ -122,7 +122,7 @@ func (h AddChainAddressHandler) Deliver(ctx weave.Context, store weave.KVStore, 
 
 	actor := nft.FindActor(h.auth, ctx, t, nft.UpdateDetails)
 	if actor == nil {
-		return res, errors.ErrUnauthorized.New("")
+		return res, errors.Wrap(errors.ErrUnauthorized, "")
 	}
 	allKeys := append(t.GetChainAddresses(), ChainAddress{BlockchainID: msg.GetBlockchainID(), Address: msg.GetAddress()})
 	if err := t.SetChainAddresses(actor, allKeys); err != nil {
@@ -177,10 +177,10 @@ func (h RemoveChainAddressHandler) Deliver(ctx weave.Context, store weave.KVStor
 
 	actor := nft.FindActor(h.auth, ctx, t, nft.UpdateDetails)
 	if actor == nil {
-		return res, errors.ErrUnauthorized.New("")
+		return res, errors.Wrap(errors.ErrUnauthorized, "")
 	}
 	if len(t.GetChainAddresses()) == 0 {
-		return res, errors.ErrInvalidInput.New("empty chain addresses")
+		return res, errors.Wrap(errors.ErrInvalidInput, "empty chain addresses")
 	}
 	obsoleteAddress := ChainAddress{BlockchainID: msg.GetBlockchainID(), Address: msg.GetAddress()}
 	newAddresses := make([]ChainAddress, 0, len(t.GetChainAddresses()))
@@ -190,7 +190,7 @@ func (h RemoveChainAddressHandler) Deliver(ctx weave.Context, store weave.KVStor
 		}
 	}
 	if len(newAddresses) == len(t.GetChainAddresses()) {
-		return res, errors.ErrNotFound.New("requested address not registered")
+		return res, errors.Wrap(errors.ErrNotFound, "requested address not registered")
 	}
 	if err := t.SetChainAddresses(actor, newAddresses); err != nil {
 		return res, err
@@ -219,7 +219,7 @@ func loadToken(h tokenHandler, store weave.KVStore, id []byte) (orm.Object, Toke
 	case err != nil:
 		return nil, nil, err
 	case o == nil:
-		return nil, nil, errors.ErrNotFound.Newf("username %s", nft.PrintableID(id))
+		return nil, nil, errors.Wrapf(errors.ErrNotFound, "username %s", nft.PrintableID(id))
 	}
 	t, e := AsUsername(o)
 	return o, t, e

--- a/cmd/bnsd/x/nft/username/model.go
+++ b/cmd/bnsd/x/nft/username/model.go
@@ -40,7 +40,7 @@ func (u *UsernameToken) GetChainAddresses() []ChainAddress {
 func (u *UsernameToken) SetChainAddresses(actor weave.Address, newAddresses []ChainAddress) error {
 	dup := containsDuplicateChains(newAddresses)
 	if dup != nil {
-		return errors.ErrDuplicate.Newf("chain %s", nft.PrintableID(dup))
+		return errors.Wrapf(errors.ErrDuplicate, "chain %s", nft.PrintableID(dup))
 	}
 	u.Details = &TokenDetails{Addresses: newAddresses}
 	return nil
@@ -81,11 +81,11 @@ func (t *TokenDetails) Clone() *TokenDetails {
 
 func (t *TokenDetails) Validate() error {
 	if t == nil {
-		return errors.ErrInvalidInput.New("token details must not be nil")
+		return errors.Wrap(errors.ErrInvalidInput, "token details must not be nil")
 	}
 	dup := containsDuplicateChains(t.Addresses)
 	if dup != nil {
-		return errors.ErrDuplicate.Newf("chain %s", nft.PrintableID(dup))
+		return errors.Wrapf(errors.ErrDuplicate, "chain %s", nft.PrintableID(dup))
 	}
 	for _, k := range t.Addresses {
 		if err := k.Validate(); err != nil {
@@ -113,10 +113,10 @@ func (p ChainAddress) Equals(o ChainAddress) bool {
 
 func (p *ChainAddress) Validate() error {
 	if !validBlockchainID(p.BlockchainID) {
-		return errors.ErrInvalidInput.Newf("id: %s", nft.PrintableID(p.BlockchainID))
+		return errors.Wrapf(errors.ErrInvalidInput, "id: %s", nft.PrintableID(p.BlockchainID))
 	}
 	if n := len(p.Address); n < 2 || n > 50 {
-		return errors.ErrInvalidInput.Newf("address length: %s", p.Address)
+		return errors.Wrapf(errors.ErrInvalidInput, "address length: %s", p.Address)
 	}
 	return nil
 }
@@ -128,7 +128,7 @@ func AsUsername(obj orm.Object) (Token, error) {
 	}
 	x, ok := obj.Value().(*UsernameToken)
 	if !ok {
-		return nil, errors.ErrInvalidInput.New(nft.UnsupportedTokenType)
+		return nil, errors.Wrap(errors.ErrInvalidInput, nft.UnsupportedTokenType)
 	}
 	return x, nil
 }

--- a/cmd/bnsd/x/nft/username/msg.go
+++ b/cmd/bnsd/x/nft/username/msg.go
@@ -78,10 +78,10 @@ func (m *RemoveChainAddressMsg) Validate() error {
 
 func validateID(id []byte) error {
 	if id == nil {
-		return errors.ErrInvalidInput.New("must not be nil")
+		return errors.Wrap(errors.ErrInvalidInput, "must not be nil")
 	}
 	if !isValidID(string(id)) {
-		return errors.ErrInvalidInput.Newf("id: %s", nft.PrintableID(id))
+		return errors.Wrapf(errors.ErrInvalidInput, "id: %s", nft.PrintableID(id))
 	}
 	return nil
 }

--- a/conditions.go
+++ b/conditions.go
@@ -39,7 +39,7 @@ func NewCondition(ext, typ string, data []byte) Condition {
 func (c Condition) Parse() (string, string, []byte, error) {
 	chunks := perm.FindSubmatch(c)
 	if len(chunks) == 0 {
-		return "", "", nil, errors.ErrInvalidInput.Newf("condition: %X", []byte(c))
+		return "", "", nil, errors.Wrapf(errors.ErrInvalidInput, "condition: %X", []byte(c))
 
 	}
 	// returns [all, match1, match2, match3]
@@ -70,7 +70,7 @@ func (c Condition) String() string {
 // Validate returns an error if the Condition is not the proper format
 func (c Condition) Validate() error {
 	if !perm.Match(c) {
-		return errors.ErrInvalidInput.Newf("condition: %X", []byte(c))
+		return errors.Wrapf(errors.ErrInvalidInput, "condition: %X", []byte(c))
 	}
 	return nil
 }
@@ -101,11 +101,11 @@ func (c *Condition) deserialize(source string) error {
 
 	args := strings.Split(source, "/")
 	if len(args) != 3 {
-		return errors.ErrInvalidInput.Newf("invalid condition format")
+		return errors.Wrapf(errors.ErrInvalidInput, "invalid condition format")
 	}
 	data, err := hex.DecodeString(args[2])
 	if err != nil {
-		return errors.ErrInvalidInput.Newf("malformed condition data: %s", err)
+		return errors.Wrapf(errors.ErrInvalidInput, "malformed condition data: %s", err)
 	}
 	*c = NewCondition(args[0], args[1], data)
 	return nil
@@ -167,7 +167,7 @@ func (a *Address) UnmarshalJSON(raw []byte) error {
 		*a = c.Address()
 		return nil
 	default:
-		return errors.ErrInvalidType.Newf("unknown format %q", chunks[0])
+		return errors.Wrapf(errors.ErrInvalidType, "unknown format %q", chunks[0])
 	}
 }
 
@@ -183,7 +183,7 @@ func (a Address) String() string {
 // Validate returns an error if the address is not the valid size
 func (a Address) Validate() error {
 	if len(a) != AddressLength {
-		return errors.ErrInvalidInput.Newf("address: %v", a)
+		return errors.Wrapf(errors.ErrInvalidInput, "address: %v", a)
 	}
 	return nil
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -119,20 +119,6 @@ func (e Error) ABCICode() uint32 {
 	return e.code
 }
 
-// New returns a new error. Returned instance is having the root cause set to
-// this error. Below two lines are equal
-//   e.New("my description")
-//   Wrap(e, "my description")
-// Allows sprintf format and vararg
-func (e *Error) New(description string) error {
-	return Wrap(e, description)
-}
-
-// Newf is basically New with formatting capabilities
-func (e *Error) Newf(description string, args ...interface{}) error {
-	return e.New(fmt.Sprintf(description, args...))
-}
-
 // Is check if given error instance is of a given kind/type. This involves
 // unwrapping given error using the Cause method if available.
 func (kind *Error) Is(err error) bool {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -19,7 +19,7 @@ func TestCause(t *testing.T) {
 			root: ErrNotFound,
 		},
 		"Wrap reveals root cause": {
-			err:  ErrNotFound.New("foo"),
+			err:  Wrap(ErrNotFound, "foo"),
 			root: ErrNotFound,
 		},
 		"Cause works for stderr as root": {

--- a/examples/errors/demo.go
+++ b/examples/errors/demo.go
@@ -12,11 +12,11 @@ import (
 )
 
 func makeError() error {
-	return errors.ErrNotFound.New("foo")
+	return errors.Wrap(errors.ErrNotFound, "foo")
 }
 
 func otherError() error {
-	return errors.ErrInvalidInput.New("unable to decode")
+	return errors.Wrap(errors.ErrInvalidInput, "unable to decode")
 }
 
 type foo struct {

--- a/examples/mycoind/app/tx.go
+++ b/examples/mycoind/app/tx.go
@@ -26,7 +26,7 @@ var _ sigs.SignedTx = (*Tx)(nil)
 func (tx *Tx) GetMsg() (weave.Msg, error) {
 	sum := tx.GetSum()
 	if sum == nil {
-		return nil, errors.ErrInvalidInput.New("unable to decode")
+		return nil, errors.Wrap(errors.ErrInvalidInput, "unable to decode")
 	}
 
 	// make sure to cover all messages defined in protobuf

--- a/examples/tutorial/x/blog/handlers.go
+++ b/examples/tutorial/x/blog/handlers.go
@@ -90,7 +90,7 @@ func (h CreateBlogMsgHandler) validate(ctx weave.Context, db weave.KVStore, tx w
 	// Retrieve tx main signer in this context
 	sender := x.MainSigner(ctx, h.auth)
 	if sender == nil {
-		return nil, errors.ErrUnauthorized.Newf(unauthorisedBlogAuthorFmt, nil)
+		return nil, errors.Wrapf(errors.ErrUnauthorized, unauthorisedBlogAuthorFmt, nil)
 	}
 
 	msg, err := tx.GetMsg()
@@ -111,7 +111,7 @@ func (h CreateBlogMsgHandler) validate(ctx weave.Context, db weave.KVStore, tx w
 	// Check the blog does not already exist
 	obj, err := h.bucket.Get(db, []byte(createBlogMsg.Slug))
 	if err != nil || (obj != nil && obj.Value() != nil) {
-		return nil, errors.ErrDuplicate.New("blog")
+		return nil, errors.Wrap(errors.ErrDuplicate, "blog")
 	}
 
 	return createBlogMsg, nil
@@ -184,7 +184,7 @@ func (h CreatePostMsgHandler) validate(ctx weave.Context, db weave.KVStore, tx w
 
 	// Check the author is one of the Tx signer
 	if !h.auth.HasAddress(ctx, createPostMsg.Author) {
-		return nil, nil, errors.ErrUnauthorized.Newf(unauthorisedPostAuthorFmt, weave.Address(createPostMsg.Author))
+		return nil, nil, errors.Wrapf(errors.ErrUnauthorized, unauthorisedPostAuthorFmt, weave.Address(createPostMsg.Author))
 	}
 
 	err = createPostMsg.Validate()
@@ -198,7 +198,7 @@ func (h CreatePostMsgHandler) validate(ctx weave.Context, db weave.KVStore, tx w
 		return nil, nil, err
 	}
 	if obj == nil || (obj != nil && obj.Value() == nil) {
-		return nil, nil, errors.ErrNotFound.New("blog")
+		return nil, nil, errors.Wrap(errors.ErrNotFound, "blog")
 	}
 
 	blog := obj.Value().(*Blog)
@@ -252,7 +252,7 @@ func (h RenameBlogMsgHandler) validate(ctx weave.Context, db weave.KVStore, tx w
 	// Retrieve tx main signer in this context
 	sender := x.MainSigner(ctx, h.auth)
 	if sender == nil {
-		return nil, nil, errors.ErrUnauthorized.Newf(unauthorisedBlogAuthorFmt, nil)
+		return nil, nil, errors.Wrapf(errors.ErrUnauthorized, unauthorisedBlogAuthorFmt, nil)
 	}
 
 	msg, err := tx.GetMsg()
@@ -277,13 +277,13 @@ func (h RenameBlogMsgHandler) validate(ctx weave.Context, db weave.KVStore, tx w
 		return nil, nil, err
 	}
 	if obj == nil || (obj != nil && obj.Value() == nil) {
-		return nil, nil, errors.ErrNotFound.New("blog")
+		return nil, nil, errors.Wrap(errors.ErrNotFound, "blog")
 	}
 
 	blog := obj.Value().(*Blog)
 	// Check main signer is one of the blog authors
 	if findAuthor(blog.Authors, sender.Address()) == -1 {
-		return nil, nil, errors.ErrUnauthorized.Newf(unauthorisedBlogAuthorFmt, sender.Address())
+		return nil, nil, errors.Wrapf(errors.ErrUnauthorized, unauthorisedBlogAuthorFmt, sender.Address())
 	}
 
 	return renameBlogMsg, blog, nil
@@ -345,7 +345,7 @@ func (h ChangeBlogAuthorsMsgHandler) validate(ctx weave.Context, db weave.KVStor
 	// Retrieve tx main signer in this context
 	sender := x.MainSigner(ctx, h.auth)
 	if sender == nil {
-		return nil, nil, errors.ErrUnauthorized.Newf(unauthorisedBlogAuthorFmt, nil)
+		return nil, nil, errors.Wrapf(errors.ErrUnauthorized, unauthorisedBlogAuthorFmt, nil)
 	}
 
 	msg, err := tx.GetMsg()
@@ -369,13 +369,13 @@ func (h ChangeBlogAuthorsMsgHandler) validate(ctx weave.Context, db weave.KVStor
 		return nil, nil, err
 	}
 	if obj == nil || (obj != nil && obj.Value() == nil) {
-		return nil, nil, errors.ErrNotFound.New("blog")
+		return nil, nil, errors.Wrap(errors.ErrNotFound, "blog")
 	}
 
 	blog := obj.Value().(*Blog)
 	// Check main signer is one of the blog authors
 	if findAuthor(blog.Authors, sender.Address()) == -1 {
-		return nil, nil, errors.ErrUnauthorized.Newf(unauthorisedBlogAuthorFmt, sender.Address())
+		return nil, nil, errors.Wrapf(errors.ErrUnauthorized, unauthorisedBlogAuthorFmt, sender.Address())
 	}
 
 	// Get the author index
@@ -383,7 +383,7 @@ func (h ChangeBlogAuthorsMsgHandler) validate(ctx weave.Context, db weave.KVStor
 	if changeBlogAuthorsMsg.Add {
 		// When removing an author we must ensure it does not exist already
 		if authorIdx >= 0 {
-			return nil, nil, errors.ErrDuplicate.Newf("author: %X", changeBlogAuthorsMsg.Author)
+			return nil, nil, errors.Wrapf(errors.ErrDuplicate, "author: %X", changeBlogAuthorsMsg.Author)
 		}
 	} else {
 		// When removing an author we must ensure :
@@ -391,11 +391,11 @@ func (h ChangeBlogAuthorsMsgHandler) validate(ctx weave.Context, db weave.KVStor
 		// 2 - There will be at least one other author left
 
 		if authorIdx == -1 {
-			return nil, nil, errors.ErrNotFound.Newf("author: %X", changeBlogAuthorsMsg.Author)
+			return nil, nil, errors.Wrapf(errors.ErrNotFound, "author: %X", changeBlogAuthorsMsg.Author)
 		}
 
 		if len(blog.Authors) == 1 {
-			return nil, nil, errors.ErrInvalidState.New("one author left")
+			return nil, nil, errors.Wrap(errors.ErrInvalidState, "one author left")
 		}
 	}
 
@@ -452,7 +452,7 @@ func (h SetProfileMsgHandler) validate(ctx weave.Context, db weave.KVStore, tx w
 	// Retrieve tx main signer in this context
 	sender := x.MainSigner(ctx, h.auth)
 	if sender == nil {
-		return nil, nil, errors.ErrUnauthorized.Newf(unauthorisedBlogAuthorFmt, nil)
+		return nil, nil, errors.Wrapf(errors.ErrUnauthorized, unauthorisedBlogAuthorFmt, nil)
 	}
 
 	msg, err := tx.GetMsg()
@@ -468,7 +468,7 @@ func (h SetProfileMsgHandler) validate(ctx weave.Context, db weave.KVStore, tx w
 	// if author is here we use it for authentication
 	if setProfileMsg.Author != nil {
 		if !h.auth.HasAddress(ctx, setProfileMsg.Author) {
-			return nil, nil, errors.ErrUnauthorized.Newf(unauthorisedPostAuthorFmt, weave.Address(setProfileMsg.Author))
+			return nil, nil, errors.Wrapf(errors.ErrUnauthorized, unauthorisedPostAuthorFmt, weave.Address(setProfileMsg.Author))
 		}
 	}
 

--- a/examples/tutorial/x/blog/models.go
+++ b/examples/tutorial/x/blog/models.go
@@ -14,13 +14,13 @@ var _ orm.CloneableData = (*Blog)(nil)
 // Validate enforces limits of title size and number of authors
 func (b *Blog) Validate() error {
 	if len(b.Title) > MaxTitleLength {
-		return errors.ErrInvalidInput.New(invalidTitle)
+		return errors.Wrap(errors.ErrInvalidInput, invalidTitle)
 	}
 	if len(b.Authors) > MaxAuthors || len(b.Authors) == 0 {
-		return errors.ErrInvalidState.Newf("authors: %d", len(b.Authors))
+		return errors.Wrapf(errors.ErrInvalidState, "authors: %d", len(b.Authors))
 	}
 	if b.NumArticles < 0 {
-		return errors.ErrInvalidModel.Newf("negative articles")
+		return errors.Wrapf(errors.ErrInvalidModel, "negative articles")
 	}
 	return nil
 }
@@ -45,16 +45,16 @@ var _ orm.CloneableData = (*Post)(nil)
 // Validate enforces limits of text and title size
 func (p *Post) Validate() error {
 	if len(p.Title) > MaxTitleLength {
-		return errors.ErrInvalidInput.New(invalidTitle)
+		return errors.Wrap(errors.ErrInvalidInput, invalidTitle)
 	}
 	if len(p.Text) > MaxTextLength {
-		return errors.ErrInvalidInput.New(invalidText)
+		return errors.Wrap(errors.ErrInvalidInput, invalidText)
 	}
 	if len(p.Author) == 0 {
-		return errors.ErrEmpty.New("author")
+		return errors.Wrap(errors.ErrEmpty, "author")
 	}
 	if p.CreationBlock < 0 {
-		return errors.ErrInvalidModel.Newf("negative creation")
+		return errors.Wrapf(errors.ErrInvalidModel, "negative creation")
 	}
 	return nil
 }
@@ -77,10 +77,10 @@ var _ orm.CloneableData = (*Profile)(nil)
 // Validate enforces limits of text and title size
 func (p *Profile) Validate() error {
 	if len(p.Name) > MaxNameLength {
-		return errors.ErrInvalidInput.New(invalidName)
+		return errors.Wrap(errors.ErrInvalidInput, invalidName)
 	}
 	if len(p.Description) > MaxDescriptionLength {
-		return errors.ErrInvalidInput.New(descriptionTooLong)
+		return errors.Wrap(errors.ErrInvalidInput, descriptionTooLong)
 	}
 	return nil
 }
@@ -148,11 +148,11 @@ func idxAuthor(obj orm.Object) ([]byte, error) {
 	// these should use proper errors, but they never occur
 	// except in case of developer error (wrong data in wrong bucket)
 	if obj == nil {
-		return nil, errors.ErrHuman.New("Cannot take index of nil")
+		return nil, errors.Wrap(errors.ErrHuman, "Cannot take index of nil")
 	}
 	post, ok := obj.Value().(*Post)
 	if !ok {
-		return nil, errors.ErrHuman.New("Can only take index of Post")
+		return nil, errors.Wrap(errors.ErrHuman, "Can only take index of Post")
 	}
 	return post.Author, nil
 }

--- a/examples/tutorial/x/blog/msgs.go
+++ b/examples/tutorial/x/blog/msgs.go
@@ -42,15 +42,15 @@ func (CreateBlogMsg) Path() string {
 func (s *CreateBlogMsg) Validate() error {
 	// validate the strings
 	if !IsValidName(s.Slug) {
-		return errors.ErrInvalidInput.New(invalidName)
+		return errors.Wrap(errors.ErrInvalidInput, invalidName)
 	}
 	if len(s.Title) < MinTitleLength || len(s.Title) > MaxTitleLength {
-		return errors.ErrInvalidInput.New(invalidTitle)
+		return errors.Wrap(errors.ErrInvalidInput, invalidTitle)
 	}
 	// check the number of authors
 	authors := len(s.Authors)
 	if authors < MinAuthors || authors > MaxAuthors {
-		return errors.ErrInvalidState.Newf("authors: %d", authors)
+		return errors.Wrapf(errors.ErrInvalidState, "authors: %d", authors)
 	}
 	// and validate all of them are valid addresses
 	for _, a := range s.Authors {
@@ -72,10 +72,10 @@ func (RenameBlogMsg) Path() string {
 // Validate makes sure that this is sensible
 func (s *RenameBlogMsg) Validate() error {
 	if !IsValidName(s.Slug) {
-		return errors.ErrInvalidInput.New(invalidName)
+		return errors.Wrap(errors.ErrInvalidInput, invalidName)
 	}
 	if len(s.Title) < MinTitleLength || len(s.Title) > MaxTitleLength {
-		return errors.ErrInvalidInput.New(invalidTitle)
+		return errors.Wrap(errors.ErrInvalidInput, invalidTitle)
 	}
 	return nil
 }
@@ -105,13 +105,13 @@ func (CreatePostMsg) Path() string {
 // Validate makes sure that this is sensible
 func (s *CreatePostMsg) Validate() error {
 	if !IsValidName(s.Blog) {
-		return errors.ErrInvalidInput.New(invalidName)
+		return errors.Wrap(errors.ErrInvalidInput, invalidName)
 	}
 	if len(s.Title) < MinTitleLength || len(s.Title) > MaxTitleLength {
-		return errors.ErrInvalidInput.New(invalidTitle)
+		return errors.Wrap(errors.ErrInvalidInput, invalidTitle)
 	}
 	if len(s.Text) < MinTextLength || len(s.Text) > MaxTextLength {
-		return errors.ErrInvalidInput.New(invalidText)
+		return errors.Wrap(errors.ErrInvalidInput, invalidText)
 	}
 
 	// if an author is present, validate it is a valid address
@@ -132,10 +132,10 @@ func (SetProfileMsg) Path() string {
 // Validate makes sure that this is sensible
 func (s *SetProfileMsg) Validate() error {
 	if !IsValidName(s.Name) {
-		return errors.ErrInvalidInput.New(invalidName)
+		return errors.Wrap(errors.ErrInvalidInput, invalidName)
 	}
 	if len(s.Description) > MaxDescriptionLength {
-		return errors.ErrInvalidInput.New(descriptionTooLong)
+		return errors.Wrap(errors.ErrInvalidInput, descriptionTooLong)
 	}
 	// if an author is present, validate it is a valid address
 	if len(s.Author) > 0 {

--- a/orm/bucket.go
+++ b/orm/bucket.go
@@ -15,12 +15,12 @@ For inspiration, look at [storm](https://github.com/asdine/storm) built on top o
 package orm
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"sort"
 
 	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/errors"
 )
 
 const (
@@ -117,7 +117,7 @@ func (b Bucket) Query(db weave.ReadOnlyKVStore, mod string,
 		prefix := b.DBKey(data)
 		return queryPrefix(db, prefix), nil
 	default:
-		return nil, errors.New("not implemented: " + mod)
+		return nil, fmt.Errorf("not implemented: %s", mod)
 	}
 }
 
@@ -248,7 +248,7 @@ func (b Bucket) WithMultiKeyIndex(name string, indexer MultiKeyIndexer, unique b
 func (b Bucket) GetIndexed(db weave.ReadOnlyKVStore, name string, key []byte) ([]Object, error) {
 	idx := b.indexes.Get(name)
 	if idx == nil {
-		return nil, ErrInvalidIndex.New(name)
+		return nil, errors.Wrap(ErrInvalidIndex, name)
 	}
 	refs, err := idx.GetAt(db, key)
 	if err != nil {
@@ -261,7 +261,7 @@ func (b Bucket) GetIndexed(db weave.ReadOnlyKVStore, name string, key []byte) ([
 func (b Bucket) GetIndexedLike(db weave.ReadOnlyKVStore, name string, pattern Object) ([]Object, error) {
 	idx := b.indexes.Get(name)
 	if idx == nil {
-		return nil, ErrInvalidIndex.New(name)
+		return nil, errors.Wrap(ErrInvalidIndex, name)
 	}
 	refs, err := idx.GetLike(db, pattern)
 	if err != nil {

--- a/orm/index.go
+++ b/orm/index.go
@@ -93,7 +93,7 @@ func (i Index) Update(db weave.KVStore, prev Object, save Object) error {
 	sw := s{prev == nil, save == nil}
 	switch sw {
 	case s{true, true}:
-		return errors.ErrHuman.New("update requires at least one non-nil object")
+		return errors.Wrap(errors.ErrHuman, "update requires at least one non-nil object")
 	case s{true, false}:
 		keys, err := i.index(save)
 		if err != nil {
@@ -119,7 +119,7 @@ func (i Index) Update(db weave.KVStore, prev Object, save Object) error {
 	case s{false, false}:
 		return i.move(db, prev, save)
 	}
-	return errors.ErrHuman.New("you have violated the rules of boolean logic")
+	return errors.Wrap(errors.ErrHuman, "you have violated the rules of boolean logic")
 }
 
 // GetLike calculates the index for the given pattern, and
@@ -213,7 +213,7 @@ func (i Index) Query(db weave.ReadOnlyKVStore, mod string,
 		}
 		return i.loadRefs(db, refs), nil
 	default:
-		return nil, errors.ErrHuman.New("not implemented: " + mod)
+		return nil, errors.Wrap(errors.ErrHuman, "not implemented: " + mod)
 	}
 }
 
@@ -237,7 +237,7 @@ func (i Index) loadRefs(db weave.ReadOnlyKVStore,
 func (i Index) move(db weave.KVStore, prev Object, save Object) error {
 	// if the primary key is not equal, we have a problem
 	if !bytes.Equal(prev.Key(), save.Key()) {
-		return errors.ErrCannotBeModified.New("cannot modify the primary key of an object")
+		return errors.Wrap(errors.ErrCannotBeModified, "cannot modify the primary key of an object")
 	}
 
 	oldKeys, err := i.index(prev)
@@ -257,7 +257,7 @@ func (i Index) move(db weave.KVStore, prev Object, save Object) error {
 			k := i.IndexKey(newKey)
 			val := db.Get(k)
 			if val != nil {
-				return errors.ErrDuplicate.New(i.name)
+				return errors.Wrap(errors.ErrDuplicate, i.name)
 			}
 		}
 	}
@@ -305,12 +305,12 @@ func (i Index) remove(db weave.KVStore, index []byte, pk []byte) error {
 	key := i.IndexKey(index)
 	cur := db.Get(key)
 	if cur == nil {
-		return errors.ErrNotFound.New("cannot remove index from nothing")
+		return errors.Wrap(errors.ErrNotFound, "cannot remove index from nothing")
 	}
 	if i.unique {
 		// if something else was here, don't delete
 		if !bytes.Equal(cur, pk) {
-			return errors.ErrNotFound.New("cannot remove index from invalid object")
+			return errors.Wrap(errors.ErrNotFound, "cannot remove index from invalid object")
 		}
 		db.Delete(key)
 		return nil
@@ -351,7 +351,7 @@ func (i Index) insert(db weave.KVStore, index []byte, pk []byte) error {
 
 	if i.unique {
 		if cur != nil {
-			return errors.ErrDuplicate.New(i.name)
+			return errors.Wrap(errors.ErrDuplicate, i.name)
 		}
 		db.Set(key, pk)
 		return nil

--- a/orm/multiref.go
+++ b/orm/multiref.go
@@ -35,7 +35,7 @@ func multiRefFromStrings(strs ...string) (*MultiRef, error) {
 func (m *MultiRef) Add(ref []byte) error {
 	i, found := m.findRef(ref)
 	if found {
-		return errors.ErrNotFound.New("cannot add a ref twice")
+		return errors.Wrap(errors.ErrNotFound, "cannot add a ref twice")
 	}
 	// append to end
 	if i == len(m.Refs) {
@@ -54,7 +54,7 @@ func (m *MultiRef) Add(ref []byte) error {
 func (m *MultiRef) Remove(ref []byte) error {
 	i, found := m.findRef(ref)
 	if !found {
-		return errors.ErrNotFound.New("cannot remove non-existent ref")
+		return errors.Wrap(errors.ErrNotFound, "cannot remove non-existent ref")
 	}
 	// splice it out
 	m.Refs = append(m.Refs[:i], m.Refs[i+1:]...)
@@ -99,7 +99,7 @@ func (m *MultiRef) Copy() CloneableData {
 // Validate just returns an error if empty
 func (m *MultiRef) Validate() error {
 	if len(m.GetRefs()) == 0 {
-		return errors.ErrEmpty.New("no references")
+		return errors.Wrap(errors.ErrEmpty, "no references")
 	}
 	return nil
 }
@@ -121,7 +121,7 @@ func (c *Counter) Copy() CloneableData {
 // Validate returns error on negative numbers
 func (c *Counter) Validate() error {
 	if c.Count < 0 {
-		return errors.ErrInvalidState.New("negative counter")
+		return errors.Wrap(errors.ErrInvalidState, "negative counter")
 	}
 	return nil
 }

--- a/orm/object.go
+++ b/orm/object.go
@@ -39,10 +39,10 @@ func (o SimpleObj) Key() []byte {
 // And delegates to the value validator if present
 func (o SimpleObj) Validate() error {
 	if len(o.key) == 0 {
-		return errors.ErrEmpty.New("missing key")
+		return errors.Wrap(errors.ErrEmpty, "missing key")
 	}
 	if o.value == nil {
-		return errors.ErrEmpty.New("missing value")
+		return errors.Wrap(errors.ErrEmpty, "missing value")
 	}
 	return o.value.Validate()
 }

--- a/tx.go
+++ b/tx.go
@@ -86,23 +86,23 @@ type TxDecoder func(txBytes []byte) (Tx, error)
 func ExtractMsgFromSum(sum interface{}) (Msg, error) {
 	// TODO: add better error messages here with new refactor
 	if sum == nil {
-		return nil, errors.ErrInvalidMsg.New("message container is <nil>")
+		return nil, errors.Wrap(errors.ErrInvalidMsg, "message container is <nil>")
 	}
 	pval := reflect.ValueOf(sum)
 	if pval.Kind() != reflect.Ptr || pval.Elem().Kind() != reflect.Struct {
-		return nil, errors.ErrInvalidMsg.New(fmt.Sprintf("invalid message container value: %T", sum))
+		return nil, errors.Wrap(errors.ErrInvalidMsg, fmt.Sprintf("invalid message container value: %T", sum))
 	}
 	val := pval.Elem()
 	if val.NumField() != 1 {
-		return nil, errors.ErrInvalidMsg.New(fmt.Sprintf("Unexpected message container field count: %d", val.NumField()))
+		return nil, errors.Wrap(errors.ErrInvalidMsg, fmt.Sprintf("Unexpected message container field count: %d", val.NumField()))
 	}
 	field := val.Field(0)
 	if field.IsNil() {
-		return nil, errors.ErrInvalidMsg.New("message is <nil>")
+		return nil, errors.Wrap(errors.ErrInvalidMsg, "message is <nil>")
 	}
 	res, ok := field.Interface().(Msg)
 	if !ok {
-		return nil, errors.ErrInvalidMsg.New(fmt.Sprintf("Unsupported message type: %T", field.Interface()))
+		return nil, errors.Wrap(errors.ErrInvalidMsg, fmt.Sprintf("Unsupported message type: %T", field.Interface()))
 	}
 	return res, nil
 }

--- a/x/batch/msg.go
+++ b/x/batch/msg.go
@@ -24,7 +24,7 @@ func Validate(msg Msg) error {
 
 	msgNum := len(l)
 	if msgNum > MaxBatchMessages {
-		return errors.ErrInvalidInput.Newf("transaction is too large, max: %d vs current: %d", MaxBatchMessages, msgNum)
+		return errors.Wrapf(errors.ErrInvalidInput, "transaction is too large, max: %d vs current: %d", MaxBatchMessages, msgNum)
 	}
 	return nil
 }

--- a/x/cash/controller.go
+++ b/x/cash/controller.go
@@ -55,7 +55,7 @@ func (c BaseController) Balance(store weave.KVStore, src weave.Address) (coin.Co
 		return nil, errors.Wrap(err, "cannot get account state")
 	}
 	if state == nil {
-		return nil, errors.ErrNotFound.New("no account")
+		return nil, errors.Wrap(errors.ErrNotFound, "no account")
 	}
 	return AsCoins(state), nil
 }
@@ -67,10 +67,10 @@ func (c BaseController) MoveCoins(store weave.KVStore,
 	src weave.Address, dest weave.Address, amount coin.Coin) error {
 
 	if amount.IsZero() {
-		return errors.ErrInvalidAmount.New("zero value")
+		return errors.Wrap(errors.ErrInvalidAmount, "zero value")
 	}
 	if !amount.IsPositive() {
-		return errors.ErrInvalidAmount.Newf("non-positive SendMsg: %#v", &amount)
+		return errors.Wrapf(errors.ErrInvalidAmount, "non-positive SendMsg: %#v", &amount)
 	}
 
 	// load sender, subtract funds, and save
@@ -79,10 +79,10 @@ func (c BaseController) MoveCoins(store weave.KVStore,
 		return err
 	}
 	if sender == nil {
-		return errors.ErrEmpty.Newf("empty account %#v", src)
+		return errors.Wrapf(errors.ErrEmpty, "empty account %#v", src)
 	}
 	if !AsCoins(sender).Contains(amount) {
-		return errors.ErrInsufficientAmount.New("funds")
+		return errors.Wrap(errors.ErrInsufficientAmount, "funds")
 	}
 	err = Subtract(AsCoinage(sender), amount)
 	if err != nil {

--- a/x/cash/handler.go
+++ b/x/cash/handler.go
@@ -58,7 +58,7 @@ func (h SendHandler) Check(ctx weave.Context, store weave.KVStore,
 
 	// make sure we have permission from the sender
 	if !h.auth.HasAddress(ctx, msg.Src) {
-		return res, errors.ErrUnauthorized.New("Account owner signature missing")
+		return res, errors.Wrap(errors.ErrUnauthorized, "Account owner signature missing")
 	}
 
 	// return cost
@@ -89,7 +89,7 @@ func (h SendHandler) Deliver(ctx weave.Context, store weave.KVStore,
 
 	// make sure we have permission from the sender
 	if !h.auth.HasAddress(ctx, msg.Src) {
-		return res, errors.ErrUnauthorized.New("Account owner signature missing")
+		return res, errors.Wrap(errors.ErrUnauthorized, "Account owner signature missing")
 	}
 
 	// move the money....

--- a/x/cash/msg.go
+++ b/x/cash/msg.go
@@ -26,7 +26,7 @@ func (SendMsg) Path() string {
 func (s *SendMsg) Validate() error {
 	amt := s.GetAmount()
 	if coin.IsEmpty(amt) || !amt.IsPositive() {
-		return errors.ErrInvalidAmount.Newf("non-positive SendMsg: %#v", amt)
+		return errors.Wrapf(errors.ErrInvalidAmount, "non-positive SendMsg: %#v", amt)
 
 	}
 	if err := amt.Validate(); err != nil {
@@ -39,10 +39,10 @@ func (s *SendMsg) Validate() error {
 		return err
 	}
 	if len(s.GetMemo()) > maxMemoSize {
-		return errors.ErrInvalidState.New("memo too long")
+		return errors.Wrap(errors.ErrInvalidState, "memo too long")
 	}
 	if len(s.GetRef()) > maxRefSize {
-		return errors.ErrInvalidState.New("ref too long")
+		return errors.Wrap(errors.ErrInvalidState, "ref too long")
 	}
 	return nil
 }
@@ -87,17 +87,17 @@ func (f *FeeInfo) DefaultPayer(addr []byte) *FeeInfo {
 // Note that fee must be present, even if 0
 func (f *FeeInfo) Validate() error {
 	if f == nil {
-		return errors.ErrInvalidInput.Newf("address: %v", nil)
+		return errors.Wrapf(errors.ErrInvalidInput, "address: %v", nil)
 	}
 	fee := f.GetFees()
 	if fee == nil {
-		return errors.ErrInvalidAmount.New("fees nil")
+		return errors.Wrap(errors.ErrInvalidAmount, "fees nil")
 	}
 	if err := fee.Validate(); err != nil {
 		return err
 	}
 	if !fee.IsNonNegative() {
-		return errors.ErrInvalidAmount.New("negative fees")
+		return errors.Wrap(errors.ErrInvalidAmount, "negative fees")
 	}
 	return weave.Address(f.Payer).Validate()
 }

--- a/x/cash/staticfee.go
+++ b/x/cash/staticfee.go
@@ -63,7 +63,7 @@ func (d FeeDecorator) Check(ctx weave.Context, store weave.KVStore, tx weave.Tx,
 
 	// verify we have access to the money
 	if !d.auth.HasAddress(ctx, finfo.Payer) {
-		return res, errors.ErrUnauthorized.New("Fee payer signature missing")
+		return res, errors.Wrap(errors.ErrUnauthorized, "Fee payer signature missing")
 	}
 	// and have enough
 	collector := gconf.Address(store, GconfCollectorAddress)
@@ -97,7 +97,7 @@ func (d FeeDecorator) Deliver(ctx weave.Context, store weave.KVStore, tx weave.T
 
 	// verify we have access to the money
 	if !d.auth.HasAddress(ctx, finfo.Payer) {
-		return res, errors.ErrUnauthorized.New("Fee payer signature missing")
+		return res, errors.Wrap(errors.ErrUnauthorized, "Fee payer signature missing")
 	}
 	// and subtract it from the account
 	collector := gconf.Address(store, GconfCollectorAddress)
@@ -123,7 +123,7 @@ func (d FeeDecorator) extractFee(ctx weave.Context, tx weave.Tx, store weave.KVS
 		if minFee.IsZero() {
 			return finfo, nil
 		}
-		return nil, errors.ErrInsufficientAmount.Newf("fees %#v", fee)
+		return nil, errors.Wrapf(errors.ErrInsufficientAmount, "fees %#v", fee)
 	}
 
 	// make sure it is a valid fee (non-negative, going somewhere)
@@ -147,7 +147,7 @@ func (d FeeDecorator) extractFee(ctx weave.Context, tx weave.Tx, store weave.KVS
 
 	}
 	if !fee.IsGTE(cmp) {
-		return nil, errors.ErrInsufficientAmount.Newf("fees %#v", fee)
+		return nil, errors.Wrapf(errors.ErrInsufficientAmount, "fees %#v", fee)
 	}
 	return finfo, nil
 }

--- a/x/cash/staticfee_test.go
+++ b/x/cash/staticfee_test.go
@@ -30,11 +30,11 @@ func (f feeTx) GetFees() *FeeInfo {
 }
 
 func (f feeTx) Marshal() ([]byte, error) {
-	return nil, errors.ErrHuman.New("TODO: not implemented")
+	return nil, errors.Wrap(errors.ErrHuman, "TODO: not implemented")
 }
 
 func (f *feeTx) Unmarshal([]byte) error {
-	return errors.ErrHuman.New("TODO: not implemented")
+	return errors.Wrap(errors.ErrHuman, "TODO: not implemented")
 }
 
 func must(obj orm.Object, err error) orm.Object {

--- a/x/currency/handler.go
+++ b/x/currency/handler.go
@@ -65,7 +65,7 @@ func (h *TokenInfoHandler) validate(ctx weave.Context, db weave.KVStore, tx weav
 
 	// Ensure we have permission if the issuer is provided.
 	if h.issuer != nil && !h.auth.HasAddress(ctx, h.issuer) {
-		return nil, errors.ErrUnauthorized.Newf("Token only issued by %s", h.issuer)
+		return nil, errors.Wrapf(errors.ErrUnauthorized, "Token only issued by %s", h.issuer)
 	}
 
 	// Token can be registered only once and must not be updated.
@@ -73,7 +73,7 @@ func (h *TokenInfoHandler) validate(ctx weave.Context, db weave.KVStore, tx weav
 	case err != nil:
 		return nil, err
 	case obj != nil:
-		return nil, errors.ErrDuplicate.Newf("ticker %s", msg.Ticker)
+		return nil, errors.Wrapf(errors.ErrDuplicate, "ticker %s", msg.Ticker)
 	}
 
 	return msg, nil

--- a/x/currency/model.go
+++ b/x/currency/model.go
@@ -23,7 +23,7 @@ func NewTokenInfo(ticker, name string) orm.Object {
 
 func (t *TokenInfo) Validate() error {
 	if !isTokenName(t.Name) {
-		return errors.ErrInvalidState.Newf("invalid token name %v", t.Name)
+		return errors.Wrapf(errors.ErrInvalidState, "invalid token name %v", t.Name)
 	}
 	return nil
 }

--- a/x/currency/msg.go
+++ b/x/currency/msg.go
@@ -17,7 +17,7 @@ func (t *NewTokenInfoMsg) Validate() error {
 		return errors.Wrapf(errors.ErrCurrency, "invalid ticker: %s", t.Ticker)
 	}
 	if !isTokenName(t.Name) {
-		return errors.ErrInvalidState.Newf("invalid token name %v", t.Name)
+		return errors.Wrapf(errors.ErrInvalidState, "invalid token name %v", t.Name)
 	}
 	return nil
 }

--- a/x/distribution/handler.go
+++ b/x/distribution/handler.go
@@ -87,7 +87,7 @@ func (h *newRevenueHandler) validate(ctx weave.Context, db weave.KVStore, tx wea
 	}
 	msg, ok := rmsg.(*NewRevenueMsg)
 	if !ok {
-		return nil, errors.ErrInvalidMsg.New("unknown transaction type")
+		return nil, errors.Wrap(errors.ErrInvalidMsg, "unknown transaction type")
 	}
 	if err := msg.Validate(); err != nil {
 		return msg, err
@@ -141,7 +141,7 @@ func (h *distributeHandler) validate(ctx weave.Context, db weave.KVStore, tx wea
 	}
 	msg, ok := rmsg.(*DistributeMsg)
 	if !ok {
-		return nil, errors.ErrInvalidMsg.New("unknown transaction type")
+		return nil, errors.Wrap(errors.ErrInvalidMsg, "unknown transaction type")
 	}
 	if err := msg.Validate(); err != nil {
 		return msg, err
@@ -211,7 +211,7 @@ func (h *resetRevenueHandler) validate(ctx weave.Context, db weave.KVStore, tx w
 	}
 	msg, ok := rmsg.(*ResetRevenueMsg)
 	if !ok {
-		return nil, errors.ErrInvalidMsg.New("unknown transaction type")
+		return nil, errors.Wrap(errors.ErrInvalidMsg, "unknown transaction type")
 	}
 	if err := msg.Validate(); err != nil {
 		return msg, err

--- a/x/distribution/msg.go
+++ b/x/distribution/msg.go
@@ -26,7 +26,7 @@ func (NewRevenueMsg) Path() string {
 
 func (msg *DistributeMsg) Validate() error {
 	if len(msg.RevenueID) == 0 {
-		return errors.ErrInvalidMsg.New("revenue ID missing")
+		return errors.Wrap(errors.ErrInvalidMsg, "revenue ID missing")
 	}
 	return nil
 }

--- a/x/escrow/handler.go
+++ b/x/escrow/handler.go
@@ -116,7 +116,7 @@ func (h CreateEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
 	// verify that timeout is in the future
 	height, _ := weave.GetHeight(ctx)
 	if msg.Timeout <= height {
-		return nil, errors.ErrInvalidInput.Newf("timeout: %d", msg.Timeout)
+		return nil, errors.Wrapf(errors.ErrInvalidInput, "timeout: %d", msg.Timeout)
 	}
 
 	// sender must authorize this (if not set, defaults to MainSigner)
@@ -230,7 +230,7 @@ func (h ReleaseEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
 	// timeout must not have expired
 	height, _ := weave.GetHeight(ctx)
 	if escrow.Timeout < height {
-		return nil, nil, errors.ErrExpired.Newf("escrow %d", escrow.Timeout)
+		return nil, nil, errors.Wrapf(errors.ErrExpired, "escrow %d", escrow.Timeout)
 	}
 
 	return msg, escrow, nil
@@ -314,7 +314,7 @@ func (h ReturnEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
 	// timeout must have expired
 	height, _ := weave.GetHeight(ctx)
 	if height <= escrow.Timeout {
-		return nil, nil, errors.ErrInvalidState.Newf("escrow not expired %d", escrow.Timeout)
+		return nil, nil, errors.Wrapf(errors.ErrInvalidState, "escrow not expired %d", escrow.Timeout)
 	}
 
 	return msg.EscrowId, escrow, nil
@@ -401,7 +401,7 @@ func (h UpdateEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
 	// timeout must not have expired
 	height, _ := weave.GetHeight(ctx)
 	if height > escrow.Timeout {
-		return nil, nil, errors.ErrExpired.Newf("escrow %d", escrow.Timeout)
+		return nil, nil, errors.Wrapf(errors.ErrExpired, "escrow %d", escrow.Timeout)
 	}
 
 	// we must have the permission for the items we want to change
@@ -435,7 +435,7 @@ func loadEscrow(bucket Bucket, db weave.KVStore, escrowID []byte) (*Escrow, erro
 	}
 	escrow := AsEscrow(obj)
 	if escrow == nil {
-		return nil, errors.ErrEmpty.Newf("escrow %d", escrowID)
+		return nil, errors.Wrapf(errors.ErrEmpty, "escrow %d", escrowID)
 	}
 	return escrow, nil
 }

--- a/x/escrow/model.go
+++ b/x/escrow/model.go
@@ -19,21 +19,21 @@ var _ orm.CloneableData = (*Escrow)(nil)
 // Validate ensures the escrow is valid
 func (e *Escrow) Validate() error {
 	if e.Sender == nil {
-		return errors.ErrEmpty.New("sender")
+		return errors.Wrap(errors.ErrEmpty, "sender")
 	}
 	// Copied from CreateEscrowMsg.Validate
 	// TODO: code reuse???
 	if e.Arbiter == nil {
-		return errors.ErrEmpty.New("arbiter")
+		return errors.Wrap(errors.ErrEmpty, "arbiter")
 	}
 	if e.Recipient == nil {
-		return errors.ErrEmpty.New("recipient")
+		return errors.Wrap(errors.ErrEmpty, "recipient")
 	}
 	if e.Timeout <= 0 {
-		return errors.ErrInvalidInput.Newf("timeout: %d", e.Timeout)
+		return errors.Wrapf(errors.ErrInvalidInput, "timeout: %d", e.Timeout)
 	}
 	if len(e.Memo) > maxMemoSize {
-		return errors.ErrInvalidInput.Newf("memo %s", e.Memo)
+		return errors.Wrapf(errors.ErrInvalidInput, "memo %s", e.Memo)
 	}
 	if err := validateConditions(e.Arbiter); err != nil {
 		return err
@@ -119,11 +119,11 @@ func NewBucket() Bucket {
 
 func getEscrow(obj orm.Object) (*Escrow, error) {
 	if obj == nil {
-		return nil, errors.ErrHuman.New("Cannot take index of nil")
+		return nil, errors.Wrap(errors.ErrHuman, "Cannot take index of nil")
 	}
 	esc, ok := obj.Value().(*Escrow)
 	if !ok {
-		return nil, errors.ErrHuman.New("Can only take index of Escrow")
+		return nil, errors.Wrap(errors.ErrHuman, "Can only take index of Escrow")
 	}
 	return esc, nil
 }

--- a/x/escrow/msg.go
+++ b/x/escrow/msg.go
@@ -60,16 +60,16 @@ func NewCreateMsg(send, rcpt weave.Address, arb weave.Condition,
 // Validate makes sure that this is sensible
 func (m *CreateEscrowMsg) Validate() error {
 	if m.Arbiter == nil {
-		return errors.ErrEmpty.New("arbiter")
+		return errors.Wrap(errors.ErrEmpty, "arbiter")
 	}
 	if m.Recipient == nil {
-		return errors.ErrEmpty.New("recipient")
+		return errors.Wrap(errors.ErrEmpty, "recipient")
 	}
 	if m.Timeout <= 0 {
-		return errors.ErrInvalidInput.Newf("timeout: %d", m.Timeout)
+		return errors.Wrapf(errors.ErrInvalidInput, "timeout: %d", m.Timeout)
 	}
 	if len(m.Memo) > maxMemoSize {
-		return errors.ErrInvalidInput.Newf("memo %s", m.Memo)
+		return errors.Wrapf(errors.ErrInvalidInput, "memo %s", m.Memo)
 	}
 	if err := validateAmount(m.Amount); err != nil {
 		return err
@@ -107,7 +107,7 @@ func (m *UpdateEscrowPartiesMsg) Validate() error {
 	if m.Arbiter == nil &&
 		m.Sender == nil &&
 		m.Recipient == nil {
-		return errors.ErrEmpty.New("all conditions")
+		return errors.Wrap(errors.ErrEmpty, "all conditions")
 	}
 	err = validateConditions(m.Arbiter)
 	if err != nil {
@@ -146,7 +146,7 @@ func validateAmount(amount coin.Coins) error {
 	// we enforce this is positive
 	positive := amount.IsPositive()
 	if !positive {
-		return errors.ErrInvalidAmount.Newf("non-positive SendMsg: %#v", &amount)
+		return errors.Wrapf(errors.ErrInvalidAmount, "non-positive SendMsg: %#v", &amount)
 	}
 	// then make sure these are properly formatted coins
 	return amount.Validate()
@@ -154,7 +154,7 @@ func validateAmount(amount coin.Coins) error {
 
 func validateEscrowID(id []byte) error {
 	if len(id) != 8 {
-		return errors.ErrInvalidInput.Newf("escrow id: %X", id)
+		return errors.Wrapf(errors.ErrInvalidInput, "escrow id: %X", id)
 	}
 	return nil
 }

--- a/x/msgfee/model.go
+++ b/x/msgfee/model.go
@@ -52,7 +52,7 @@ func (b *MsgFeeBucket) Create(db weave.KVStore, mf *MsgFee) (orm.Object, error) 
 // Save persists the state of a given revenue entity.
 func (b *MsgFeeBucket) Save(db weave.KVStore, obj orm.Object) error {
 	if _, ok := obj.Value().(*MsgFee); !ok {
-		return errors.ErrInvalidModel.Newf("invalid type: %T", obj.Value())
+		return errors.Wrapf(errors.ErrInvalidModel, "invalid type: %T", obj.Value())
 	}
 	return b.Bucket.Save(db, obj)
 }
@@ -69,7 +69,7 @@ func (b *MsgFeeBucket) MessageFee(db weave.KVStore, msgPath string) (*coin.Coin,
 	}
 	mf, ok := obj.Value().(*MsgFee)
 	if !ok {
-		return nil, errors.ErrInvalidModel.Newf("invalid type: %T", obj.Value())
+		return nil, errors.Wrapf(errors.ErrInvalidModel, "invalid type: %T", obj.Value())
 	}
 	return &mf.Fee, nil
 }

--- a/x/multisig/decorator.go
+++ b/x/multisig/decorator.go
@@ -69,7 +69,7 @@ func (d Decorator) withMultisig(ctx weave.Context, store weave.KVStore, tx weave
 			// check sigs (can be sig or multisig)
 			authenticated := x.HasNAddresses(ctx, d.auth, sigs, int(contract.ActivationThreshold))
 			if !authenticated {
-				return ctx, errors.ErrUnauthorized.Newf("contract=%X", contractID)
+				return ctx, errors.Wrapf(errors.ErrUnauthorized, "contract=%X", contractID)
 			}
 
 			ctx = withMultisig(ctx, contractID)
@@ -86,7 +86,7 @@ func (d Decorator) getContract(store weave.KVStore, id []byte) (*Contract, error
 	}
 
 	if obj == nil || (obj != nil && obj.Value() == nil) {
-		return nil, errors.ErrNotFound.Newf(contractNotFoundFmt, id)
+		return nil, errors.Wrapf(errors.ErrNotFound, contractNotFoundFmt, id)
 	}
 
 	contract := obj.Value().(*Contract)

--- a/x/multisig/decorator_test.go
+++ b/x/multisig/decorator_test.go
@@ -83,14 +83,14 @@ func TestDecorator(t *testing.T) {
 			multisigTx([]byte("foo"), contractID1),
 			[]weave.Condition{a},
 			nil,
-			errors.ErrUnauthorized.Newf("contract=%X", contractID1),
+			errors.Wrapf(errors.ErrUnauthorized, "contract=%X", contractID1),
 		},
 		// with invalid multisig contract ID
 		{
 			multisigTx([]byte("foo"), []byte("bad id")),
 			[]weave.Condition{a, b},
 			nil,
-			errors.ErrNotFound.Newf(contractNotFoundFmt, []byte("bad id")),
+			errors.Wrapf(errors.ErrNotFound, contractNotFoundFmt, []byte("bad id")),
 		},
 		// contractID3 is activated by contractID2
 		{
@@ -111,7 +111,7 @@ func TestDecorator(t *testing.T) {
 			multisigTx([]byte("foo"), contractID3),
 			[]weave.Condition{d, e}, // cconditions for ontractID2 are there but ontractID2 must be passed explicitly
 			nil,
-			errors.ErrUnauthorized.Newf("contract=%X", contractID3),
+			errors.Wrapf(errors.ErrUnauthorized, "contract=%X", contractID3),
 		},
 	}
 

--- a/x/multisig/handlers.go
+++ b/x/multisig/handlers.go
@@ -64,7 +64,7 @@ func (h CreateContractMsgHandler) validate(ctx weave.Context, db weave.KVStore, 
 	// Retrieve tx main signer in this context
 	sender := x.MainSigner(ctx, h.auth)
 	if sender == nil {
-		return nil, errors.ErrUnauthorized.New("No signer")
+		return nil, errors.Wrap(errors.ErrUnauthorized, "No signer")
 	}
 
 	msg, err := tx.GetMsg()
@@ -148,7 +148,7 @@ func (h UpdateContractMsgHandler) validate(ctx weave.Context, db weave.KVStore, 
 		return nil, err
 	}
 	if obj == nil || (obj != nil && obj.Value() == nil) {
-		return nil, errors.ErrNotFound.Newf(contractNotFoundFmt, updateContractMsg.Id)
+		return nil, errors.Wrapf(errors.ErrNotFound, contractNotFoundFmt, updateContractMsg.Id)
 	}
 	contract := obj.Value().(*Contract)
 
@@ -161,7 +161,7 @@ func (h UpdateContractMsgHandler) validate(ctx weave.Context, db weave.KVStore, 
 	// check sigs
 	authenticated := x.HasNAddresses(ctx, h.auth, sigs, int(contract.AdminThreshold))
 	if !authenticated {
-		return nil, errors.ErrUnauthorized.Newf("contract=%X", updateContractMsg.Id)
+		return nil, errors.Wrapf(errors.ErrUnauthorized, "contract=%X", updateContractMsg.Id)
 	}
 
 	return updateContractMsg, nil

--- a/x/multisig/handlers_test.go
+++ b/x/multisig/handlers_test.go
@@ -80,7 +80,7 @@ func TestCreateContractMsgHandler(t *testing.T) {
 		{
 			name: "missing sigs",
 			msg:  &CreateContractMsg{},
-			err:  errors.ErrInvalidMsg.New("missing sigs"),
+			err:  errors.Wrap(errors.ErrInvalidMsg, "missing sigs"),
 		},
 		{
 			name: "bad activation threshold",
@@ -89,7 +89,7 @@ func TestCreateContractMsgHandler(t *testing.T) {
 				ActivationThreshold: 4,
 				AdminThreshold:      3,
 			},
-			err: errors.ErrInvalidMsg.New(invalidThreshold),
+			err: errors.Wrap(errors.ErrInvalidMsg, invalidThreshold),
 		},
 		{
 			name: "bad admin threshold",
@@ -98,7 +98,7 @@ func TestCreateContractMsgHandler(t *testing.T) {
 				ActivationThreshold: 1,
 				AdminThreshold:      -1,
 			},
-			err: errors.ErrInvalidMsg.New(invalidThreshold),
+			err: errors.Wrap(errors.ErrInvalidMsg, invalidThreshold),
 		},
 		{
 			name: "0 activation threshold",
@@ -107,7 +107,7 @@ func TestCreateContractMsgHandler(t *testing.T) {
 				ActivationThreshold: 0,
 				AdminThreshold:      1,
 			},
-			err: errors.ErrInvalidMsg.New(invalidThreshold),
+			err: errors.Wrap(errors.ErrInvalidMsg, invalidThreshold),
 		},
 	}
 

--- a/x/multisig/model.go
+++ b/x/multisig/model.go
@@ -19,13 +19,13 @@ var _ orm.CloneableData = (*Contract)(nil)
 // Validate enforces sigs and threshold boundaries
 func (c *Contract) Validate() error {
 	if len(c.Sigs) == 0 {
-		return errors.ErrInvalidMsg.New("missing sigs")
+		return errors.Wrap(errors.ErrInvalidMsg, "missing sigs")
 	}
 	if c.ActivationThreshold <= 0 || int(c.ActivationThreshold) > len(c.Sigs) {
-		return errors.ErrInvalidMsg.New(invalidThreshold)
+		return errors.Wrap(errors.ErrInvalidMsg, invalidThreshold)
 	}
 	if c.AdminThreshold <= 0 {
-		return errors.ErrInvalidMsg.New(invalidThreshold)
+		return errors.Wrap(errors.ErrInvalidMsg, invalidThreshold)
 	}
 	for _, a := range c.Sigs {
 		if err := weave.Address(a).Validate(); err != nil {

--- a/x/multisig/msg.go
+++ b/x/multisig/msg.go
@@ -21,13 +21,13 @@ func (CreateContractMsg) Path() string {
 // Validate enforces sigs and threshold boundaries
 func (c *CreateContractMsg) Validate() error {
 	if len(c.Sigs) == 0 {
-		return errors.ErrInvalidMsg.New("missing sigs")
+		return errors.Wrap(errors.ErrInvalidMsg, "missing sigs")
 	}
 	if c.ActivationThreshold <= 0 || int(c.ActivationThreshold) > len(c.Sigs) {
-		return errors.ErrInvalidMsg.New(invalidThreshold)
+		return errors.Wrap(errors.ErrInvalidMsg, invalidThreshold)
 	}
 	if c.AdminThreshold <= 0 {
-		return errors.ErrInvalidMsg.New(invalidThreshold)
+		return errors.Wrap(errors.ErrInvalidMsg, invalidThreshold)
 	}
 	for _, a := range c.Sigs {
 		if err := weave.Address(a).Validate(); err != nil {
@@ -45,13 +45,13 @@ func (UpdateContractMsg) Path() string {
 // Validate enforces sigs and threshold boundaries
 func (c *UpdateContractMsg) Validate() error {
 	if len(c.Sigs) == 0 {
-		return errors.ErrInvalidMsg.New("missing sigs")
+		return errors.Wrap(errors.ErrInvalidMsg, "missing sigs")
 	}
 	if c.ActivationThreshold <= 0 || int(c.ActivationThreshold) > len(c.Sigs) {
-		return errors.ErrInvalidMsg.New(invalidThreshold)
+		return errors.Wrap(errors.ErrInvalidMsg, invalidThreshold)
 	}
 	if c.AdminThreshold <= 0 {
-		return errors.ErrInvalidMsg.New(invalidThreshold)
+		return errors.Wrap(errors.ErrInvalidMsg, invalidThreshold)
 	}
 	for _, a := range c.Sigs {
 		if err := weave.Address(a).Validate(); err != nil {

--- a/x/namecoin/errors_test.go
+++ b/x/namecoin/errors_test.go
@@ -12,6 +12,6 @@ import (
 func TestErrNoSuchWallet(t *testing.T) {
 	hasNonASCII := regexp.MustCompile("[[:^ascii:]]").MatchString
 	addr := crypto.GenPrivKeyEd25519().PublicKey().Address()
-	msg := errors.ErrNotFound.Newf("wallet %s", addr).Error()
+	msg := errors.Wrapf(errors.ErrNotFound, "wallet %s", addr).Error()
 	require.False(t, hasNonASCII(msg), msg)
 }

--- a/x/namecoin/handler.go
+++ b/x/namecoin/handler.go
@@ -116,7 +116,7 @@ func (h TokenHandler) validate(ctx weave.Context, db weave.KVStore,
 
 	// make sure we have permission if the issuer is set
 	if h.issuer == nil || !h.auth.HasAddress(ctx, h.issuer) {
-		return nil, errors.ErrUnauthorized.Newf("Token only issued by %s", h.issuer)
+		return nil, errors.Wrapf(errors.ErrUnauthorized, "Token only issued by %s", h.issuer)
 	}
 
 	// make sure no token there yet
@@ -125,7 +125,7 @@ func (h TokenHandler) validate(ctx weave.Context, db weave.KVStore,
 		return nil, err
 	}
 	if obj != nil {
-		return nil, errors.ErrDuplicate.Newf("token with ticker %s", msg.Ticker)
+		return nil, errors.Wrapf(errors.ErrDuplicate, "token with ticker %s", msg.Ticker)
 	}
 
 	return msg, nil
@@ -170,7 +170,7 @@ func (h SetNameHandler) Deliver(ctx weave.Context, db weave.KVStore,
 		return res, err
 	}
 	if obj == nil {
-		return res, errors.ErrNotFound.Newf("wallet %s", msg.Address)
+		return res, errors.Wrapf(errors.ErrNotFound, "wallet %s", msg.Address)
 	}
 	named := AsNamed(obj)
 	err = named.SetName(msg.Name)
@@ -202,7 +202,7 @@ func (h SetNameHandler) validate(ctx weave.Context, db weave.KVStore,
 
 	// only wallet owner can set the name
 	if !h.auth.HasAddress(ctx, msg.Address) {
-		return nil, errors.ErrUnauthorized.New("Not wallet owner")
+		return nil, errors.Wrap(errors.ErrUnauthorized, "Not wallet owner")
 	}
 
 	return msg, nil

--- a/x/namecoin/init.go
+++ b/x/namecoin/init.go
@@ -70,7 +70,7 @@ func setWallets(db weave.KVStore, gens []GenesisAccount) error {
 	bucket := NewWalletBucket()
 	for _, gen := range gens {
 		if len(gen.Address) != weave.AddressLength {
-			return errors.ErrInvalidInput.Newf("address: %s", gen.Address)
+			return errors.Wrapf(errors.ErrInvalidInput, "address: %s", gen.Address)
 		}
 		wallet, err := WalletWith(gen.Address, gen.Name, gen.Wallet.Coins...)
 		if err != nil {

--- a/x/namecoin/msg.go
+++ b/x/namecoin/msg.go
@@ -40,10 +40,10 @@ func (t *NewTokenMsg) Validate() error {
 		return errors.Wrapf(errors.ErrCurrency, "invalid ticker: %s", t.Ticker)
 	}
 	if !IsTokenName(t.Name) {
-		return errors.ErrInvalidInput.Newf(invalidTokenNameFmt, t.Name)
+		return errors.Wrapf(errors.ErrInvalidInput, invalidTokenNameFmt, t.Name)
 	}
 	if t.SigFigs < minSigFigs || t.SigFigs > maxSigFigs {
-		return errors.ErrInvalidInput.Newf(invalidSigFigsFmt, t.SigFigs)
+		return errors.Wrapf(errors.ErrInvalidInput, invalidSigFigsFmt, t.SigFigs)
 	}
 	return nil
 }
@@ -65,10 +65,10 @@ func (SetWalletNameMsg) Path() string {
 // Validate makes sure that this is sensible
 func (s *SetWalletNameMsg) Validate() error {
 	if len(s.Address) != weave.AddressLength {
-		return errors.ErrInvalidInput.Newf("address: %v", s.Address)
+		return errors.Wrapf(errors.ErrInvalidInput, "address: %v", s.Address)
 	}
 	if !IsWalletName(s.Name) {
-		return errors.ErrInvalidInput.Newf("wallet name: %v", s.Name)
+		return errors.Wrapf(errors.ErrInvalidInput, "wallet name: %v", s.Name)
 	}
 	return nil
 }

--- a/x/namecoin/token.go
+++ b/x/namecoin/token.go
@@ -21,10 +21,10 @@ var _ orm.CloneableData = (*Token)(nil)
 // Validate ensures the token is valid
 func (t *Token) Validate() error {
 	if !IsTokenName(t.Name) {
-		return errors.ErrInvalidInput.Newf(invalidTokenNameFmt, t.Name)
+		return errors.Wrapf(errors.ErrInvalidInput, invalidTokenNameFmt, t.Name)
 	}
 	if t.SigFigs < minSigFigs || t.SigFigs > maxSigFigs {
-		return errors.ErrInvalidInput.Newf(invalidSigFigsFmt, t.SigFigs)
+		return errors.Wrapf(errors.ErrInvalidInput, invalidSigFigsFmt, t.SigFigs)
 	}
 	return nil
 }
@@ -101,7 +101,7 @@ func (b TokenBucket) Save(db weave.KVStore, obj orm.Object) error {
 	}
 	name := string(obj.Key())
 	if !coin.IsCC(name) {
-		return errors.ErrInvalidInput.Newf(invalidTokenNameFmt, name)
+		return errors.Wrapf(errors.ErrInvalidInput, invalidTokenNameFmt, name)
 	}
 	return b.Bucket.Save(db, obj)
 }

--- a/x/namecoin/wallet.go
+++ b/x/namecoin/wallet.go
@@ -31,7 +31,7 @@ func (w *Wallet) SetCoins(coins []*coin.Coin) {
 func (w *Wallet) Validate() error {
 	name := w.GetName()
 	if name != "" && !IsWalletName(name) {
-		return errors.ErrInvalidInput.Newf("wallet name: %v", name)
+		return errors.Wrapf(errors.ErrInvalidInput, "wallet name: %v", name)
 	}
 	return cash.XCoins(w).Validate()
 }
@@ -47,10 +47,10 @@ func (w *Wallet) Copy() orm.CloneableData {
 // SetName verifies the name is valid and sets it on the wallet
 func (w *Wallet) SetName(name string) error {
 	if w.Name != "" {
-		return errors.ErrCannotBeModified.New("wallet already has a name")
+		return errors.Wrap(errors.ErrCannotBeModified, "wallet already has a name")
 	}
 	if !IsWalletName(name) {
-		return errors.ErrInvalidInput.Newf("wallet name %s", name)
+		return errors.Wrapf(errors.ErrInvalidInput, "wallet name %s", name)
 	}
 	w.Name = name
 	return nil
@@ -147,11 +147,11 @@ func (b WalletBucket) Save(db weave.KVStore, obj orm.Object) error {
 // simple indexer for Wallet name
 func nameIndex(obj orm.Object) ([]byte, error) {
 	if obj == nil {
-		return nil, errors.ErrInvalidModel.New("nil")
+		return nil, errors.Wrap(errors.ErrInvalidModel, "nil")
 	}
 	wallet, ok := obj.Value().(*Wallet)
 	if !ok {
-		return nil, errors.ErrInvalidModel.New("not wallet")
+		return nil, errors.Wrap(errors.ErrInvalidModel, "not wallet")
 	}
 	// big-endian encoded int64
 	return []byte(wallet.Name), nil

--- a/x/nft/approvals.go
+++ b/x/nft/approvals.go
@@ -69,7 +69,7 @@ func (a ApprovalOptions) EqualsAfterUse(used ApprovalOptions) bool {
 
 func (a ApprovalOptions) Validate() error {
 	if a.Count == 0 || a.Count < UnlimitedCount {
-		return errors.ErrInvalidInput.New("Approval count should either be unlimited or above zero")
+		return errors.Wrap(errors.ErrInvalidInput, "Approval count should either be unlimited or above zero")
 	}
 	return nil
 }
@@ -84,11 +84,11 @@ func (m Approvals) Validate(actionMaps ...map[Action]int32) error {
 		}
 
 		if !isValidAction(action) {
-			return errors.ErrInvalidInput.New(fmt.Sprintf("illegal action: %s", action))
+			return errors.Wrap(errors.ErrInvalidInput, fmt.Sprintf("illegal action: %s", action))
 		}
 		for _, actionMap := range actionMaps {
 			if _, ok := actionMap[action]; ok {
-				return errors.ErrInvalidInput.New(fmt.Sprintf("illegal action: %s", action))
+				return errors.Wrap(errors.ErrInvalidInput, fmt.Sprintf("illegal action: %s", action))
 			}
 		}
 	}

--- a/x/nft/base/handler.go
+++ b/x/nft/base/handler.go
@@ -31,7 +31,7 @@ func asBase(obj orm.Object) (nft.BaseNFT, error) {
 	}
 	x, ok := obj.Value().(nft.BaseNFT)
 	if !ok {
-		return nil, errors.ErrInvalidInput.New(nft.UnsupportedTokenType)
+		return nil, errors.Wrap(errors.ErrInvalidInput, nft.UnsupportedTokenType)
 	}
 	return x, nil
 }
@@ -42,7 +42,7 @@ func loadToken(bucket orm.Bucket, store weave.KVStore, id []byte) (orm.Object, n
 	case err != nil:
 		return nil, nil, err
 	case o == nil:
-		return nil, nil, errors.ErrNotFound.Newf("nft %s", nft.PrintableID(id))
+		return nil, nil, errors.Wrapf(errors.ErrNotFound, "nft %s", nft.PrintableID(id))
 	}
 	t, e := asBase(o)
 	return o, t, e
@@ -84,7 +84,7 @@ func (h *ApprovalOpsHandler) Deliver(ctx weave.Context, store weave.KVStore, tx 
 
 	bucket, ok := h.buckets[msg.GetT()]
 	if !ok {
-		return res, errors.ErrInvalidInput.New(nft.UnsupportedTokenType)
+		return res, errors.Wrap(errors.ErrInvalidInput, nft.UnsupportedTokenType)
 	}
 
 	o, t, err := loadToken(bucket, store, msg.GetID())
@@ -94,7 +94,7 @@ func (h *ApprovalOpsHandler) Deliver(ctx weave.Context, store weave.KVStore, tx 
 
 	actor := nft.FindActor(h.auth, ctx, t, nft.UpdateApprovals)
 	if actor == nil {
-		return res, errors.ErrUnauthorized.New("Needs update approval")
+		return res, errors.Wrap(errors.ErrUnauthorized, "Needs update approval")
 	}
 
 	switch v := msg.(type) {

--- a/x/nft/bucket.go
+++ b/x/nft/bucket.go
@@ -2,6 +2,7 @@ package nft
 
 import (
 	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/orm"
 )
 
@@ -18,11 +19,11 @@ func WithOwnerIndex(bucket orm.Bucket) orm.Bucket {
 
 func ownerIndex(obj orm.Object) ([]byte, error) {
 	if obj == nil {
-		return nil, orm.ErrInvalidIndex.New("nil")
+		return nil, errors.Wrap(orm.ErrInvalidIndex, "nil")
 	}
 	o, ok := obj.Value().(Owned)
 	if !ok {
-		return nil, orm.ErrInvalidIndex.New("unsupported type")
+		return nil, errors.Wrap(orm.ErrInvalidIndex, "unsupported type")
 	}
 	return []byte(o.OwnerAddress()), nil
 }

--- a/x/nft/model.go
+++ b/x/nft/model.go
@@ -10,7 +10,7 @@ var _ orm.CloneableData = (*NonFungibleToken)(nil)
 
 func (m *NonFungibleToken) Validate() error {
 	if !isValidTokenID(m.ID) {
-		return errors.ErrInvalidInput.Newf("id: %s", PrintableID(m.ID))
+		return errors.Wrapf(errors.ErrInvalidInput, "id: %s", PrintableID(m.ID))
 	}
 
 	if err := weave.Address(m.Owner).Validate(); err != nil {

--- a/x/nft/msg.go
+++ b/x/nft/msg.go
@@ -28,10 +28,10 @@ func (m AddApprovalMsg) Validate() error {
 		return err
 	}
 	if !isValidAction(m.Action) {
-		return errors.ErrInvalidInput.New("invalid action")
+		return errors.Wrap(errors.ErrInvalidInput, "invalid action")
 	}
 	if !isValidTokenID(m.ID) {
-		return errors.ErrInvalidInput.New("invalid token ID")
+		return errors.Wrap(errors.ErrInvalidInput, "invalid token ID")
 	}
 	return m.Options.Validate()
 }
@@ -41,10 +41,10 @@ func (m RemoveApprovalMsg) Validate() error {
 		return err
 	}
 	if !isValidAction(m.Action) {
-		return errors.ErrInvalidInput.New("invalid action")
+		return errors.Wrap(errors.ErrInvalidInput, "invalid action")
 	}
 	if !isValidTokenID(m.ID) {
-		return errors.ErrInvalidInput.New("invalid token ID")
+		return errors.Wrap(errors.ErrInvalidInput, "invalid token ID")
 	}
 	return nil
 }

--- a/x/paychan/model.go
+++ b/x/paychan/model.go
@@ -11,28 +11,28 @@ var _ orm.CloneableData = (*PaymentChannel)(nil)
 // Validate ensures the payment channel is valid.
 func (pc *PaymentChannel) Validate() error {
 	if pc.Src == nil {
-		return errors.ErrInvalidModel.New("missing source")
+		return errors.Wrap(errors.ErrInvalidModel, "missing source")
 	}
 	if pc.SenderPubkey == nil {
-		return errors.ErrInvalidModel.New("missing sender public key")
+		return errors.Wrap(errors.ErrInvalidModel, "missing sender public key")
 	}
 	if pc.Recipient == nil {
-		return errors.ErrInvalidModel.New("missing recipient")
+		return errors.Wrap(errors.ErrInvalidModel, "missing recipient")
 	}
 	if pc.Timeout <= 0 {
-		return errors.ErrInvalidModel.New("timeout in the past")
+		return errors.Wrap(errors.ErrInvalidModel, "timeout in the past")
 	}
 	if pc.Total == nil || !pc.Total.IsPositive() {
-		return errors.ErrInvalidModel.New("negative total")
+		return errors.Wrap(errors.ErrInvalidModel, "negative total")
 	}
 	if len(pc.Memo) > 128 {
-		return errors.ErrInvalidModel.New("memo too long")
+		return errors.Wrap(errors.ErrInvalidModel, "memo too long")
 	}
 
 	// Transfer value must not be greater than the Total value represented
 	// by the PaymentChannel.
 	if pc.Transferred == nil || !pc.Transferred.IsNonNegative() || pc.Transferred.Compare(*pc.Total) > 0 {
-		return errors.ErrInvalidModel.New("invalid transferred value")
+		return errors.Wrap(errors.ErrInvalidModel, "invalid transferred value")
 	}
 	return nil
 }
@@ -82,11 +82,11 @@ func (b *PaymentChannelBucket) GetPaymentChannel(db weave.KVStore, paymentChanne
 		return nil, err
 	}
 	if obj == nil || obj.Value() == nil {
-		return nil, errors.ErrNotFound.New("payment channel not found")
+		return nil, errors.Wrap(errors.ErrNotFound, "payment channel not found")
 	}
 	pc, ok := obj.Value().(*PaymentChannel)
 	if !ok {
-		return nil, errors.ErrNotFound.New("payment channel not found")
+		return nil, errors.Wrap(errors.ErrNotFound, "payment channel not found")
 	}
 	return pc, nil
 }

--- a/x/paychan/msg.go
+++ b/x/paychan/msg.go
@@ -17,22 +17,22 @@ const (
 
 func (m *CreatePaymentChannelMsg) Validate() error {
 	if m.Src == nil {
-		return errors.ErrInvalidMsg.New("missing source")
+		return errors.Wrap(errors.ErrInvalidMsg, "missing source")
 	}
 	if m.SenderPubkey == nil {
-		return errors.ErrInvalidMsg.New("missing sender public key")
+		return errors.Wrap(errors.ErrInvalidMsg, "missing sender public key")
 	}
 	if m.Recipient == nil {
-		return errors.ErrInvalidMsg.New("missing recipient")
+		return errors.Wrap(errors.ErrInvalidMsg, "missing recipient")
 	}
 	if m.Total == nil || m.Total.IsZero() {
-		return errors.ErrInvalidMsg.New("invalid total amount")
+		return errors.Wrap(errors.ErrInvalidMsg, "invalid total amount")
 	}
 	if m.Timeout <= 0 {
-		return errors.ErrInvalidMsg.New("invalid timeout value")
+		return errors.Wrap(errors.ErrInvalidMsg, "invalid timeout value")
 	}
 	if len(m.Memo) > 128 {
-		return errors.ErrInvalidMsg.New("memo too long")
+		return errors.Wrap(errors.ErrInvalidMsg, "memo too long")
 	}
 
 	return validateAddresses(m.Recipient, m.Src)
@@ -44,19 +44,19 @@ func (CreatePaymentChannelMsg) Path() string {
 
 func (m *TransferPaymentChannelMsg) Validate() error {
 	if m.Signature == nil {
-		return errors.ErrInvalidMsg.New("missing signature")
+		return errors.Wrap(errors.ErrInvalidMsg, "missing signature")
 	}
 	if m.Payment == nil {
-		return errors.ErrInvalidMsg.New("missing payment")
+		return errors.Wrap(errors.ErrInvalidMsg, "missing payment")
 	}
 	if m.Payment.ChainID == "" {
-		return errors.ErrInvalidMsg.New("missing chain ID")
+		return errors.Wrap(errors.ErrInvalidMsg, "missing chain ID")
 	}
 	if m.Payment.ChannelID == nil {
-		return errors.ErrInvalidMsg.New("missing channel ID")
+		return errors.Wrap(errors.ErrInvalidMsg, "missing channel ID")
 	}
 	if !m.Payment.Amount.IsPositive() {
-		return errors.ErrInvalidMsg.New("invalid amount value")
+		return errors.Wrap(errors.ErrInvalidMsg, "invalid amount value")
 	}
 	return nil
 }
@@ -67,10 +67,10 @@ func (TransferPaymentChannelMsg) Path() string {
 
 func (m *ClosePaymentChannelMsg) Validate() error {
 	if m.ChannelID == nil {
-		return errors.ErrInvalidMsg.New("missing channel ID")
+		return errors.Wrap(errors.ErrInvalidMsg, "missing channel ID")
 	}
 	if len(m.Memo) > 128 {
-		return errors.ErrInvalidMsg.New("memo too long")
+		return errors.Wrap(errors.ErrInvalidMsg, "memo too long")
 	}
 	return nil
 }

--- a/x/sigs/controller.go
+++ b/x/sigs/controller.go
@@ -77,7 +77,7 @@ func VerifySignature(db weave.KVStore, sig *StdSignature,
 
 	user := AsUser(obj)
 	if !user.Pubkey.Verify(toSign, sig.Signature) {
-		return nil, errors.ErrUnauthorized.New("invalid signature")
+		return nil, errors.Wrap(errors.ErrUnauthorized, "invalid signature")
 	}
 
 	err = user.CheckAndIncrementSequence(sig.Sequence)
@@ -105,10 +105,10 @@ the public key signing/verification step
 */
 func BuildSignBytes(signBytes []byte, chainID string, seq int64) ([]byte, error) {
 	if seq < 0 {
-		return nil, ErrInvalidSequence.New("negative")
+		return nil, errors.Wrap(ErrInvalidSequence, "negative")
 	}
 	if !weave.IsValidChainID(chainID) {
-		return nil, errors.ErrInvalidInput.Newf("chain id: %v", chainID)
+		return nil, errors.Wrapf(errors.ErrInvalidInput, "chain id: %v", chainID)
 	}
 
 	// encode nonce as 8 byte, big-endian

--- a/x/sigs/decorator.go
+++ b/x/sigs/decorator.go
@@ -58,7 +58,7 @@ func (d Decorator) Check(ctx weave.Context, store weave.KVStore, tx weave.Tx,
 		}
 	}
 	if len(signers) == 0 && !d.allowMissingSigs {
-		return res, errors.ErrUnauthorized.New("missing signature")
+		return res, errors.Wrap(errors.ErrUnauthorized, "missing signature")
 	}
 
 	ctx = withSigners(ctx, signers)
@@ -80,7 +80,7 @@ func (d Decorator) Deliver(ctx weave.Context, store weave.KVStore, tx weave.Tx,
 		}
 	}
 	if len(signers) == 0 && !d.allowMissingSigs {
-		return res, errors.ErrUnauthorized.New("missing signature")
+		return res, errors.Wrap(errors.ErrUnauthorized, "missing signature")
 	}
 
 	ctx = withSigners(ctx, signers)

--- a/x/sigs/model.go
+++ b/x/sigs/model.go
@@ -3,6 +3,7 @@ package sigs
 import (
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/crypto"
+	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/orm"
 )
 
@@ -19,10 +20,10 @@ var _ orm.CloneableData = (*UserData)(nil)
 func (u *UserData) Validate() error {
 	seq := u.Sequence
 	if seq < 0 {
-		return ErrInvalidSequence.Newf("Seq(%d)", seq)
+		return errors.Wrapf(ErrInvalidSequence, "Seq(%d)", seq)
 	}
 	if seq > 0 && u.Pubkey == nil {
-		return ErrInvalidSequence.Newf("Seq(%d) needs Pubkey", seq)
+		return errors.Wrapf(ErrInvalidSequence, "Seq(%d) needs Pubkey", seq)
 	}
 	return nil
 }
@@ -41,7 +42,7 @@ func (u *UserData) Copy() orm.CloneableData {
 // If not, it will not change the sequence, but return an error
 func (u *UserData) CheckAndIncrementSequence(check int64) error {
 	if u.Sequence != check {
-		return ErrInvalidSequence.Newf("Mismatch expected %d, got %d", check, u.Sequence)
+		return errors.Wrapf(ErrInvalidSequence, "mismatch expected %d, got %d", check, u.Sequence)
 	}
 	u.Sequence++
 	return nil

--- a/x/sigs/tx.go
+++ b/x/sigs/tx.go
@@ -22,13 +22,13 @@ type SignedTx interface {
 func (s *StdSignature) Validate() error {
 	seq := s.GetSequence()
 	if seq < 0 {
-		return ErrInvalidSequence.New("Negative")
+		return errors.Wrap(ErrInvalidSequence, "negative")
 	}
 	if s.Pubkey == nil {
-		return errors.ErrUnauthorized.New("missing public key")
+		return errors.Wrap(errors.ErrUnauthorized, "missing public key")
 	}
 	if s.Signature == nil {
-		return errors.ErrUnauthorized.New("missing signature")
+		return errors.Wrap(errors.ErrUnauthorized, "missing signature")
 	}
 
 	return nil

--- a/x/validators/model.go
+++ b/x/validators/model.go
@@ -70,7 +70,7 @@ func GetAccounts(bucket orm.Bucket, kv weave.KVStore) (*Accounts, error) {
 	}
 
 	if res == nil {
-		return nil, errors.ErrNotFound.New("account")
+		return nil, errors.Wrap(errors.ErrNotFound, "account")
 	}
 	switch t := res.Value().(type) {
 	case *Accounts:

--- a/x/validators/msg.go
+++ b/x/validators/msg.go
@@ -21,10 +21,10 @@ func (*SetValidatorsMsg) Path() string {
 func (m ValidatorUpdate) Validate() error {
 	if len(m.Pubkey.Data) != 32 ||
 		strings.ToLower(m.Pubkey.Type) != "ed25519" {
-		return ErrInvalidPubKey.New(m.Pubkey.Type)
+		return errors.Wrap(ErrInvalidPubKey, m.Pubkey.Type)
 	}
 	if m.Power < 0 {
-		return ErrInvalidPower.Newf("%d", m.Power)
+		return errors.Wrapf(ErrInvalidPower, "%d", m.Power)
 	}
 	return nil
 }
@@ -45,7 +45,7 @@ func (m Pubkey) AsABCI() abci.PubKey {
 
 func (m *SetValidatorsMsg) Validate() error {
 	if len(m.ValidatorUpdates) == 0 {
-		return errors.ErrEmpty.New("validator set")
+		return errors.Wrap(errors.ErrEmpty, "validator set")
 	}
 	for _, v := range m.ValidatorUpdates {
 		if err := v.Validate(); err != nil {


### PR DESCRIPTION
Use `errors.Wrap` and `errors.Wrapf` insteand of `New` and `Newf`
methods. This is a removal of a syntatic sugar.

Using `Wrap` function instead of method allows for consistent usage of
error wrapping. Before it could have been confusing when to use `Wrap`
and when `New`.

resolve #382