### PR TITLE
Run bnsd scenarios in debug mode

### DIFF
--- a/cmd/bnsd/scenarios/main_test.go
+++ b/cmd/bnsd/scenarios/main_test.go
@@ -103,7 +103,7 @@ func delayForRateLimits() {
 }
 
 func initApp(config *cfg.Config, addr weave.Address) (abci.Application, error) {
-	bnsd, err := app.GenerateApp(config.RootDir, logger, false)
+	bnsd, err := app.GenerateApp(config.RootDir, logger, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When running bnsd scenarios and using local server instance run it in
debug mode (the server). This will provide better insight into failures.

Part of https://github.com/iov-one/weave/issues/363