### PR TITLE
 Extend multisig contract with weights

### DIFF
--- a/cmd/bnsd/scenarios/main_test.go
+++ b/cmd/bnsd/scenarios/main_test.go
@@ -159,7 +159,9 @@ func initGenesis(filename string, addr weave.Address) (*tm.GenesisDoc, error) {
 		},
 		"multisig": []interface{}{
 			dict{
-				"sigs":                 []weave.Address{addr},
+				"participants": []interface{}{
+					dict{"power": 1, "signature": addr},
+				},
 				"activation_threshold": 1,
 				"admin_threshold":      1,
 			},

--- a/weavetest/handlers.go
+++ b/weavetest/handlers.go
@@ -1,6 +1,8 @@
 package weavetest
 
-import "github.com/iov-one/weave"
+import (
+	"github.com/iov-one/weave"
+)
 
 // Handler implements a mock of weave.Handler
 //

--- a/weavetest/results.pb.go
+++ b/weavetest/results.pb.go
@@ -21,8 +21,8 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
-// ResultSet contains a list of keys or values. This is binary compatible with
-// weave/app.ResultSet
+// ResultSet contains a list of keys or values. This is a copy of app/ResultSet
+// and therefore it is binary compatible with it. Copied to avoid import.
 type ResultSet struct {
 	Results [][]byte `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
 }

--- a/x/multisig/codec.pb.go
+++ b/x/multisig/codec.pb.go
@@ -7,6 +7,7 @@ import (
 	fmt "fmt"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
+	github_com_iov_one_weave "github.com/iov-one/weave"
 	io "io"
 	math "math"
 )
@@ -23,12 +24,17 @@ var _ = math.Inf
 const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
 type Contract struct {
-	// addresses to control it
-	Sigs [][]byte `protobuf:"bytes,1,rep,name=sigs,proto3" json:"sigs,omitempty"`
-	// threshold needed to sign to activate it
-	ActivationThreshold int64 `protobuf:"varint,2,opt,name=activation_threshold,json=activationThreshold,proto3" json:"activation_threshold,omitempty"`
-	// threshold needed to sign to change it
-	AdminThreshold int64 `protobuf:"varint,3,opt,name=admin_threshold,json=adminThreshold,proto3" json:"admin_threshold,omitempty"`
+	// Participants defines a list of all signatures that are allowed to sign the
+	// contract.
+	Participants []*Participant `protobuf:"bytes,1,rep,name=participants,proto3" json:"participants,omitempty"`
+	// Activation threshold defines the minimal weight value that must be
+	// provided from participants in order to activate the contract. Weight is
+	// computed as the sum of weights of all participating signatures.
+	ActivationThreshold Weight `protobuf:"varint,2,opt,name=activation_threshold,json=activationThreshold,proto3,casttype=Weight" json:"activation_threshold,omitempty"`
+	// Admin threshold defines the minimal weight value that must be provided
+	// from participants in order to administrate the contract. Weight is
+	// computed as the sum of weights of all participating signatures.
+	AdminThreshold Weight `protobuf:"varint,3,opt,name=admin_threshold,json=adminThreshold,proto3,casttype=Weight" json:"admin_threshold,omitempty"`
 }
 
 func (m *Contract) Reset()         { *m = Contract{} }
@@ -64,41 +70,92 @@ func (m *Contract) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_Contract proto.InternalMessageInfo
 
-func (m *Contract) GetSigs() [][]byte {
+func (m *Contract) GetParticipants() []*Participant {
 	if m != nil {
-		return m.Sigs
+		return m.Participants
 	}
 	return nil
 }
 
-func (m *Contract) GetActivationThreshold() int64 {
+func (m *Contract) GetActivationThreshold() Weight {
 	if m != nil {
 		return m.ActivationThreshold
 	}
 	return 0
 }
 
-func (m *Contract) GetAdminThreshold() int64 {
+func (m *Contract) GetAdminThreshold() Weight {
 	if m != nil {
 		return m.AdminThreshold
 	}
 	return 0
 }
 
+// Participant clubs together a signature with a weight. The greater the weight
+// the greater the power of a signature.
+type Participant struct {
+	Signature github_com_iov_one_weave.Address `protobuf:"bytes,1,opt,name=signature,proto3,casttype=github.com/iov-one/weave.Address" json:"signature,omitempty"`
+	Power     Weight                           `protobuf:"varint,2,opt,name=power,proto3,casttype=Weight" json:"power,omitempty"`
+}
+
+func (m *Participant) Reset()         { *m = Participant{} }
+func (m *Participant) String() string { return proto.CompactTextString(m) }
+func (*Participant) ProtoMessage()    {}
+func (*Participant) Descriptor() ([]byte, []int) {
+	return fileDescriptor_e5080d98b87cf9a7, []int{1}
+}
+func (m *Participant) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Participant) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Participant.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalTo(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Participant) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Participant.Merge(m, src)
+}
+func (m *Participant) XXX_Size() int {
+	return m.Size()
+}
+func (m *Participant) XXX_DiscardUnknown() {
+	xxx_messageInfo_Participant.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Participant proto.InternalMessageInfo
+
+func (m *Participant) GetSignature() github_com_iov_one_weave.Address {
+	if m != nil {
+		return m.Signature
+	}
+	return nil
+}
+
+func (m *Participant) GetPower() Weight {
+	if m != nil {
+		return m.Power
+	}
+	return 0
+}
+
 type CreateContractMsg struct {
-	// addresses to control it
-	Sigs [][]byte `protobuf:"bytes,1,rep,name=sigs,proto3" json:"sigs,omitempty"`
-	// threshold needed to sign to activate it
-	ActivationThreshold int64 `protobuf:"varint,2,opt,name=activation_threshold,json=activationThreshold,proto3" json:"activation_threshold,omitempty"`
-	// threshold needed to sign to change it
-	AdminThreshold int64 `protobuf:"varint,3,opt,name=admin_threshold,json=adminThreshold,proto3" json:"admin_threshold,omitempty"`
+	Participants        []*Participant `protobuf:"bytes,1,rep,name=participants,proto3" json:"participants,omitempty"`
+	ActivationThreshold Weight         `protobuf:"varint,2,opt,name=activation_threshold,json=activationThreshold,proto3,casttype=Weight" json:"activation_threshold,omitempty"`
+	AdminThreshold      Weight         `protobuf:"varint,3,opt,name=admin_threshold,json=adminThreshold,proto3,casttype=Weight" json:"admin_threshold,omitempty"`
 }
 
 func (m *CreateContractMsg) Reset()         { *m = CreateContractMsg{} }
 func (m *CreateContractMsg) String() string { return proto.CompactTextString(m) }
 func (*CreateContractMsg) ProtoMessage()    {}
 func (*CreateContractMsg) Descriptor() ([]byte, []int) {
-	return fileDescriptor_e5080d98b87cf9a7, []int{1}
+	return fileDescriptor_e5080d98b87cf9a7, []int{2}
 }
 func (m *CreateContractMsg) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -127,21 +184,21 @@ func (m *CreateContractMsg) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_CreateContractMsg proto.InternalMessageInfo
 
-func (m *CreateContractMsg) GetSigs() [][]byte {
+func (m *CreateContractMsg) GetParticipants() []*Participant {
 	if m != nil {
-		return m.Sigs
+		return m.Participants
 	}
 	return nil
 }
 
-func (m *CreateContractMsg) GetActivationThreshold() int64 {
+func (m *CreateContractMsg) GetActivationThreshold() Weight {
 	if m != nil {
 		return m.ActivationThreshold
 	}
 	return 0
 }
 
-func (m *CreateContractMsg) GetAdminThreshold() int64 {
+func (m *CreateContractMsg) GetAdminThreshold() Weight {
 	if m != nil {
 		return m.AdminThreshold
 	}
@@ -149,21 +206,17 @@ func (m *CreateContractMsg) GetAdminThreshold() int64 {
 }
 
 type UpdateContractMsg struct {
-	// contract id
-	Id []byte `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	// addresses to control it
-	Sigs [][]byte `protobuf:"bytes,2,rep,name=sigs,proto3" json:"sigs,omitempty"`
-	// threshold needed to sign to activate it
-	ActivationThreshold int64 `protobuf:"varint,3,opt,name=activation_threshold,json=activationThreshold,proto3" json:"activation_threshold,omitempty"`
-	// threshold needed to sign to change it
-	AdminThreshold int64 `protobuf:"varint,4,opt,name=admin_threshold,json=adminThreshold,proto3" json:"admin_threshold,omitempty"`
+	ContractID          []byte         `protobuf:"bytes,1,opt,name=contract_id,json=contractId,proto3" json:"contract_id,omitempty"`
+	Participants        []*Participant `protobuf:"bytes,2,rep,name=participants,proto3" json:"participants,omitempty"`
+	ActivationThreshold Weight         `protobuf:"varint,3,opt,name=activation_threshold,json=activationThreshold,proto3,casttype=Weight" json:"activation_threshold,omitempty"`
+	AdminThreshold      Weight         `protobuf:"varint,4,opt,name=admin_threshold,json=adminThreshold,proto3,casttype=Weight" json:"admin_threshold,omitempty"`
 }
 
 func (m *UpdateContractMsg) Reset()         { *m = UpdateContractMsg{} }
 func (m *UpdateContractMsg) String() string { return proto.CompactTextString(m) }
 func (*UpdateContractMsg) ProtoMessage()    {}
 func (*UpdateContractMsg) Descriptor() ([]byte, []int) {
-	return fileDescriptor_e5080d98b87cf9a7, []int{2}
+	return fileDescriptor_e5080d98b87cf9a7, []int{3}
 }
 func (m *UpdateContractMsg) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -192,28 +245,28 @@ func (m *UpdateContractMsg) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_UpdateContractMsg proto.InternalMessageInfo
 
-func (m *UpdateContractMsg) GetId() []byte {
+func (m *UpdateContractMsg) GetContractID() []byte {
 	if m != nil {
-		return m.Id
+		return m.ContractID
 	}
 	return nil
 }
 
-func (m *UpdateContractMsg) GetSigs() [][]byte {
+func (m *UpdateContractMsg) GetParticipants() []*Participant {
 	if m != nil {
-		return m.Sigs
+		return m.Participants
 	}
 	return nil
 }
 
-func (m *UpdateContractMsg) GetActivationThreshold() int64 {
+func (m *UpdateContractMsg) GetActivationThreshold() Weight {
 	if m != nil {
 		return m.ActivationThreshold
 	}
 	return 0
 }
 
-func (m *UpdateContractMsg) GetAdminThreshold() int64 {
+func (m *UpdateContractMsg) GetAdminThreshold() Weight {
 	if m != nil {
 		return m.AdminThreshold
 	}
@@ -222,6 +275,7 @@ func (m *UpdateContractMsg) GetAdminThreshold() int64 {
 
 func init() {
 	proto.RegisterType((*Contract)(nil), "multisig.Contract")
+	proto.RegisterType((*Participant)(nil), "multisig.Participant")
 	proto.RegisterType((*CreateContractMsg)(nil), "multisig.CreateContractMsg")
 	proto.RegisterType((*UpdateContractMsg)(nil), "multisig.UpdateContractMsg")
 }
@@ -229,23 +283,30 @@ func init() {
 func init() { proto.RegisterFile("x/multisig/codec.proto", fileDescriptor_e5080d98b87cf9a7) }
 
 var fileDescriptor_e5080d98b87cf9a7 = []byte{
-	// 255 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0xab, 0xd0, 0xcf, 0x2d,
-	0xcd, 0x29, 0xc9, 0x2c, 0xce, 0x4c, 0xd7, 0x4f, 0xce, 0x4f, 0x49, 0x4d, 0xd6, 0x2b, 0x28, 0xca,
-	0x2f, 0xc9, 0x17, 0xe2, 0x80, 0x89, 0x4a, 0xe9, 0xa6, 0x67, 0x96, 0x64, 0x94, 0x26, 0xe9, 0x25,
-	0xe7, 0xe7, 0xea, 0xa7, 0xe7, 0xa7, 0xe7, 0xeb, 0x83, 0x15, 0x24, 0x95, 0xa6, 0x81, 0x79, 0x60,
-	0x0e, 0x98, 0x05, 0xd1, 0xa8, 0x54, 0xc5, 0xc5, 0xe1, 0x9c, 0x9f, 0x57, 0x52, 0x94, 0x98, 0x5c,
-	0x22, 0x24, 0xc4, 0xc5, 0x52, 0x9c, 0x99, 0x5e, 0x2c, 0xc1, 0xa8, 0xc0, 0xac, 0xc1, 0x13, 0x04,
-	0x66, 0x0b, 0x19, 0x72, 0x89, 0x24, 0x26, 0x97, 0x64, 0x96, 0x25, 0x96, 0x64, 0xe6, 0xe7, 0xc5,
-	0x97, 0x64, 0x14, 0xa5, 0x16, 0x67, 0xe4, 0xe7, 0xa4, 0x48, 0x30, 0x29, 0x30, 0x6a, 0x30, 0x07,
-	0x09, 0x23, 0xe4, 0x42, 0x60, 0x52, 0x42, 0xea, 0x5c, 0xfc, 0x89, 0x29, 0xb9, 0x99, 0xc8, 0xaa,
-	0x99, 0xc1, 0xaa, 0xf9, 0xc0, 0xc2, 0x70, 0x85, 0x4a, 0xcd, 0x8c, 0x5c, 0x82, 0xce, 0x45, 0xa9,
-	0x89, 0x25, 0xa9, 0x30, 0x27, 0xf8, 0x16, 0xa7, 0xd3, 0xdd, 0x15, 0x93, 0x19, 0xb9, 0x04, 0x43,
-	0x0b, 0x52, 0xd0, 0x5c, 0xc1, 0xc7, 0xc5, 0x94, 0x99, 0x22, 0xc1, 0xa8, 0xc0, 0xa8, 0xc1, 0x13,
-	0xc4, 0x94, 0x99, 0x02, 0x77, 0x15, 0x13, 0x11, 0xae, 0x62, 0x26, 0xc9, 0x55, 0x2c, 0xd8, 0x5c,
-	0xe5, 0x24, 0x71, 0xe2, 0x91, 0x1c, 0xe3, 0x85, 0x47, 0x72, 0x8c, 0x0f, 0x1e, 0xc9, 0x31, 0x4e,
-	0x78, 0x2c, 0xc7, 0x70, 0xe1, 0xb1, 0x1c, 0xc3, 0x8d, 0xc7, 0x72, 0x0c, 0x49, 0x6c, 0xe0, 0x88,
-	0x33, 0x06, 0x04, 0x00, 0x00, 0xff, 0xff, 0x69, 0xa7, 0x2f, 0x9f, 0x0b, 0x02, 0x00, 0x00,
+	// 367 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x93, 0x3f, 0x4f, 0xfa, 0x40,
+	0x1c, 0xc6, 0x39, 0xf8, 0xfd, 0x08, 0x7e, 0x41, 0x0c, 0xf5, 0x4f, 0x1a, 0x87, 0xd2, 0x10, 0x07,
+	0x16, 0xda, 0x44, 0x26, 0x07, 0x07, 0x8b, 0x0b, 0x83, 0x89, 0x69, 0x34, 0x8e, 0xe4, 0xe8, 0x9d,
+	0xed, 0x25, 0xd0, 0x6b, 0xee, 0xae, 0xe0, 0xcb, 0xf0, 0xed, 0xb8, 0x3a, 0x39, 0x32, 0x3a, 0x11,
+	0x53, 0x5e, 0x82, 0x1b, 0x93, 0x49, 0xa1, 0x82, 0x62, 0x62, 0xa2, 0x93, 0xdb, 0x3d, 0xf7, 0xfd,
+	0x3c, 0x97, 0xef, 0xf3, 0x24, 0x07, 0x07, 0x77, 0xf6, 0x30, 0x1e, 0x28, 0x26, 0x99, 0x6f, 0x7b,
+	0x9c, 0x50, 0xcf, 0x8a, 0x04, 0x57, 0x5c, 0x2b, 0x65, 0xb7, 0x87, 0x2d, 0x9f, 0xa9, 0x20, 0xee,
+	0x5b, 0x1e, 0x1f, 0xda, 0x3e, 0xf7, 0xb9, 0x9d, 0x02, 0xfd, 0xf8, 0x36, 0x55, 0xa9, 0x48, 0x4f,
+	0x0b, 0x63, 0xe3, 0x01, 0x41, 0xa9, 0xc3, 0x43, 0x25, 0xb0, 0xa7, 0xb4, 0x13, 0xa8, 0x44, 0x58,
+	0x28, 0xe6, 0xb1, 0x08, 0x87, 0x4a, 0xea, 0xc8, 0x2c, 0x34, 0xcb, 0xc7, 0xfb, 0x56, 0xf6, 0xb8,
+	0x75, 0xb9, 0x9a, 0xba, 0x1f, 0x50, 0xed, 0x14, 0xf6, 0xb0, 0xa7, 0xd8, 0x08, 0x2b, 0xc6, 0xc3,
+	0x9e, 0x0a, 0x04, 0x95, 0x01, 0x1f, 0x10, 0x3d, 0x6f, 0xa2, 0xe6, 0xb6, 0x03, 0xf3, 0x69, 0xbd,
+	0x78, 0x43, 0x99, 0x1f, 0x28, 0x77, 0x77, 0xc5, 0x5d, 0x65, 0x98, 0xd6, 0x86, 0x1d, 0x4c, 0x86,
+	0x6c, 0xdd, 0x59, 0xd8, 0x70, 0x56, 0x53, 0xe4, 0xdd, 0xd4, 0x90, 0x50, 0x5e, 0x5b, 0x48, 0x73,
+	0x60, 0x4b, 0x32, 0x3f, 0xc4, 0x2a, 0x16, 0x54, 0x47, 0x26, 0x6a, 0x56, 0x9c, 0xa3, 0xf9, 0xb4,
+	0x6e, 0xae, 0x15, 0xc2, 0xf8, 0xa8, 0xc5, 0x43, 0x6a, 0x8f, 0x29, 0x1e, 0x51, 0xeb, 0x8c, 0x10,
+	0x41, 0xa5, 0x74, 0x57, 0x36, 0xcd, 0x84, 0xff, 0x11, 0x1f, 0x53, 0xf1, 0xc5, 0xde, 0x8b, 0x41,
+	0xe3, 0x11, 0x41, 0xad, 0x23, 0x28, 0x56, 0x34, 0xab, 0xed, 0x42, 0xfa, 0x7f, 0xad, 0xb9, 0x57,
+	0x04, 0xb5, 0xeb, 0x88, 0x7c, 0x0a, 0x61, 0x43, 0xd9, 0x5b, 0xca, 0x1e, 0x23, 0xcb, 0x0a, 0xab,
+	0xc9, 0xb4, 0x0e, 0x19, 0xd5, 0x3d, 0x77, 0x21, 0x43, 0xba, 0x64, 0x23, 0x75, 0xfe, 0xf7, 0xa9,
+	0x0b, 0x3f, 0x4e, 0xfd, 0xef, 0xbb, 0xd4, 0x8e, 0xfe, 0x94, 0x18, 0x68, 0x92, 0x18, 0xe8, 0x25,
+	0x31, 0xd0, 0xfd, 0xcc, 0xc8, 0x4d, 0x66, 0x46, 0xee, 0x79, 0x66, 0xe4, 0xfa, 0xc5, 0xf4, 0x33,
+	0xb4, 0xdf, 0x02, 0x00, 0x00, 0xff, 0xff, 0xcc, 0xdd, 0x34, 0x16, 0x5f, 0x03, 0x00, 0x00,
 }
 
 func (m *Contract) Marshal() (dAtA []byte, err error) {
@@ -263,12 +324,16 @@ func (m *Contract) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.Sigs) > 0 {
-		for _, b := range m.Sigs {
+	if len(m.Participants) > 0 {
+		for _, msg := range m.Participants {
 			dAtA[i] = 0xa
 			i++
-			i = encodeVarintCodec(dAtA, i, uint64(len(b)))
-			i += copy(dAtA[i:], b)
+			i = encodeVarintCodec(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
 		}
 	}
 	if m.ActivationThreshold != 0 {
@@ -280,6 +345,35 @@ func (m *Contract) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x18
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(m.AdminThreshold))
+	}
+	return i, nil
+}
+
+func (m *Participant) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Participant) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Signature) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(len(m.Signature)))
+		i += copy(dAtA[i:], m.Signature)
+	}
+	if m.Power != 0 {
+		dAtA[i] = 0x10
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(m.Power))
 	}
 	return i, nil
 }
@@ -299,12 +393,16 @@ func (m *CreateContractMsg) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.Sigs) > 0 {
-		for _, b := range m.Sigs {
+	if len(m.Participants) > 0 {
+		for _, msg := range m.Participants {
 			dAtA[i] = 0xa
 			i++
-			i = encodeVarintCodec(dAtA, i, uint64(len(b)))
-			i += copy(dAtA[i:], b)
+			i = encodeVarintCodec(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
 		}
 	}
 	if m.ActivationThreshold != 0 {
@@ -335,18 +433,22 @@ func (m *UpdateContractMsg) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.Id) > 0 {
+	if len(m.ContractID) > 0 {
 		dAtA[i] = 0xa
 		i++
-		i = encodeVarintCodec(dAtA, i, uint64(len(m.Id)))
-		i += copy(dAtA[i:], m.Id)
+		i = encodeVarintCodec(dAtA, i, uint64(len(m.ContractID)))
+		i += copy(dAtA[i:], m.ContractID)
 	}
-	if len(m.Sigs) > 0 {
-		for _, b := range m.Sigs {
+	if len(m.Participants) > 0 {
+		for _, msg := range m.Participants {
 			dAtA[i] = 0x12
 			i++
-			i = encodeVarintCodec(dAtA, i, uint64(len(b)))
-			i += copy(dAtA[i:], b)
+			i = encodeVarintCodec(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
 		}
 	}
 	if m.ActivationThreshold != 0 {
@@ -377,9 +479,9 @@ func (m *Contract) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if len(m.Sigs) > 0 {
-		for _, b := range m.Sigs {
-			l = len(b)
+	if len(m.Participants) > 0 {
+		for _, e := range m.Participants {
+			l = e.Size()
 			n += 1 + l + sovCodec(uint64(l))
 		}
 	}
@@ -392,15 +494,31 @@ func (m *Contract) Size() (n int) {
 	return n
 }
 
+func (m *Participant) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Signature)
+	if l > 0 {
+		n += 1 + l + sovCodec(uint64(l))
+	}
+	if m.Power != 0 {
+		n += 1 + sovCodec(uint64(m.Power))
+	}
+	return n
+}
+
 func (m *CreateContractMsg) Size() (n int) {
 	if m == nil {
 		return 0
 	}
 	var l int
 	_ = l
-	if len(m.Sigs) > 0 {
-		for _, b := range m.Sigs {
-			l = len(b)
+	if len(m.Participants) > 0 {
+		for _, e := range m.Participants {
+			l = e.Size()
 			n += 1 + l + sovCodec(uint64(l))
 		}
 	}
@@ -419,13 +537,13 @@ func (m *UpdateContractMsg) Size() (n int) {
 	}
 	var l int
 	_ = l
-	l = len(m.Id)
+	l = len(m.ContractID)
 	if l > 0 {
 		n += 1 + l + sovCodec(uint64(l))
 	}
-	if len(m.Sigs) > 0 {
-		for _, b := range m.Sigs {
-			l = len(b)
+	if len(m.Participants) > 0 {
+		for _, e := range m.Participants {
+			l = e.Size()
 			n += 1 + l + sovCodec(uint64(l))
 		}
 	}
@@ -482,7 +600,132 @@ func (m *Contract) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Sigs", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Participants", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCodec
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Participants = append(m.Participants, &Participant{})
+			if err := m.Participants[len(m.Participants)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ActivationThreshold", wireType)
+			}
+			m.ActivationThreshold = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ActivationThreshold |= Weight(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AdminThreshold", wireType)
+			}
+			m.AdminThreshold = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.AdminThreshold |= Weight(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCodec(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Participant) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCodec
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Participant: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Participant: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Signature", wireType)
 			}
 			var byteLen int
 			for shift := uint(0); ; shift += 7 {
@@ -509,14 +752,16 @@ func (m *Contract) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Sigs = append(m.Sigs, make([]byte, postIndex-iNdEx))
-			copy(m.Sigs[len(m.Sigs)-1], dAtA[iNdEx:postIndex])
+			m.Signature = append(m.Signature[:0], dAtA[iNdEx:postIndex]...)
+			if m.Signature == nil {
+				m.Signature = []byte{}
+			}
 			iNdEx = postIndex
 		case 2:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ActivationThreshold", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Power", wireType)
 			}
-			m.ActivationThreshold = 0
+			m.Power = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowCodec
@@ -526,26 +771,7 @@ func (m *Contract) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ActivationThreshold |= int64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field AdminThreshold", wireType)
-			}
-			m.AdminThreshold = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowCodec
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.AdminThreshold |= int64(b&0x7F) << shift
+				m.Power |= Weight(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -605,9 +831,9 @@ func (m *CreateContractMsg) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Sigs", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Participants", wireType)
 			}
-			var byteLen int
+			var msglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowCodec
@@ -617,23 +843,25 @@ func (m *CreateContractMsg) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= int(b&0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			if byteLen < 0 {
+			if msglen < 0 {
 				return ErrInvalidLengthCodec
 			}
-			postIndex := iNdEx + byteLen
+			postIndex := iNdEx + msglen
 			if postIndex < 0 {
 				return ErrInvalidLengthCodec
 			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Sigs = append(m.Sigs, make([]byte, postIndex-iNdEx))
-			copy(m.Sigs[len(m.Sigs)-1], dAtA[iNdEx:postIndex])
+			m.Participants = append(m.Participants, &Participant{})
+			if err := m.Participants[len(m.Participants)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		case 2:
 			if wireType != 0 {
@@ -649,7 +877,7 @@ func (m *CreateContractMsg) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ActivationThreshold |= int64(b&0x7F) << shift
+				m.ActivationThreshold |= Weight(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -668,7 +896,7 @@ func (m *CreateContractMsg) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.AdminThreshold |= int64(b&0x7F) << shift
+				m.AdminThreshold |= Weight(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -728,7 +956,7 @@ func (m *UpdateContractMsg) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field ContractID", wireType)
 			}
 			var byteLen int
 			for shift := uint(0); ; shift += 7 {
@@ -755,16 +983,16 @@ func (m *UpdateContractMsg) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Id = append(m.Id[:0], dAtA[iNdEx:postIndex]...)
-			if m.Id == nil {
-				m.Id = []byte{}
+			m.ContractID = append(m.ContractID[:0], dAtA[iNdEx:postIndex]...)
+			if m.ContractID == nil {
+				m.ContractID = []byte{}
 			}
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Sigs", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Participants", wireType)
 			}
-			var byteLen int
+			var msglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowCodec
@@ -774,23 +1002,25 @@ func (m *UpdateContractMsg) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= int(b&0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			if byteLen < 0 {
+			if msglen < 0 {
 				return ErrInvalidLengthCodec
 			}
-			postIndex := iNdEx + byteLen
+			postIndex := iNdEx + msglen
 			if postIndex < 0 {
 				return ErrInvalidLengthCodec
 			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Sigs = append(m.Sigs, make([]byte, postIndex-iNdEx))
-			copy(m.Sigs[len(m.Sigs)-1], dAtA[iNdEx:postIndex])
+			m.Participants = append(m.Participants, &Participant{})
+			if err := m.Participants[len(m.Participants)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		case 3:
 			if wireType != 0 {
@@ -806,7 +1036,7 @@ func (m *UpdateContractMsg) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ActivationThreshold |= int64(b&0x7F) << shift
+				m.ActivationThreshold |= Weight(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -825,7 +1055,7 @@ func (m *UpdateContractMsg) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.AdminThreshold |= int64(b&0x7F) << shift
+				m.AdminThreshold |= Weight(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/x/multisig/codec.proto
+++ b/x/multisig/codec.proto
@@ -5,30 +5,35 @@ package multisig;
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 message Contract {
-  // addresses to control it
-  repeated bytes sigs = 1;
-  // threshold needed to sign to activate it
-  int64 activation_threshold = 2;
-  // threshold needed to sign to change it
-  int64 admin_threshold = 3;
+  // Participants defines a list of all signatures that are allowed to sign the
+  // contract.
+  repeated Participant participants = 1;
+  // Activation threshold defines the minimal weight value that must be
+  // provided from participants in order to activate the contract. Weight is
+  // computed as the sum of weights of all participating signatures.
+  uint32 activation_threshold = 2 [(gogoproto.casttype) = "Weight"];
+  // Admin threshold defines the minimal weight value that must be provided
+  // from participants in order to administrate the contract. Weight is
+  // computed as the sum of weights of all participating signatures.
+  uint32 admin_threshold = 3 [(gogoproto.casttype) = "Weight"];
+}
+
+// Participant clubs together a signature with a weight. The greater the weight
+// the greater the power of a signature.
+message Participant {
+  bytes signature = 1 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
+  uint32 power = 2 [(gogoproto.casttype) = "Weight"];
 }
 
 message CreateContractMsg {
-  // addresses to control it
-  repeated bytes sigs = 1;
-  // threshold needed to sign to activate it
-  int64 activation_threshold = 2;
-  // threshold needed to sign to change it
-  int64 admin_threshold = 3;
+  repeated Participant participants = 1;
+  uint32 activation_threshold = 2 [(gogoproto.casttype) = "Weight"];
+  uint32 admin_threshold = 3 [(gogoproto.casttype) = "Weight"];
 }
 
 message UpdateContractMsg {
-  // contract id
-  bytes id = 1;
-  // addresses to control it
-  repeated bytes sigs = 2;
-  // threshold needed to sign to activate it
-  int64 activation_threshold = 3;
-  // threshold needed to sign to change it
-  int64 admin_threshold = 4;
+  bytes contract_id = 1 [(gogoproto.customname) = "ContractID"];
+  repeated Participant participants = 2;
+  uint32 activation_threshold = 3 [(gogoproto.casttype) = "Weight"];
+  uint32 admin_threshold = 4 [(gogoproto.casttype) = "Weight"];
 }

--- a/x/multisig/decorator.go
+++ b/x/multisig/decorator.go
@@ -71,7 +71,8 @@ func (d Decorator) authMultisig(ctx weave.Context, store weave.KVStore, tx weave
 			}
 		}
 		if power < contract.ActivationThreshold {
-			return ctx, errors.Wrapf(errors.ErrUnauthorized, "%d power is not enough", power)
+			return ctx, errors.Wrapf(errors.ErrUnauthorized,
+				"%d power is not enough to activate %q", power, contractID)
 		}
 
 		ctx = withMultisig(ctx, contractID)

--- a/x/multisig/decorator.go
+++ b/x/multisig/decorator.go
@@ -42,7 +42,7 @@ func (d Decorator) Deliver(ctx weave.Context, store weave.KVStore, tx weave.Tx, 
 }
 
 func (d Decorator) authMultisig(ctx weave.Context, store weave.KVStore, tx weave.Tx) (weave.Context, error) {
-	multisigContract, ok := tx.(multiSigTx)
+	multisigContract, ok := tx.(MultiSigTx)
 	if !ok {
 		return ctx, nil
 	}
@@ -78,11 +78,4 @@ func (d Decorator) authMultisig(ctx weave.Context, store weave.KVStore, tx weave
 	}
 
 	return ctx, nil
-}
-
-// multiSigTx is an optional interface for a Tx that allows it to
-// support multisig contract. Multisig authentication can be done only
-// for transactions that do support this interface.
-type multiSigTx interface {
-	GetMultisig() [][]byte
 }

--- a/x/multisig/decorator_test.go
+++ b/x/multisig/decorator_test.go
@@ -159,7 +159,7 @@ type ContractTx struct {
 	MultisigID [][]byte
 }
 
-var _ multiSigTx = ContractTx{}
+var _ MultiSigTx = ContractTx{}
 var _ weave.Tx = ContractTx{}
 
 func (p ContractTx) GetMultisig() [][]byte {

--- a/x/multisig/errors.go
+++ b/x/multisig/errors.go
@@ -1,6 +1,0 @@
-package multisig
-
-var (
-	invalidThreshold    = "activation/change threshold must be lower than or equal to the number of sigs"
-	contractNotFoundFmt = "multisig contract not found contract=%X"
-)

--- a/x/multisig/handlers.go
+++ b/x/multisig/handlers.go
@@ -150,7 +150,8 @@ func (h UpdateContractMsgHandler) validate(ctx weave.Context, db weave.KVStore, 
 		}
 	}
 	if power < contract.AdminThreshold {
-		return msg, errors.Wrapf(errors.ErrUnauthorized, "%d power is not enough", power)
+		return msg, errors.Wrapf(errors.ErrUnauthorized,
+			"%d power is not enough to administrate %q", power, msg.ContractID)
 	}
 
 	if err := msg.Validate(); err != nil {

--- a/x/multisig/handlers_test.go
+++ b/x/multisig/handlers_test.go
@@ -60,7 +60,7 @@ func TestCreateContractHandler(t *testing.T) {
 					{Power: 3, Signature: cindy},
 				},
 				ActivationThreshold: 2,
-				AdminThreshold:      1000,
+				AdminThreshold:      maxWeightValue,
 			},
 		},
 		"cannot create if activation threshold is higher than admin threshold": {
@@ -196,7 +196,7 @@ func TestUpdateContractHandler(t *testing.T) {
 					{Power: 3, Signature: cindy},
 				},
 				ActivationThreshold: 1,
-				AdminThreshold:      10000,
+				AdminThreshold:      maxWeightValue,
 			},
 		},
 		"cannot update if activation threshold is higher than admin threshold": {

--- a/x/multisig/init_test.go
+++ b/x/multisig/init_test.go
@@ -18,13 +18,13 @@ func TestGenesisKey(t *testing.T) {
 		{
 			"multisig": [
 				{
-					"sigs": [
-						"e4c7e4c71a3b301a2521753ddd1d2c26fd6fe1bf",
-						"904bc35e341b428d4faa535022b553efbc443d49",
-						"91d66344d78599b66e1b504db958b1b07a8f5049"
+					"participants": [
+						{"power": 1, "signature": "e4c7e4c71a3b301a2521753ddd1d2c26fd6fe1bf"},
+						{"power": 2, "signature": "904bc35e341b428d4faa535022b553efbc443d49"},
+						{"power": 7, "signature": "91d66344d78599b66e1b504db958b1b07a8f5049"}
 					],
 					"activation_threshold": 2,
-					"admin_threshold": 2
+					"admin_threshold": 3
 				}
 			]
 		}
@@ -53,19 +53,19 @@ func TestGenesisKey(t *testing.T) {
 	if !ok {
 		t.Errorf("invalid object stored: %T", obj)
 	}
-	if want, got := int64(2), c.ActivationThreshold; want != got {
+	if want, got := Weight(2), c.ActivationThreshold; want != got {
 		t.Errorf("want activation threshold %d, got %d", want, got)
 	}
-	if want, got := int64(2), c.AdminThreshold; want != got {
+	if want, got := Weight(3), c.AdminThreshold; want != got {
 		t.Errorf("want admin threshold %d, got %d", want, got)
 	}
-	wantSigs := [][]byte{
-		fromHex(t, "e4c7e4c71a3b301a2521753ddd1d2c26fd6fe1bf"),
-		fromHex(t, "904bc35e341b428d4faa535022b553efbc443d49"),
-		fromHex(t, "91d66344d78599b66e1b504db958b1b07a8f5049"),
+	wantParticipants := []*Participant{
+		{Power: 1, Signature: fromHex(t, "e4c7e4c71a3b301a2521753ddd1d2c26fd6fe1bf")},
+		{Power: 2, Signature: fromHex(t, "904bc35e341b428d4faa535022b553efbc443d49")},
+		{Power: 7, Signature: fromHex(t, "91d66344d78599b66e1b504db958b1b07a8f5049")},
 	}
-	if !reflect.DeepEqual(wantSigs, c.Sigs) {
-		t.Errorf("want signatures \n%#v\n, got \n%#v", wantSigs, c.Sigs)
+	if !reflect.DeepEqual(wantParticipants, c.Participants) {
+		t.Errorf("want participants \n%#v\n, got \n%#v", wantParticipants, c.Participants)
 	}
 
 }

--- a/x/multisig/model.go
+++ b/x/multisig/model.go
@@ -13,32 +13,42 @@ const (
 	SequenceName = "id"
 )
 
-// enforce that Contract fulfils desired interface compile-time
-var _ orm.CloneableData = (*Contract)(nil)
+// Weight represents the strength of a signature.
+type Weight uint32
 
-// Validate enforces sigs and threshold boundaries
-func (c *Contract) Validate() error {
-	if len(c.Sigs) == 0 {
-		return errors.Wrap(errors.ErrInvalidMsg, "missing sigs")
-	}
-	if c.ActivationThreshold <= 0 || int(c.ActivationThreshold) > len(c.Sigs) {
-		return errors.Wrap(errors.ErrInvalidMsg, invalidThreshold)
-	}
-	if c.AdminThreshold <= 0 {
-		return errors.Wrap(errors.ErrInvalidMsg, invalidThreshold)
-	}
-	for _, a := range c.Sigs {
-		if err := weave.Address(a).Validate(); err != nil {
-			return err
-		}
+func (w Weight) Validate() error {
+	if w < 1 {
+		return errors.Wrap(errors.ErrInvalidState,
+			"weight must be greater than 0")
 	}
 	return nil
 }
 
-// Copy makes a new Profile with the same data
+var _ orm.CloneableData = (*Contract)(nil)
+
+func (c *Contract) Validate() error {
+	switch n := len(c.Participants); {
+	case n == 0:
+		return errors.Wrap(errors.ErrInvalidMsg, "no participants")
+	case n > 100:
+		return errors.Wrap(errors.ErrInvalidMsg, "too many participants")
+	}
+	return validateWeights(errors.ErrInvalidModel,
+		c.Participants, c.ActivationThreshold, c.AdminThreshold)
+}
+
 func (c *Contract) Copy() orm.CloneableData {
+	ps := make([]*Participant, 0, len(c.Participants))
+	for _, p := range c.Participants {
+		sig := make(weave.Address, len(p.Signature))
+		copy(sig, p.Signature)
+		ps = append(ps, &Participant{
+			Signature: sig,
+			Power:     p.Power,
+		})
+	}
 	return &Contract{
-		Sigs:                c.Sigs,
+		Participants:        ps,
 		ActivationThreshold: c.ActivationThreshold,
 		AdminThreshold:      c.AdminThreshold,
 	}
@@ -76,4 +86,22 @@ func (b ContractBucket) Save(db weave.KVStore, obj orm.Object) error {
 func (b ContractBucket) Build(db weave.KVStore, c *Contract) orm.Object {
 	key := b.idSeq.NextVal(db)
 	return orm.NewSimpleObj(key, c)
+}
+
+// GetContract returns a contract with given ID.
+func (b ContractBucket) GetContract(store weave.KVStore, contractID []byte) (*Contract, error) {
+	obj, err := b.Get(store, contractID)
+	if err != nil {
+		return nil, errors.Wrap(err, "bucket lookup")
+	}
+
+	if obj == nil || obj.Value() == nil {
+		return nil, errors.Wrapf(errors.ErrNotFound, "contract id %q", contractID)
+	}
+
+	c, ok := obj.Value().(*Contract)
+	if !ok {
+		return nil, errors.Wrapf(errors.ErrInvalidModel, "invalid type: %T", obj.Value())
+	}
+	return c, nil
 }

--- a/x/multisig/model.go
+++ b/x/multisig/model.go
@@ -11,6 +11,11 @@ const (
 	BucketName = "contracts"
 	// SequenceName is an auto-increment ID counter for contracts
 	SequenceName = "id"
+
+	// Maximum value a weight value can be set to. This is uint8 capacity
+	// but because we use protobuf for serialization, weight is represented
+	// by uint32 and we must manually force the limit.
+	maxWeightValue = 255
 )
 
 // Weight represents the strength of a signature.
@@ -20,6 +25,10 @@ func (w Weight) Validate() error {
 	if w < 1 {
 		return errors.Wrap(errors.ErrInvalidState,
 			"weight must be greater than 0")
+	}
+	if w > maxWeightValue {
+		return errors.Wrapf(errors.ErrOverflow,
+			"weight is %d and must not be greater than %d", w, maxWeightValue)
 	}
 	return nil
 }

--- a/x/multisig/model.go
+++ b/x/multisig/model.go
@@ -29,9 +29,9 @@ var _ orm.CloneableData = (*Contract)(nil)
 func (c *Contract) Validate() error {
 	switch n := len(c.Participants); {
 	case n == 0:
-		return errors.Wrap(errors.ErrInvalidMsg, "no participants")
-	case n > 100:
-		return errors.Wrap(errors.ErrInvalidMsg, "too many participants")
+		return errors.Wrap(errors.ErrInvalidModel, "no participants")
+	case n > maxParticipantsAllowed:
+		return errors.Wrap(errors.ErrInvalidModel, "too many participants")
 	}
 	return validateWeights(errors.ErrInvalidModel,
 		c.Participants, c.ActivationThreshold, c.AdminThreshold)

--- a/x/multisig/msg.go
+++ b/x/multisig/msg.go
@@ -10,6 +10,10 @@ const (
 
 	creationCost int64 = 300 // 3x more expensive than SendMsg
 	updateCost   int64 = 150 // Half the creation cost
+
+	// To avoid burning CPU, this is the maximum number of participants
+	// allowed to be part of a single contract.
+	maxParticipantsAllowed = 100
 )
 
 // Path fulfills weave.Msg interface to allow routing
@@ -22,7 +26,7 @@ func (c *CreateContractMsg) Validate() error {
 	switch n := len(c.Participants); {
 	case n == 0:
 		return errors.Wrap(errors.ErrInvalidMsg, "no participants")
-	case n > 100:
+	case n > maxParticipantsAllowed:
 		return errors.Wrap(errors.ErrInvalidMsg, "too many participants")
 	}
 	return validateWeights(errors.ErrInvalidMsg,
@@ -39,7 +43,7 @@ func (c *UpdateContractMsg) Validate() error {
 	switch n := len(c.Participants); {
 	case n == 0:
 		return errors.Wrap(errors.ErrInvalidMsg, "no participants")
-	case n > 100:
+	case n > maxParticipantsAllowed:
 		return errors.Wrap(errors.ErrInvalidMsg, "too many participants")
 	}
 	return validateWeights(errors.ErrInvalidMsg,

--- a/x/multisig/msg.go
+++ b/x/multisig/msg.go
@@ -1,7 +1,6 @@
 package multisig
 
 import (
-	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 )
 
@@ -20,21 +19,14 @@ func (CreateContractMsg) Path() string {
 
 // Validate enforces sigs and threshold boundaries
 func (c *CreateContractMsg) Validate() error {
-	if len(c.Sigs) == 0 {
-		return errors.Wrap(errors.ErrInvalidMsg, "missing sigs")
+	switch n := len(c.Participants); {
+	case n == 0:
+		return errors.Wrap(errors.ErrInvalidMsg, "no participants")
+	case n > 100:
+		return errors.Wrap(errors.ErrInvalidMsg, "too many participants")
 	}
-	if c.ActivationThreshold <= 0 || int(c.ActivationThreshold) > len(c.Sigs) {
-		return errors.Wrap(errors.ErrInvalidMsg, invalidThreshold)
-	}
-	if c.AdminThreshold <= 0 {
-		return errors.Wrap(errors.ErrInvalidMsg, invalidThreshold)
-	}
-	for _, a := range c.Sigs {
-		if err := weave.Address(a).Validate(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return validateWeights(errors.ErrInvalidMsg,
+		c.Participants, c.ActivationThreshold, c.AdminThreshold)
 }
 
 // Path fulfills weave.Msg interface to allow routing
@@ -44,19 +36,62 @@ func (UpdateContractMsg) Path() string {
 
 // Validate enforces sigs and threshold boundaries
 func (c *UpdateContractMsg) Validate() error {
-	if len(c.Sigs) == 0 {
-		return errors.Wrap(errors.ErrInvalidMsg, "missing sigs")
+	switch n := len(c.Participants); {
+	case n == 0:
+		return errors.Wrap(errors.ErrInvalidMsg, "no participants")
+	case n > 100:
+		return errors.Wrap(errors.ErrInvalidMsg, "too many participants")
 	}
-	if c.ActivationThreshold <= 0 || int(c.ActivationThreshold) > len(c.Sigs) {
-		return errors.Wrap(errors.ErrInvalidMsg, invalidThreshold)
+	return validateWeights(errors.ErrInvalidMsg,
+		c.Participants, c.ActivationThreshold, c.AdminThreshold)
+}
+
+// validateWeights returns an error if given participants and thresholds
+// configuration is not valid. This check is done on model and messages so
+// instead of copying the code it is extracted into this function.
+func validateWeights(
+	baseErr error,
+	ps []*Participant,
+	activationThreshold Weight,
+	adminThreshold Weight,
+) error {
+	if len(ps) == 0 {
+		return errors.Wrap(baseErr, "missing participants")
 	}
-	if c.AdminThreshold <= 0 {
-		return errors.Wrap(errors.ErrInvalidMsg, invalidThreshold)
-	}
-	for _, a := range c.Sigs {
-		if err := weave.Address(a).Validate(); err != nil {
-			return err
+
+	for _, p := range ps {
+		if err := p.Power.Validate(); err != nil {
+			return errors.Wrapf(err, "participant %s", p.Signature)
+		}
+		if err := p.Signature.Validate(); err != nil {
+			return errors.Wrapf(err, "participant %s", p.Signature)
 		}
 	}
+	if err := activationThreshold.Validate(); err != nil {
+		return errors.Wrap(err, "activation threshold")
+	}
+	if err := adminThreshold.Validate(); err != nil {
+		return errors.Wrap(err, "admin threshold")
+	}
+
+	var total Weight
+	for _, p := range ps {
+		total += p.Power
+	}
+
+	if activationThreshold > total {
+		return errors.Wrap(baseErr, "activation threshold greater than total power")
+	}
+
+	// adminThreshold can be higher than total power. This can be used to
+	// create contracts that are locked. They can only be activated by
+	// never changed.
+
+	if activationThreshold > adminThreshold {
+		// This configuration does not make any sense. It is easier to
+		// change the multisig as an admin than to activate it.
+		return errors.Wrap(baseErr, "activation threshold greater than the admin threshold")
+	}
+
 	return nil
 }

--- a/x/multisig/tx.go
+++ b/x/multisig/tx.go
@@ -1,7 +1,0 @@
-package multisig
-
-// MultiSigTx is an optional interface for a Tx that allows
-// it to support multisig contract
-type MultiSigTx interface {
-	GetMultisig() [][]byte
-}

--- a/x/multisig/tx.go
+++ b/x/multisig/tx.go
@@ -1,0 +1,8 @@
+package multisig
+
+// MultiSigTx is an optional interface for a Tx that allows it to
+// support multisig contract. Multisig authentication can be done only
+// for transactions that do support this interface.
+type MultiSigTx interface {
+	GetMultisig() [][]byte
+}


### PR DESCRIPTION
`x/multisig` extension was updated and now each signature is having a
weight that defines what is the power of that signature.

- each signature power/weight must be greater than 0,
- activation threshold must be less or equal to the sum of all signature
  powers,
- admin threshold can be greater than the sum of all signature powers.
  This can be used to create a contract that can be only activated but
  never changed,
- multisig contract must have at least one participant/signature
  declared,
- maximum number of participants is 100 in order to prevent CPU burning,


- [ ] :bell: Update the CHANGELOG and include the breaking change description. 

resolve #285