### PR TITLE
Change benchmark tables

### DIFF
--- a/cmd/bnsd/app/app_performance_test.go
+++ b/cmd/bnsd/app/app_performance_test.go
@@ -27,7 +27,7 @@ func BenchmarkBnsdEmptyBlock(b *testing.B) {
 		},
 	}
 
-	bnsd, _ := newBnsd(b)
+	bnsd, cleanup := newBnsd(b)
 	runner := weavetest.NewWeaveRunner(b, bnsd, "mychain")
 	runner.InitChain(genesis)
 
@@ -43,6 +43,9 @@ func BenchmarkBnsdEmptyBlock(b *testing.B) {
 			b.Fatal("unexpected change state")
 		}
 	}
+
+	b.StopTimer()
+	cleanup()
 }
 
 func BenchmarkBNSDSendToken(b *testing.B) {
@@ -112,7 +115,7 @@ func BenchmarkBNSDSendToken(b *testing.B) {
 
 	for testName, tc := range cases {
 		b.Run(testName, func(b *testing.B) {
-			bnsd, _ := newBnsd(b)
+			bnsd, cleanup := newBnsd(b)
 			runner := weavetest.NewWeaveRunner(b, bnsd, "mychain")
 			runner.InitChain(makeGenesis(tc.fee))
 
@@ -156,6 +159,8 @@ func BenchmarkBNSDSendToken(b *testing.B) {
 			blocks := weavetest.SplitTxs(txs, tc.txPerBlock)
 			b.ResetTimer()
 			runner.ProcessAllTxs(blocks)
+			b.StopTimer()
+			cleanup()
 		})
 	}
 }

--- a/cmd/bnsd/app/app_performance_test.go
+++ b/cmd/bnsd/app/app_performance_test.go
@@ -40,7 +40,7 @@ func BenchmarkBnsdEmptyBlock(b *testing.B) {
 			return nil
 		})
 		if changed {
-			b.Fatalf("unexpected change state")
+			b.Fatal("unexpected change state")
 		}
 	}
 }
@@ -160,7 +160,7 @@ func BenchmarkBNSDSendToken(b *testing.B) {
 }
 
 // newBnsd returns the test application, along with a function to delete all testdata at the end
-func newBnsd(t weavetest.Tester) (abci.Application, func()) {
+func newBnsd(t testing.TB) (abci.Application, func()) {
 	t.Helper()
 
 	homeDir, err := ioutil.TempDir("", "bnsd_performance_home")

--- a/cmd/bnsd/app/app_performance_test.go
+++ b/cmd/bnsd/app/app_performance_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/coin"
-	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/weavetest"
 	"github.com/iov-one/weave/x/cash"
 	"github.com/iov-one/weave/x/sigs"
@@ -42,7 +41,7 @@ func BenchmarkBnsdEmptyBlock(b *testing.B) {
 			return nil
 		})
 		if changed {
-			b.Fatal("unexpected change state")
+			b.Fatalf("unexpected change state")
 		}
 	}
 }
@@ -155,57 +154,9 @@ func BenchmarkBNSDSendToken(b *testing.B) {
 			}
 
 			b.ResetTimer()
-			ProcessAllTxs(runner, b, txs, tc.txPerBlock, true)
+			runner.ProcessAllTxs(txs, tc.txPerBlock, true)
 		})
 	}
-}
-
-func ProcessAllTxs(runner *weavetest.WeaveRunner, b *testing.B, txs []weave.Tx, txPerBlock int, shouldChange bool) {
-	numBlocks := NumBlocks(len(txs), txPerBlock)
-	for i := 0; i < numBlocks; i++ {
-		changed := runner.InBlock(func(wapp weavetest.WeaveApp) error {
-			numTxs := TxsInBlock(len(txs), txPerBlock, i == numBlocks-1)
-			offset := i * txPerBlock
-
-			// let's do all CheckTx first
-			for j := 0; j < numTxs; j++ {
-				tx := txs[offset+j]
-				if err := wapp.CheckTx(tx); err != nil {
-					return errors.Wrap(err, "cannot check tx")
-				}
-			}
-			// then all DeliverTx... as would be done in reality
-			for j := 0; j < numTxs; j++ {
-				tx := txs[offset+j]
-				if err := wapp.DeliverTx(tx); err != nil {
-					return errors.Wrap(err, "cannot deliver tx")
-				}
-			}
-			return nil
-		})
-		if changed != shouldChange {
-			b.Fatal("unexpected change state")
-		}
-	}
-}
-
-// NumBlocks returns total number of blocks for benchmarks that split b.N
-// into many smaller blocks
-func NumBlocks(totalTx, txPerBlock int) int {
-	runs := totalTx / txPerBlock
-	if totalTx%txPerBlock > 0 {
-		return runs + 1
-	}
-	return runs
-}
-
-// TxsInBlock will return the txPerBlock, unless this is the last block and there
-// is some remainder (so runs+1 above), where it will only return that extra, not a full block
-func TxsInBlock(totalTx, txPerBlock int, lastBlock bool) int {
-	if lastBlock && (totalTx%txPerBlock > 0) {
-		return totalTx % txPerBlock
-	}
-	return txPerBlock
 }
 
 // newBnsd returns the test application, along with a function to delete all testdata at the end
@@ -226,6 +177,8 @@ func newBnsd(t weavetest.Tester) (abci.Application, func()) {
 	}
 	return bnsd, cleanup
 }
+
+//----- TODO: move Nonce to a better location.... ----//
 
 // Nonce has a client/address pair, queries for the nonce
 // and caches recent nonce locally to quickly sign

--- a/cmd/bnsd/app/app_performance_test.go
+++ b/cmd/bnsd/app/app_performance_test.go
@@ -153,8 +153,9 @@ func BenchmarkBNSDSendToken(b *testing.B) {
 				txs[k] = tx
 			}
 
+			blocks := weavetest.SplitTxs(txs, tc.txPerBlock)
 			b.ResetTimer()
-			runner.ProcessAllTxs(txs, tc.txPerBlock, true)
+			runner.ProcessAllTxs(blocks)
 		})
 	}
 }


### PR DESCRIPTION
Some changes to how you were doing table-driven benchmarks.

Separate setup code for each different case (empty block, sendtx, distribute, etc...)

Tables to control parameters to cover larger spectrum of the performance (like multiple tx per block, with/without fees, num of multisig participants, etc)