### PR TITLE
More detailed benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ endif
 # protoc: protodocs
 protoc:
 	protoc --gogofaster_out=. $(PROTOC_FLAGS) app/*.proto
+	protoc --gogofaster_out=. $(PROTOC_FLAGS) weavetest/*.proto
 	protoc --gogofaster_out=. $(PROTOC_FLAGS) coin/*.proto
 	protoc --gogofaster_out=. $(PROTOC_FLAGS) crypto/*.proto
 	protoc --gogofaster_out=. $(PROTOC_FLAGS) orm/*.proto

--- a/cmd/bnsd/app/app_performance_test.go
+++ b/cmd/bnsd/app/app_performance_test.go
@@ -123,6 +123,11 @@ func BenchmarkBNSDSendToken(b *testing.B) {
 			fee:        coin.Coin{Whole: 1, Ticker: "IOV"},
 			strategy:   weavetest.DeliverOnly,
 		},
+		"100 tx, with fee (deliver with precheck)": {
+			txPerBlock: 100,
+			fee:        coin.Coin{Whole: 1, Ticker: "IOV"},
+			strategy:   weavetest.DeliverWithPrecheck,
+		},
 	}
 
 	for testName, tc := range cases {

--- a/cmd/bnsd/app/app_performance_test.go
+++ b/cmd/bnsd/app/app_performance_test.go
@@ -86,30 +86,42 @@ func BenchmarkBNSDSendToken(b *testing.B) {
 	cases := map[string]struct {
 		txPerBlock int
 		fee        coin.Coin
+		strategy   weavetest.Strategy
 	}{
 		"1 tx, no fee": {
 			txPerBlock: 1,
 			fee:        coin.Coin{},
+			strategy:   weavetest.CheckAndDeliver,
+		},
+		"1 tx, no fee (deliver only)": {
+			txPerBlock: 1,
+			fee:        coin.Coin{},
+			strategy:   weavetest.DeliverOnly,
 		},
 		"10 tx, no fee": {
 			txPerBlock: 10,
 			fee:        coin.Coin{},
+			strategy:   weavetest.CheckAndDeliver,
 		},
 		"100 tx, no fee": {
 			txPerBlock: 100,
 			fee:        coin.Coin{},
-		},
-		"1 tx, with fee": {
-			txPerBlock: 1,
-			fee:        coin.Coin{Whole: 1, Ticker: "IOV"},
-		},
-		"10 tx, with fee": {
-			txPerBlock: 10,
-			fee:        coin.Coin{Whole: 1, Ticker: "IOV"},
+			strategy:   weavetest.CheckAndDeliver,
 		},
 		"100 tx, with fee": {
 			txPerBlock: 100,
 			fee:        coin.Coin{Whole: 1, Ticker: "IOV"},
+			strategy:   weavetest.CheckAndDeliver,
+		},
+		// "100 tx, with fee (check only)": {
+		// 	txPerBlock: 100,
+		// 	fee:        coin.Coin{Whole: 1, Ticker: "IOV"},
+		// 	strategy:   weavetest.CheckOnly,
+		// },
+		"100 tx, with fee (deliver only)": {
+			txPerBlock: 100,
+			fee:        coin.Coin{Whole: 1, Ticker: "IOV"},
+			strategy:   weavetest.DeliverOnly,
 		},
 	}
 
@@ -158,7 +170,7 @@ func BenchmarkBNSDSendToken(b *testing.B) {
 
 			blocks := weavetest.SplitTxs(txs, tc.txPerBlock)
 			b.ResetTimer()
-			runner.ProcessAllTxs(blocks)
+			runner.ProcessAllTxs(blocks, tc.strategy)
 			b.StopTimer()
 			cleanup()
 		})

--- a/cmd/bnsd/app/app_performance_test.go
+++ b/cmd/bnsd/app/app_performance_test.go
@@ -113,11 +113,11 @@ func BenchmarkBNSDSendToken(b *testing.B) {
 			fee:        coin.Coin{Whole: 1, Ticker: "IOV"},
 			strategy:   weavetest.CheckAndDeliver,
 		},
-		// "100 tx, with fee (check only)": {
-		// 	txPerBlock: 100,
-		// 	fee:        coin.Coin{Whole: 1, Ticker: "IOV"},
-		// 	strategy:   weavetest.CheckOnly,
-		// },
+		"100 tx, with fee (check only)": {
+			txPerBlock: 100,
+			fee:        coin.Coin{Whole: 1, Ticker: "IOV"},
+			strategy:   weavetest.CheckOnly,
+		},
 		"100 tx, with fee (deliver only)": {
 			txPerBlock: 100,
 			fee:        coin.Coin{Whole: 1, Ticker: "IOV"},
@@ -154,7 +154,6 @@ func BenchmarkBNSDSendToken(b *testing.B) {
 						},
 					},
 				}
-
 				// hmmm.... can we collapse this to the message and one line to get nonce and sign?
 				nonce, err := aliceNonce.Next()
 				if err != nil {
@@ -166,6 +165,11 @@ func BenchmarkBNSDSendToken(b *testing.B) {
 				}
 				tx.Signatures = append(tx.Signatures, sig)
 				txs[k] = tx
+
+				// must reset nonce per block for CheckOnly
+				if tc.strategy == weavetest.CheckOnly && (k+1)%tc.txPerBlock == 0 {
+					aliceNonce = NewNonce(runner, alice)
+				}
 			}
 
 			blocks := weavetest.SplitTxs(txs, tc.txPerBlock)


### PR DESCRIPTION
One more as I was curious....

Allows ProcessAllTxs to do either:

* Check all, then Deliver all per block
* Only check all per block
* Only deliver all per block
* Check all with timer paused, then Deliver all with timer active (most realistic scenario for block time)

Interesting to see that in larger blocks (eg. 100), the time difference between Check and Deliver is minimal.