### PR TITLE
simplify nonce counting in bnsd benchmark

### DIFF
--- a/x/sigs/nonce.go
+++ b/x/sigs/nonce.go
@@ -1,0 +1,24 @@
+package sigs
+
+import (
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/errors"
+)
+
+// NextNonce returns the next numeric nonce value that should be used during a
+// transaction signing.
+// Any address can contain a nonce. In practice you always want to acquire a
+// nonce for the signer. You can get the signers address by calling
+//   address := <crypto.Signer>.PublicKey().Address()
+func NextNonce(db weave.ReadOnlyKVStore, signer weave.Address) (int64, error) {
+	obj, err := NewBucket().Get(db, signer)
+	if err != nil {
+		return 0, errors.Wrap(err, "bucket get")
+	}
+	if u := AsUser(obj); u != nil {
+		return u.Sequence, nil
+	}
+
+	// If not yet present, nonce counting starts with zero.
+	return 0, nil
+}


### PR DESCRIPTION
I think this is a great simplification of the nonce computation. Not caching allows to avoid errors and if using the database is an issue then increment the nonce value manually ([as done right now](https://github.com/iov-one/weave/compare/benchmarks_on_real_bnsd...benchmarks_on_real_bnsd_simplify_nonce?expand=1#diff-d1253d050ac787d66da49feebc759a91R174)).

The code was moved to `x/sigs` because it depends on the functionality provided by this extension. Nonce cannot be computed without importing `x/sigs`.

I do not like [`if !tc.strategy.Has(weavetest.ExecDeliver) && (k+1)%tc.txPerBlock == 0 {`](https://github.com/iov-one/weave/compare/benchmarks_on_real_bnsd...benchmarks_on_real_bnsd_simplify_nonce?expand=1#diff-d1253d050ac787d66da49feebc759a91R173) line as it requires too much knowledge to undestand. I will propose something as soon as I will know how to do about it :thinking: 