### PR TITLE
Rework escrow initializer

### DIFF
--- a/cmd/bnsd/app/init.go
+++ b/cmd/bnsd/app/init.go
@@ -103,7 +103,7 @@ func DecorateApp(application app.BaseApp, logger log.Logger) app.BaseApp {
 		&currency.Initializer{},
 		&validators.Initializer{},
 		&distribution.Initializer{},
-		&escrow.Initializer{Minter: cash.NewController(cash.NewBucket())},
+		&escrow.Initializer{},
 	))
 	application.WithLogger(logger)
 	return application

--- a/cmd/bnsd/scenarios/main_test.go
+++ b/cmd/bnsd/scenarios/main_test.go
@@ -144,6 +144,15 @@ func initGenesis(filename string, addr weave.Address) (*tm.GenesisDoc, error) {
 					},
 				},
 			},
+			dict{
+				"address": "cond:escrow/seq/0000000000000001",
+				"coins": []interface{}{
+					dict{
+						"whole":  100000,
+						"ticker": "IOV",
+					},
+				},
+			},
 		},
 		"currencies": []interface{}{
 			dict{

--- a/x/escrow/init.go
+++ b/x/escrow/init.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/coin"
-	"github.com/iov-one/weave/x/cash"
 	"github.com/pkg/errors"
 )
 
@@ -13,7 +12,6 @@ var _ weave.Initializer = (*Initializer)(nil)
 
 // Initializer fulfils the Initializer interface to load data from the genesis file
 type Initializer struct {
-	Minter cash.CoinMinter
 }
 
 // FromGenesis will parse initial escrow  info from genesis and save it in the database.
@@ -44,12 +42,6 @@ func (i *Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
 		obj := bucket.Build(db, &escr)
 		if err := bucket.Save(db, obj); err != nil {
 			return err
-		}
-		escAddr := Condition(obj.Key()).Address()
-		for _, c := range e.Amount {
-			if err := i.Minter.CoinMint(db, escAddr, *c); err != nil {
-				return errors.Wrap(err, "failed to issue coins")
-			}
 		}
 	}
 	return nil

--- a/x/escrow/init_test.go
+++ b/x/escrow/init_test.go
@@ -6,10 +6,8 @@ import (
 	"testing"
 
 	"github.com/iov-one/weave"
-	"github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/weavetest"
-	"github.com/iov-one/weave/x/cash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,16 +17,6 @@ func TestGenesisKey(t *testing.T) {
 {
   "escrow": [
     {
-      "amount": [
-        {
-          "ticker": "ALX",
-          "whole": 987654321
-        },
-        {
-          "ticker": "IOV",
-          "whole": 123456789
-        }
-      ],
       "arbiter": "foo/bar/636f6e646974696f6e64617461",
       "recipient": "C30A2424104F542576EF01FECA2FF558F5EAA61A",
       "sender": "0000000000000000000000000000000000000000",
@@ -42,8 +30,7 @@ func TestGenesisKey(t *testing.T) {
 	db := store.MemStore()
 
 	// when
-	cashCtrl := cash.NewController(cash.NewBucket())
-	ini := Initializer{Minter: cashCtrl}
+	ini := Initializer{}
 	require.NoError(t, ini.FromGenesis(opts, db))
 
 	// then
@@ -59,10 +46,4 @@ func TestGenesisKey(t *testing.T) {
 
 	expArbiter := weave.NewCondition("foo", "bar", []byte("conditiondata"))
 	assert.Equal(t, expArbiter, weave.Condition(e.Arbiter))
-
-	balance, err := cashCtrl.Balance(db, Condition(obj.Key()).Address())
-	require.NoError(t, err)
-	require.Len(t, balance, 2)
-	assert.Equal(t, coin.Coin{Ticker: "ALX", Whole: 987654321}, *balance[0])
-	assert.Equal(t, coin.Coin{Ticker: "IOV", Whole: 123456789}, *balance[1])
 }


### PR DESCRIPTION
This patch makes the minter in the escrow initializer obsolete. Instead a weave condition is used as an address with the wallet.
The benefit of this change is a cleaner genesis as well as to stick with a single way/ package to create tokens.