### PR TITLE
Optimize CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,16 @@ os:
 go:
 - "1.10"
 - "1.11"
-# - tip
+#- "1.12"
+
 
 env:
-- GORACE="halt_on_error=1"
-  BUILD_VERSION=$(echo ${TRAVIS_COMMIT} | cut -c 1-10)
-  TM_VERSION=v0.27.4
-  FORCE_TM_TEST=1
+  global:
+    - TM_VERSION=v0.27.4
+    - BUILD_VERSION=$(echo ${TRAVIS_COMMIT} | cut -c 1-10)
+    - MAIN_GO_VERSION=1.11
+    - GORACE="halt_on_error=1"
+    - FORCE_TM_TEST=1
 
 install:
 - make deps
@@ -30,37 +33,48 @@ install:
   cd ${GOPATH}/src/github.com/tendermint/tendermint ;
   git checkout ${TM_VERSION} ;
   make get_tools && make check && make install ;
-  cd - ;
-  rm -rf ${GOPATH}/src/github.com/tendermint/tendermint
+  cd -;
+
+cache:
+  directories:
+    - $GOPATH
+    - $GOCACHE
 
 script:
-- make lint
-- make build
-- make test
-- make dist
+- make lint;
+- make test;
+- if [[ "$TRAVIS_GO_VERSION" == "$MAIN_GO_VERSION" ]]; then
+    make cover;
+    ./coverage/upload.sh;
+  fi;
+- if [[ "$TRAVIS_GO_VERSION" == "$MAIN_GO_VERSION" && "$TRAVIS_OS_NAME" == "linux" ]]; then
+    release_latest=$( [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_TAG" == "" && "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]] && echo "yes" || echo "no" );
+    release_tag=$( [[ "$TRAVIS_TAG" != "" ]] && echo "yes" || echo "no" );
 
-after_script:
-- make cover
-- ./coverage/upload.sh
+    if [[ $release_latest == "yes" || $release_tag == "yes" ]]; then
+      make dist;
+    fi
 
-after_success:
-- if [[ "$TRAVIS_GO_VERSION" == "1.10" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$TRAVIS_BRANCH" == "master" ]] && [[ "$TRAVIS_TAG" == "" ]] && [[ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]]; then
-  docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
-  docker tag  "iov1/bcpd:${BUILD_VERSION}" "iov1/bcpd:latest" ;
-  docker push "iov1/bcpd:latest";
-  docker tag  "iov1/bnsd:${BUILD_VERSION}" "iov1/bnsd:latest" ;
-  docker push "iov1/bnsd:latest";
-  docker logout;
-  fi
-# build the tagged image
-- if [[ "$TRAVIS_GO_VERSION" == "1.10" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$TRAVIS_TAG" != "" ]]; then
-  docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
-  docker tag  "iov1/bcpd:${BUILD_VERSION}" "iov1/bcpd:$TRAVIS_TAG" ;
-  docker push "iov1/bcpd:$TRAVIS_TAG";
-  docker tag  "iov1/bnsd:${BUILD_VERSION}" "iov1/bnsd:$TRAVIS_TAG" ;
-  docker push "iov1/bnsd:$TRAVIS_TAG";
-  docker logout;
-  fi
+    if [[ $release_latest == "yes" ]]; then
+      docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
+      docker tag  "iov1/bcpd:${BUILD_VERSION}" "iov1/bcpd:latest" ;
+      docker push "iov1/bcpd:latest";
+      docker tag  "iov1/bnsd:${BUILD_VERSION}" "iov1/bnsd:latest" ;
+      docker push "iov1/bnsd:latest";
+      docker logout;
+    fi;
+
+    if [[ $release_tag == "yes" ]]; then
+      docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
+      docker tag  "iov1/bcpd:${BUILD_VERSION}" "iov1/bcpd:$TRAVIS_TAG" ;
+      docker push "iov1/bcpd:$TRAVIS_TAG";
+      docker tag  "iov1/bnsd:${BUILD_VERSION}" "iov1/bnsd:$TRAVIS_TAG" ;
+      docker push "iov1/bnsd:$TRAVIS_TAG";
+      docker logout;
+    fi;
+  fi;
+
+
 notifications:
   email: false
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install build test tf cover deps tools prototools protoc
+.PHONY: all install test tf cover deps prototools protoc govet
 
 EXAMPLES := examples/mycoind cmd/bcpd cmd/bnsd
 
@@ -12,18 +12,14 @@ GOPATH ?= $$HOME/go
 
 PROTOC_FLAGS := -I=. -I=./vendor -I=$(GOPATH)/src
 
-all: deps build test
+all: deps test
 
 dist:
-	cd cmd/bnsd ; make dist ; cd -
-	cd cmd/bcpd ; make dist ; cd -
+	cd cmd/bnsd && $(MAKE) dist
+	cd cmd/bcpd && $(MAKE) dist
 
 install:
 	for ex in $(EXAMPLES); do cd $$ex && make install && cd -; done
-
-# This is to make sure it all compiles
-build:
-	go build ./...
 
 test:
 	go vet -composites=false ./...
@@ -50,16 +46,16 @@ cover:
 		github.com/iov-one/weave/cmd/bnsd/scenarios
 	cat coverage/*.out > coverage/coverage.txt
 
-deps: tools
-	@rm -rf vendor/
+deps:
+	#rm -rf vendor/
+	ifndef $(shell command -v dep help > /dev/null)
+		go get github.com/golang/dep/cmd/dep
+	endif
 	dep ensure -vendor-only
-
-tools:
-	@go get github.com/golang/dep/cmd/dep
 
 lint:
 ifndef $(shell command -v prototool help > /dev/null)
-	@go get github.com/uber/prototool/cmd/prototool
+	go get github.com/uber/prototool/cmd/prototool
 endif
 	prototool lint
 


### PR DESCRIPTION
Improvements to CI setup to shorten the execution time. Current build time is [18 min 51 sec](https://travis-ci.com/iov-one/weave/builds/105310606).

- Cache `GOPATH` between builds
Before using cache (empty cache, first run): Total time 19 min 4 sec 
First time after using cache (GOPATH restored):  Total time 16 min 2 sec :chart_with_upwards_trend: 

- Run coverage and binary/container builds only for the main Go version (1.11 right now).
- Build the container only if it will be published.
- Do not remove `vendor/`  directory

[Total time 12 min 51 sec](https://travis-ci.com/iov-one/weave/builds/105429273)   :tada:  - 6min improvement.

Addint one more Go version (1.12) will not make this process any longer.