### PR TITLE
Initial test unification attempt

### DIFF
--- a/weavetest/assert/assert.go
+++ b/weavetest/assert/assert.go
@@ -1,0 +1,36 @@
+package assert
+
+import (
+	"reflect"
+	"testing"
+)
+
+// NoErr fails the test if given error is not nil.
+func NoErr(t testing.TB, err error) {
+	t.Helper()
+	if !errIsNil(err) {
+		t.Fatalf("want the error to be nil, got %+v", err)
+	}
+}
+
+// errIsNil returns true if value represented by the given error is nil.
+//
+// Most of the time a simple == check is enough. There is a very narrowed
+// spectrum of cases  where a more sophisticated check is required.
+func errIsNil(err error) bool {
+	if err == nil {
+		return true
+	}
+	if val := reflect.ValueOf(err); val.Kind() == reflect.Ptr {
+		return val.IsNil()
+	}
+	return false
+}
+
+// Equal fails the test if two values are not equal.
+func Equal(t testing.TB, want, got interface{}) {
+	t.Helper()
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("values not equal \nwant %v\n got %v", want, got)
+	}
+}

--- a/weavetest/assert/assert.go
+++ b/weavetest/assert/assert.go
@@ -5,26 +5,30 @@ import (
 	"testing"
 )
 
-// NoErr fails the test if given error is not nil.
-func NoErr(t testing.TB, err error) {
+// Nil fails the test if given value is not nil.
+func Nil(t testing.TB, value interface{}) {
 	t.Helper()
-	if !errIsNil(err) {
-		t.Fatalf("want the error to be nil, got %+v", err)
+	if !isNil(value) {
+		t.Fatalf("want a nil value, got %#v", value)
 	}
 }
 
-// errIsNil returns true if value represented by the given error is nil.
-//
-// Most of the time a simple == check is enough. There is a very narrowed
-// spectrum of cases  where a more sophisticated check is required.
-func errIsNil(err error) bool {
-	if err == nil {
+func isNil(value interface{}) (isnil bool) {
+	if value == nil {
 		return true
 	}
-	if val := reflect.ValueOf(err); val.Kind() == reflect.Ptr {
-		return val.IsNil()
-	}
-	return false
+
+	defer func() {
+		if recover() != nil {
+			isnil = false
+		}
+	}()
+
+	// The argument must be a chan, func, interface, map, pointer, or slice
+	// value; if it is not, IsNil panics.
+	isnil = reflect.ValueOf(value).IsNil()
+
+	return isnil
 }
 
 // Equal fails the test if two values are not equal.

--- a/x/hashlock/context_test.go
+++ b/x/hashlock/context_test.go
@@ -23,10 +23,6 @@ func TestContext(t *testing.T) {
 		match []weave.Address
 		not   []weave.Address
 	}{
-		"empty context": {
-			ctx: bg,
-			not: []weave.Address{sig, other, random},
-		},
 		"context with a preimage": {
 			ctx:   withPreimage(bg, foo),
 			perms: []weave.Condition{PreimageCondition(foo)},
@@ -37,6 +33,10 @@ func TestContext(t *testing.T) {
 			ctx:   withPreimage(bg, []byte("one more time")),
 			perms: []weave.Condition{PreimageCondition([]byte("one more time"))},
 			not:   []weave.Address{sig, other, random},
+		},
+		"empty context": {
+			ctx: bg,
+			not: []weave.Address{sig, other, random},
 		},
 	}
 

--- a/x/hashlock/decorator_test.go
+++ b/x/hashlock/decorator_test.go
@@ -50,11 +50,11 @@ func TestDecorator(t *testing.T) {
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
 			_, err := stack.Check(bg, db, tc.tx)
-			assert.NoErr(t, err)
+			assert.Nil(t, err)
 			assert.Equal(t, tc.perms, h.Perms)
 
 			_, err = stack.Deliver(bg, db, tc.tx)
-			assert.NoErr(t, err)
+			assert.Nil(t, err)
 			assert.Equal(t, tc.perms, h.Perms)
 		})
 	}

--- a/x/hashlock/decorator_test.go
+++ b/x/hashlock/decorator_test.go
@@ -7,8 +7,7 @@ import (
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/weavetest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/iov-one/weave/weavetest/assert"
 )
 
 func TestDecorator(t *testing.T) {
@@ -51,11 +50,11 @@ func TestDecorator(t *testing.T) {
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
 			_, err := stack.Check(bg, db, tc.tx)
-			require.NoError(t, err)
+			assert.NoErr(t, err)
 			assert.Equal(t, tc.perms, h.Perms)
 
 			_, err = stack.Deliver(bg, db, tc.tx)
-			require.NoError(t, err)
+			assert.NoErr(t, err)
 			assert.Equal(t, tc.perms, h.Perms)
 		})
 	}


### PR DESCRIPTION
Before putting more energy into refactoring testing I want to make sure that I undestand the change correctly and that everyone is ok with this approach. This is a tiny pull request to verify this.

I have also updated the original story with a fresh description of what the task is https://github.com/iov-one/weave/issues/249

---

We have decided to cleanup weave tests and to follow a simple approach
of using standard library `testing` package with minimal set of helper
functions written by us.

- a `weavetest/assert` package was created, providing two test helper
  functions
- `x/hashlock` was updated to show the direction of further changes

this is part of https://github.com/iov-one/weave/issues/249

---

What I think is awesome is that failing tests output looks very standard now. Below is an example when the `assert.Equal` fails the test

```
$ go test github.com/iov-one/weave/x/hashlock/...
--- FAIL: TestDecorator (0.00s)
    --- FAIL: TestDecorator/Hash_a_preimage (0.00s)
        decorator_test.go:58: values not equal 
            want [hash/sha256/FCDE2B2EDBA56BF408601FB721FE9B5C338D10EE429EA04FAE5511B68FBF8FB9]
             got <nil>
    --- FAIL: TestDecorator/doesn't_support_hashlock_interface (0.00s)
        decorator_test.go:58: values not equal 
            want []
             got <nil>
    --- FAIL: TestDecorator/Correct_interface_but_no_content (0.00s)
        decorator_test.go:58: values not equal 
            want []
             got <nil>
```