### PR TITLE
weavetest/assert: update log format

### DIFF
--- a/weavetest/assert/assert.go
+++ b/weavetest/assert/assert.go
@@ -9,7 +9,9 @@ import (
 func Nil(t testing.TB, value interface{}) {
 	t.Helper()
 	if !isNil(value) {
-		t.Fatalf("want a nil value, got %#v", value)
+		// Use %+v so that if we are printing an error that supports
+		// stack traces then a full stack trace is shown.
+		t.Fatalf("want a nil value, got %+v", value)
 	}
 }
 


### PR DESCRIPTION
Use `%+v` instead of `%#v` so that if we are printing an error value that
contains a stack trace information then the full stack trace is printed.