### PR TITLE
x/escrow: make expiration time inclusive

### DIFF
--- a/x/escrow/codec.pb.go
+++ b/x/escrow/codec.pb.go
@@ -39,6 +39,10 @@ type Escrow struct {
 	// If unreleased before timeout, escrow will return to sender.
 	// Timeout represents wall clock time as read from the block header. Timeout
 	// is represented using POSIX time format.
+	// Expiration time is inclusive meaning that the escrow expires as soon as
+	// the current time is equal or greater than timeout value.
+	// nonexpired: [created, timeout)
+	// expired: [timeout, infinity)
 	Timeout github_com_iov_one_weave.UnixTime `protobuf:"varint,5,opt,name=timeout,proto3,casttype=github.com/iov-one/weave.UnixTime" json:"timeout,omitempty"`
 	// max length 128 character
 	Memo string `protobuf:"bytes,6,opt,name=memo,proto3" json:"memo,omitempty"`

--- a/x/escrow/codec.proto
+++ b/x/escrow/codec.proto
@@ -21,6 +21,10 @@ message Escrow {
   // If unreleased before timeout, escrow will return to sender.
   // Timeout represents wall clock time as read from the block header. Timeout
   // is represented using POSIX time format.
+  // Expiration time is inclusive meaning that the escrow expires as soon as
+  // the current time is equal or greater than timeout value.
+  // nonexpired: [created, timeout)
+  // expired: [timeout, infinity)
   int64 timeout = 5 [(gogoproto.casttype) = "github.com/iov-one/weave.UnixTime"];
 
   // max length 128 character

--- a/x/escrow/time.go
+++ b/x/escrow/time.go
@@ -5,7 +5,8 @@ import (
 )
 
 // isExpired returns true if given time is in the past as compared to the "now"
-// as declared for the block.
+// as declared for the block. Expiration is inclusive, meaning that if current
+// time is equal to the expiration time than this function returns true.
 //
 // This function panic if the block time is not provided in the context. This
 // must never happen. The panic is here to prevent from broken setup to be
@@ -15,5 +16,5 @@ func isExpired(ctx weave.Context, t weave.UnixTime) bool {
 	if !ok {
 		panic("block time is not present")
 	}
-	return t < weave.AsUnixTime(blockNow)
+	return t <= weave.AsUnixTime(blockNow)
 }

--- a/x/escrow/time_test.go
+++ b/x/escrow/time_test.go
@@ -22,6 +22,10 @@ func TestIsExpired(t *testing.T) {
 	if !isExpired(ctx, past) {
 		t.Error("past is not expired")
 	}
+
+	if !isExpired(ctx, now) {
+		t.Fatal("when expiration time is equal to now it is expected to be expired")
+	}
 }
 
 func TestIsExpiredRequiresBlockTime(t *testing.T) {


### PR DESCRIPTION
When considering escrow expiration time make the comparison inclusive.
If current time is equal to the timeout value, escrow entity must be
considered expired.

resolve #446