### PR TITLE
Kvstore returns error

### DIFF
--- a/app/helpers.go
+++ b/app/helpers.go
@@ -68,7 +68,7 @@ func (a *ABCIStore) Iterator(start, end []byte) (weave.Iterator, error) {
 	}
 	models, err := toModels(query.Key, query.Value)
 	if err != nil {
-		return nil, errors.Wrapf(errors.ErrInvalidState, "cannot convert to model: %v", err.Error())
+		return nil, err
 	}
 
 	return NewSliceIterator(models), nil
@@ -115,26 +115,20 @@ func (s *SliceIterator) Valid() bool {
 //
 // If Valid returns false, this method will panic.keys
 func (s *SliceIterator) Next() error {
-	s.assertValid()
+	if s.idx >= len(s.data) {
+		return errors.Wrap(errors.ErrDatabase, "Passed end of slice")
+	}
 	s.idx++
 	return nil
 }
 
-func (s *SliceIterator) assertValid() {
-	if s.idx >= len(s.data) {
-		panic("Passed end of slice")
-	}
-}
-
 // Key returns the key of the cursor.
 func (s *SliceIterator) Key() (key []byte) {
-	s.assertValid()
 	return s.data[s.idx].Key
 }
 
 // Value returns the value of the cursor.
 func (s *SliceIterator) Value() (value []byte) {
-	s.assertValid()
 	return s.data[s.idx].Value
 }
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -66,6 +66,10 @@ var (
 	// due to a currency issues.
 	ErrCurrency = Register(17, "currency")
 
+	// ErrDatabase is returned whenever the underlying kvstore fails to
+	// process raw bytes (get/set/delete/write)
+	ErrDatabase = Register(18, "database")
+
 	// ErrPanic is only set when we recover from a panic, so we know to
 	// redact potentially sensitive system info
 	ErrPanic = Register(111222, "panic")

--- a/gconf/gconf.go
+++ b/gconf/gconf.go
@@ -7,8 +7,8 @@ import (
 
 // Store is a subset of weave.KVStore.
 type Store interface {
-	Get([]byte) []byte
-	Set([]byte, []byte)
+	Get([]byte) ([]byte, error)
+	Set([]byte, []byte) error
 }
 
 // Save will Validate the object, before writing it to a special "configuration"
@@ -22,8 +22,7 @@ func Save(db Store, pkg string, src ValidMarshaler) error {
 	if err != nil {
 		return errors.Wrapf(err, "marshal: key %q", key)
 	}
-	db.Set(key, raw)
-	return nil
+	return db.Set(key, raw)
 }
 
 // ValidMarshaler is implemented by object that can serialize itself to a binary
@@ -38,7 +37,10 @@ type ValidMarshaler interface {
 
 func Load(db Store, pkg string, dst Unmarshaler) error {
 	key := []byte("_c:" + pkg)
-	raw := db.Get(key)
+	raw, err := db.Get(key)
+	if err != nil {
+		return err
+	}
 	if raw == nil {
 		return errors.Wrapf(errors.ErrNotFound, "key %q", key)
 	}

--- a/orm/bucket.go
+++ b/orm/bucket.go
@@ -189,8 +189,7 @@ func (b Bucket) Save(db weave.KVStore, model Object) error {
 	}
 
 	// now save this one
-	db.Set(b.DBKey(model.Key()), bz)
-	return nil
+	return db.Set(b.DBKey(model.Key()), bz)
 }
 
 // Delete will remove the value at a key
@@ -202,8 +201,7 @@ func (b Bucket) Delete(db weave.KVStore, key []byte) error {
 
 	// now save this one
 	dbkey := b.DBKey(key)
-	db.Delete(dbkey)
-	return nil
+	return db.Delete(dbkey)
 }
 
 func (b Bucket) updateIndexes(db weave.KVStore, key []byte, model Object) error {

--- a/orm/bucket.go
+++ b/orm/bucket.go
@@ -104,8 +104,10 @@ func (b Bucket) Query(db weave.ReadOnlyKVStore, mod string, data []byte) ([]weav
 	switch mod {
 	case weave.KeyQueryMod:
 		key := b.DBKey(data)
-		value := db.Get(key)
-		// return nothing on miss
+		value, err := db.Get(key)
+		if err != nil {
+			return nil, err
+		}
 		if value == nil {
 			return nil, nil
 		}
@@ -113,7 +115,7 @@ func (b Bucket) Query(db weave.ReadOnlyKVStore, mod string, data []byte) ([]weav
 		return res, nil
 	case weave.PrefixQueryMod:
 		prefix := b.DBKey(data)
-		return queryPrefix(db, prefix), nil
+		return queryPrefix(db, prefix)
 	default:
 		return nil, errors.Wrapf(errors.ErrInvalidInput, "unknown mod: %s", mod)
 	}
@@ -141,7 +143,10 @@ func (b Bucket) DBKey(key []byte) []byte {
 // Get one element
 func (b Bucket) Get(db weave.ReadOnlyKVStore, key []byte) (Object, error) {
 	dbkey := b.DBKey(key)
-	bz := db.Get(dbkey)
+	bz, err := db.Get(dbkey)
+	if err != nil {
+		return nil, err
+	}
 	if bz == nil {
 		return nil, nil
 	}

--- a/orm/bucket_test.go
+++ b/orm/bucket_test.go
@@ -144,13 +144,16 @@ func TestBucketSequence(t *testing.T) {
 	// this operation several times.
 	for i := int64(1); i < 10; i++ {
 		sa := b1.Sequence("seq1")
-		a := sa.NextInt(db)
+		a, err := sa.NextInt(db)
+		assert.Nil(t, err)
 
 		sb := b1.Sequence("seq2") // The same bucket but different name.
-		b := sb.NextInt(db)
+		b, err := sb.NextInt(db)
+		assert.Nil(t, err)
 
 		sc := b2.Sequence("seq1") // The same name but different bucket.
-		c := sc.NextInt(db)
+		c, err := sc.NextInt(db)
+		assert.Nil(t, err)
 
 		if a != i || a != b || a != c {
 			t.Fatalf("different sequencces increment independently: a=%d b=%d c=%d", a, b, c)
@@ -480,9 +483,9 @@ func TestBucketIndexDeterministic(t *testing.T) {
 	assert.Equal(t, 3, len(ops))
 	assertOps(t, ops, 3, 0)
 
-	// Saving second item should update the item as well as the one index
-	// that changed (don't write constant index).
-	assert.Nil(t, bucket.Save(db, val2))
+	// saving second item should update the item as well as the one index that changed (don't write constant index)
+	err := bucket.Save(db, val2)
+	assert.Nil(t, err)
 	ops = log.ShowOps()
 	assert.Equal(t, 6, len(ops))
 	assertOps(t, ops, 5, 1)

--- a/orm/query_test.go
+++ b/orm/query_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/store"
-	"github.com/stretchr/testify/assert"
+	"github.com/iov-one/weave/weavetest/assert"
 )
 
 func TestPrefixRange(t *testing.T) {
@@ -79,8 +79,9 @@ func TestQueryPrefix(t *testing.T) {
 				db.Set(m.Key, m.Value)
 			}
 
-			res := queryPrefix(db, tc.prefix)
-			assert.EqualValues(t, tc.expected, res)
+			res, err := queryPrefix(db, tc.prefix)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expected, res)
 		})
 	}
 }

--- a/orm/sequence.go
+++ b/orm/sequence.go
@@ -24,24 +24,27 @@ func NewSequence(bucket, name string) Sequence {
 }
 
 // NextVal increments the sequence and returns its state as 8 bytes.
-func (s *Sequence) NextVal(db weave.KVStore) []byte {
-	_, bz := s.increment(db, 1)
-	return bz
+func (s *Sequence) NextVal(db weave.KVStore) ([]byte, error) {
+	_, bz, err := s.increment(db, 1)
+	return bz, err
 }
 
 // NextInt increments the sequence and returns its state as int.
-func (s *Sequence) NextInt(db weave.KVStore) int64 {
-	val, _ := s.increment(db, 1)
-	return val
+func (s *Sequence) NextInt(db weave.KVStore) (int64, error) {
+	val, _, err := s.increment(db, 1)
+	return val, err
 }
 
-func (s *Sequence) increment(db weave.KVStore, inc int64) (int64, []byte) {
-	raw := db.Get(s.id)
+func (s *Sequence) increment(db weave.KVStore, inc int64) (int64, []byte, error) {
+	raw, err := db.Get(s.id)
+	if err != nil {
+		return 0, nil, err
+	}
 	val := decodeSequence(raw)
 	val += inc
 	raw = encodeSequence(val)
-	db.Set(s.id, raw)
-	return val, raw
+	err = db.Set(s.id, raw)
+	return val, raw, err
 }
 
 func decodeSequence(bz []byte) int64 {

--- a/orm/sequence_test.go
+++ b/orm/sequence_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/iov-one/weave/store"
+	"github.com/iov-one/weave/weavetest/assert"
 )
 
 func TestSequence(t *testing.T) {
@@ -20,7 +21,8 @@ func TestSequence(t *testing.T) {
 		// Ensure that multiple sequences can be used within the same
 		// store.
 		for _, s := range sequences {
-			got := s.NextInt(db)
+			got, err := s.NextInt(db)
+			assert.Nil(t, err)
 			if got != want {
 				t.Fatalf("want %d, got %d", want, got)
 			}
@@ -34,7 +36,9 @@ func TestSequenceKeyFormat(t *testing.T) {
 	s.NextVal(db)
 	// As defined in NewSequence documentation
 	key := `_s.bucket:name`
-	if !db.Has([]byte(key)) {
+	has, err := db.Has([]byte(key))
+	assert.Nil(t, err)
+	if !has {
 		t.Fatal("sequence not found in store, invalid key?")
 	}
 

--- a/store.go
+++ b/store.go
@@ -8,27 +8,27 @@ package weave
 // ReadOnlyKVStore is a simple interface to query data.
 type ReadOnlyKVStore interface {
 	// Get returns nil iff key doesn't exist. Panics on nil key.
-	Get(key []byte) []byte
+	Get(key []byte) ([]byte, error)
 
 	// Has checks if a key exists. Panics on nil key.
-	Has(key []byte) bool
+	Has(key []byte) (bool, error)
 
 	// Iterator over a domain of keys in ascending order. End is exclusive.
 	// Start must be less than end, or the Iterator is invalid.
 	// CONTRACT: No writes may happen within a domain while an iterator exists over it.
-	Iterator(start, end []byte) Iterator
+	Iterator(start, end []byte) (Iterator, error)
 
 	// ReverseIterator over a domain of keys in descending order. End is exclusive.
 	// Start must be greater than end, or the Iterator is invalid.
 	// CONTRACT: No writes may happen within a domain while an iterator exists over it.
-	ReverseIterator(start, end []byte) Iterator
+	ReverseIterator(start, end []byte) (Iterator, error)
 }
 
 // SetDeleter is a minimal interface for writing,
 // Unifying KVStore and Batch
 type SetDeleter interface {
-	Set(key, value []byte) // CONTRACT: key, value readonly []byte
-	Delete(key []byte)     // CONTRACT: key readonly []byte
+	Set(key, value []byte) error // CONTRACT: key, value readonly []byte
+	Delete(key []byte) error     // CONTRACT: key readonly []byte
 }
 
 // KVStore is a simple interface to get/set data
@@ -46,7 +46,7 @@ type KVStore interface {
 // Batch can write multiple ops atomically to an underlying KVStore
 type Batch interface {
 	SetDeleter
-	Write()
+	Write() error
 }
 
 /*
@@ -62,6 +62,10 @@ keys. These may all be preloaded, or loaded on demand.
     k, v := itr.Key(); itr.Value()
     // ...
   }
+
+Note that Valid(), Key() and Value() are assumed to use a cached state
+(read on initialization or Next) and should never return errors.
+Next() may well return a read error.
 */
 type Iterator interface {
 	// Valid returns whether the current position is valid.
@@ -72,7 +76,7 @@ type Iterator interface {
 	// defined by order of iteration.
 	//
 	// If Valid returns false, this method will panic.
-	Next()
+	Next() error
 
 	// Key returns the key of the cursor.
 	// If Valid returns false, this method will panic.
@@ -118,7 +122,7 @@ type KVCacheWrap interface {
 	CacheableKVStore
 
 	// Write syncs with the underlying store.
-	Write()
+	Write() error
 
 	// Discard invalidates this CacheWrap and releases all data
 	Discard()
@@ -139,7 +143,7 @@ type KVCacheWrap interface {
 type CommitKVStore interface {
 	// Get returns the value at last committed state
 	// returns nil iff key doesn't exist. Panics on nil key.
-	Get(key []byte) []byte
+	Get(key []byte) ([]byte, error)
 
 	// TODO: Get with proof, also historical queries
 	// GetVersionedWithProof(key []byte, version int64) (value []byte)
@@ -158,7 +162,7 @@ type CommitKVStore interface {
 	CacheWrap() KVCacheWrap
 
 	// Commit the next version to disk, and returns info
-	Commit() CommitID
+	Commit() (CommitID, error)
 
 	// LoadLatestVersion loads the latest persisted version.
 	// If there was a crash during the last commit, it is guaranteed
@@ -166,7 +170,7 @@ type CommitKVStore interface {
 	LoadLatestVersion() error
 
 	// LatestVersion returns info on the latest version saved to disk
-	LatestVersion() CommitID
+	LatestVersion() (CommitID, error)
 
 	// ?????
 	// LoadVersion loads a specific persisted version.  When you load an old version, or

--- a/store/btree.go
+++ b/store/btree.go
@@ -2,9 +2,9 @@ package store
 
 import (
 	"bytes"
-	"fmt"
 
 	"github.com/google/btree"
+	"github.com/iov-one/weave/errors"
 )
 
 const (
@@ -140,7 +140,7 @@ func (b BTreeCacheWrap) Get(key []byte) ([]byte, error) {
 		case deletedItem:
 			return nil, nil
 		default:
-			return nil, fmt.Errorf("Unknown item in btree: %#v", res)
+			return nil, errors.Wrapf(errors.ErrDatabase, "Unknown item in btree: %#v", res)
 		}
 	}
 	return b.back.Get(key)
@@ -156,7 +156,7 @@ func (b BTreeCacheWrap) Has(key []byte) (bool, error) {
 		case deletedItem:
 			return false, nil
 		default:
-			return false, fmt.Errorf("Unknown item in btree: %#v", res)
+			return false, errors.Wrapf(errors.ErrDatabase, "Unknown item in btree: %#v", res)
 		}
 	}
 	return b.back.Has(key)

--- a/store/btree.go
+++ b/store/btree.go
@@ -99,9 +99,10 @@ func (b BTreeCacheWrap) NewBatch() Batch {
 
 // Write syncs with the underlying store.
 // And then cleans up
-func (b BTreeCacheWrap) Write() {
-	b.batch.Write()
+func (b BTreeCacheWrap) Write() error {
+	err := b.batch.Write()
 	b.Discard()
+	return err
 }
 
 // Discard invalidates this CacheWrap and releases all data
@@ -116,44 +117,46 @@ func (b BTreeCacheWrap) Discard() {
 }
 
 // Set writes to the BTree and to the batch
-func (b BTreeCacheWrap) Set(key, value []byte) {
+func (b BTreeCacheWrap) Set(key, value []byte) error {
 	b.bt.ReplaceOrInsert(newSetItem(key, value))
 	b.batch.Set(key, value)
+	return nil
 }
 
 // Delete deletes from the BTree and to the batch
-func (b BTreeCacheWrap) Delete(key []byte) {
+func (b BTreeCacheWrap) Delete(key []byte) error {
 	b.bt.ReplaceOrInsert(newDeletedItem(key))
 	b.batch.Delete(key)
+	return nil
 }
 
 // Get reads from btree if there, else backing store
-func (b BTreeCacheWrap) Get(key []byte) []byte {
+func (b BTreeCacheWrap) Get(key []byte) ([]byte, error) {
 	res := b.bt.Get(bkey{key})
 	if res != nil {
 		switch t := res.(type) {
 		case setItem:
-			return t.value
+			return t.value, nil
 		case deletedItem:
-			return nil
+			return nil, nil
 		default:
-			panic(fmt.Sprintf("Unknown item in btree: %#v", res))
+			return nil, fmt.Errorf("Unknown item in btree: %#v", res)
 		}
 	}
 	return b.back.Get(key)
 }
 
 // Has reads from btree if there, else backing store
-func (b BTreeCacheWrap) Has(key []byte) bool {
+func (b BTreeCacheWrap) Has(key []byte) (bool, error) {
 	res := b.bt.Get(bkey{key})
 	if res != nil {
 		switch res.(type) {
 		case setItem:
-			return true
+			return true, nil
 		case deletedItem:
-			return false
+			return false, nil
 		default:
-			panic(fmt.Sprintf("Unknown item in btree: %#v", res))
+			return false, fmt.Errorf("Unknown item in btree: %#v", res)
 		}
 	}
 	return b.back.Has(key)
@@ -161,9 +164,12 @@ func (b BTreeCacheWrap) Has(key []byte) bool {
 
 // Iterator over a domain of keys in ascending order.
 // Combines results from btree and backing store
-func (b BTreeCacheWrap) Iterator(start, end []byte) Iterator {
+func (b BTreeCacheWrap) Iterator(start, end []byte) (Iterator, error) {
 	// take the backing iterator for start
-	parentIter := b.back.Iterator(start, end)
+	parentIter, err := b.back.Iterator(start, end)
+	if err != nil {
+		return nil, err
+	}
 	iter := newItemIter(parentIter)
 
 	if start == nil && end == nil {
@@ -177,14 +183,17 @@ func (b BTreeCacheWrap) Iterator(start, end []byte) Iterator {
 	}
 	iter.skipAllDeleted()
 
-	return iter
+	return iter, nil
 }
 
 // ReverseIterator over a domain of keys in descending order.
 // Combines results from btree and backing store
-func (b BTreeCacheWrap) ReverseIterator(start, end []byte) Iterator {
+func (b BTreeCacheWrap) ReverseIterator(start, end []byte) (Iterator, error) {
 	// take the backing iterator for start
-	parentIter := b.back.ReverseIterator(start, end)
+	parentIter, err := b.back.ReverseIterator(start, end)
+	if err != nil {
+		return nil, err
+	}
 	iter := newItemIter(parentIter)
 
 	if start == nil && end == nil {
@@ -198,7 +207,7 @@ func (b BTreeCacheWrap) ReverseIterator(start, end []byte) Iterator {
 	}
 	iter.skipAllDeleted()
 
-	return iter
+	return iter, nil
 }
 
 /////////////////////////////////////////////////////////
@@ -333,22 +342,25 @@ func (i *itemIter) Valid() bool {
 // defined by order of iteration.
 //
 // If Valid returns false, this method will panic.
-func (i *itemIter) Next() {
+func (i *itemIter) Next() error {
 	// advance either us, parent, or both
 	switch i.firstKey() {
 	case us:
 		i.idx++
-	case parent:
-		i.parent.Next()
 	case both:
 		i.idx++
-		i.parent.Next()
+		fallthrough
+	case parent:
+		err := i.parent.Next()
+		if err != nil {
+			return err
+		}
 	default:
 		panic("Advanced past the end!")
 	}
 
 	// keep advancing over all deleted entries
-	i.skipAllDeleted()
+	return i.skipAllDeleted()
 }
 
 // Key returns the key of the cursor.
@@ -381,14 +393,21 @@ func (i *itemIter) Close() {
 }
 
 // skipAllDeleted loops and skips any number of deleted items
-func (i *itemIter) skipAllDeleted() {
-	for i.skipDeleted() {
+func (i *itemIter) skipAllDeleted() error {
+	var err error
+	more := true
+	for more {
+		more, err = i.skipDeleted()
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // skipDeleted jumps over all elements we can safely fast forward
 // return true if skipped, so we can skip again
-func (i *itemIter) skipDeleted() bool {
+func (i *itemIter) skipDeleted() (bool, error) {
 	src := i.firstKey()
 	if src == us || src == both {
 		// if our next is deleted, advance...
@@ -396,12 +415,15 @@ func (i *itemIter) skipDeleted() bool {
 			i.idx++
 			// if parent had the same key, advance parent as well
 			if src == both {
-				i.parent.Next()
+				err := i.parent.Next()
+				if err != nil {
+					return false, err
+				}
 			}
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // get requires this is valid, gets what we are pointing at

--- a/store/btree_test.go
+++ b/store/btree_test.go
@@ -19,6 +19,7 @@ func makeBase() CacheableKVStore {
 }
 
 func assertGetHas(t testing.TB, kv ReadOnlyKVStore, key, val []byte, has bool) {
+	t.Helper()
 	got, err := kv.Get(key)
 	assert.Nil(t, err)
 	assert.Equal(t, val, got)

--- a/store/btree_test.go
+++ b/store/btree_test.go
@@ -18,6 +18,15 @@ func makeBase() CacheableKVStore {
 	return MemStore()
 }
 
+func assertGetHas(t testing.TB, kv ReadOnlyKVStore, key, val []byte, has bool) {
+	got, err := kv.Get(key)
+	assert.Nil(t, err)
+	assert.Equal(t, val, got)
+	exists, err := kv.Has(key)
+	assert.Nil(t, err)
+	assert.Equal(t, has, exists)
+}
+
 // TestBTreeCacheGetSet does basic sanity checks on our cache
 //
 // Other tests should handle deletes, setting same value,
@@ -28,54 +37,52 @@ func TestBTreeCacheGetSet(t *testing.T) {
 	// make sure the btree is empty at start but returns results
 	// that are written to it
 	k, v := []byte("french"), []byte("fry")
-	assert.Nil(t, base.Get(k))
-	assert.Equal(t, base.Has(k), false)
-	base.Set(k, v)
-	assert.Equal(t, v, base.Get(k))
-	assert.Equal(t, base.Has(k), true)
+	assertGetHas(t, base, k, nil, false)
+	err := base.Set(k, v)
+	assert.Nil(t, err)
+	assertGetHas(t, base, k, v, true)
 
 	// now layer another btree on top and make sure that we get
 	// base data
 	cache := base.CacheWrap()
-	assert.Equal(t, v, cache.Get(k))
-	assert.Equal(t, cache.Has(k), true)
+	assertGetHas(t, cache, k, v, true)
 
 	// writing more data is only visible in the cache
 	k2, v2 := []byte("LA"), []byte("Dodgers")
-	assert.Nil(t, cache.Get(k2))
-	assert.Equal(t, cache.Has(k2), false)
-	cache.Set(k2, v2)
-	assert.Equal(t, v2, cache.Get(k2))
-	assert.Nil(t, base.Get(k2))
-	assert.Equal(t, cache.Has(k2), true)
-	assert.Equal(t, base.Has(k2), false)
+	assertGetHas(t, cache, k2, nil, false)
+	err = cache.Set(k2, v2)
+	assert.Nil(t, err)
+	assertGetHas(t, cache, k2, v2, true)
+	assertGetHas(t, base, k2, nil, false)
 
 	// we can write the cache to the base layer...
-	cache.Write()
-	assert.Equal(t, v, base.Get(k))
-	assert.Equal(t, v2, base.Get(k2))
-	assert.Equal(t, base.Has(k), true)
-	assert.Equal(t, base.Has(k2), true)
+	err = cache.Write()
+	assert.Nil(t, err)
+	assertGetHas(t, base, k, v, true)
+	assertGetHas(t, base, k2, v2, true)
 
 	// we can discard one
 	k3, v3 := []byte("Bayern"), []byte("Munich")
 	c2 := base.CacheWrap()
-	assert.Equal(t, v, c2.Get(k))
-	assert.Equal(t, v2, c2.Get(k2))
-	c2.Set(k3, v3)
+	assertGetHas(t, c2, k, v, true)
+	assertGetHas(t, c2, k2, v2, true)
+	err = c2.Set(k3, v3)
+	assert.Nil(t, err)
 	c2.Discard()
 
 	// and commit another
 	c3 := base.CacheWrap()
-	assert.Equal(t, v, c3.Get(k))
-	assert.Equal(t, v2, c3.Get(k2))
-	c3.Delete(k)
-	c3.Write()
+	assertGetHas(t, c3, k, v, true)
+	assertGetHas(t, c3, k2, v2, true)
+	err = c3.Delete(k)
+	assert.Nil(t, err)
+	err = c3.Write()
+	assert.Nil(t, err)
 
 	// make sure it commits proper
-	assert.Nil(t, base.Get(k))
-	assert.Equal(t, v2, base.Get(k2))
-	assert.Nil(t, base.Get(k3))
+	assertGetHas(t, c2, k, nil, false)
+	assertGetHas(t, c2, k2, v2, true)
+	assertGetHas(t, c2, k3, nil, false)
 }
 
 // TestBTreeCacheConflicts checks that we can handle
@@ -92,10 +99,10 @@ func TestBTreeCacheConflicts(t *testing.T) {
 		childQueries  []Model // Key is what we query, Value is what we expect
 	}{
 		"overwrite one, delete another, add a third": {
-			[]Op{SetOp(ks[1], vs[1]), SetOp(ks[2], vs[2])},
-			[]Op{SetOp(ks[1], vs[11]), SetOp(ks[3], vs[7]), DelOp(ks[2])},
-			[]Model{Pair(ks[1], vs[1]), Pair(ks[2], vs[2]), Pair(ks[3], nil)},
-			[]Model{Pair(ks[1], vs[11]), Pair(ks[2], nil), Pair(ks[3], vs[7])},
+			parentOps:     []Op{SetOp(ks[1], vs[1]), SetOp(ks[2], vs[2])},
+			childOps:      []Op{SetOp(ks[1], vs[11]), SetOp(ks[3], vs[7]), DelOp(ks[2])},
+			parentQueries: []Model{Pair(ks[1], vs[1]), Pair(ks[2], vs[2]), Pair(ks[3], nil)},
+			childQueries:  []Model{Pair(ks[1], vs[11]), Pair(ks[2], nil), Pair(ks[3], vs[7])},
 		},
 	}
 
@@ -113,27 +120,18 @@ func TestBTreeCacheConflicts(t *testing.T) {
 
 			// now check the parent is unaffected
 			for _, q := range tc.parentQueries {
-				res := parent.Get(q.Key)
-				assert.Equal(t, q.Value, res)
-				has := parent.Has(q.Key)
-				assert.Equal(t, q.Value != nil, has)
+				assertGetHas(t, parent, q.Key, q.Value, q.Value != nil)
 			}
 
 			// the child shows changes
 			for _, q := range tc.childQueries {
-				res := child.Get(q.Key)
-				assert.Equal(t, q.Value, res)
-				has := child.Has(q.Key)
-				assert.Equal(t, q.Value != nil, has)
+				assertGetHas(t, child, q.Key, q.Value, q.Value != nil)
 			}
 
 			// write child to parent and make sure it also shows proper data
 			child.Write()
 			for _, q := range tc.childQueries {
-				res := parent.Get(q.Key)
-				assert.Equal(t, q.Value, res)
-				has := parent.Has(q.Key)
-				assert.Equal(t, q.Value != nil, has)
+				assertGetHas(t, parent, q.Key, q.Value, q.Value != nil)
 			}
 		})
 	}
@@ -311,11 +309,13 @@ func (i iterCase) verify(t testing.TB, base CacheableKVStore) {
 
 	for _, q := range i.queries {
 		var iter Iterator
+		var err error
 		if q.reverse {
-			iter = child.ReverseIterator(q.start, q.end)
+			iter, err = child.ReverseIterator(q.start, q.end)
 		} else {
-			iter = child.Iterator(q.start, q.end)
+			iter, err = child.Iterator(q.start, q.end)
 		}
+		assert.Nil(t, err)
 		// Make sure proper iteration works.
 		for i := 0; i < len(q.expected); i++ {
 			assert.Equal(t, iter.Valid(), true)

--- a/store/helpers.go
+++ b/store/helpers.go
@@ -1,6 +1,6 @@
 package store
 
-import "fmt"
+import "github.com/iov-one/weave/errors"
 
 ////////////////////////////////////////////////
 // Slice -> Iterator
@@ -120,7 +120,7 @@ func (o Op) Apply(out SetDeleter) error {
 	case delKind:
 		return out.Delete(o.key)
 	default:
-		return fmt.Errorf("Unknown kind: %d", o.kind)
+		return errors.Wrapf(errors.ErrDatabase, "Unknown kind: %d", o.kind)
 	}
 }
 

--- a/store/helpers.go
+++ b/store/helpers.go
@@ -31,9 +31,10 @@ func (s *SliceIterator) Valid() bool {
 // defined by order of iteration.
 //
 // If Valid returns false, this method will panic.
-func (s *SliceIterator) Next() {
+func (s *SliceIterator) Next() error {
 	s.assertValid()
 	s.idx++
+	return nil
 }
 
 func (s *SliceIterator) assertValid() {
@@ -68,25 +69,25 @@ type EmptyKVStore struct{}
 var _ KVStore = EmptyKVStore{}
 
 // Get always returns nil
-func (e EmptyKVStore) Get(key []byte) []byte { return nil }
+func (e EmptyKVStore) Get(key []byte) ([]byte, error) { return nil, nil }
 
 // Has always returns false
-func (e EmptyKVStore) Has(key []byte) bool { return false }
+func (e EmptyKVStore) Has(key []byte) (bool, error) { return false, nil }
 
 // Set is a noop
-func (e EmptyKVStore) Set(key, value []byte) {}
+func (e EmptyKVStore) Set(key, value []byte) error { return nil }
 
 // Delete is a noop
-func (e EmptyKVStore) Delete(key []byte) {}
+func (e EmptyKVStore) Delete(key []byte) error { return nil }
 
 // Iterator is always empty
-func (e EmptyKVStore) Iterator(start, end []byte) Iterator {
-	return NewSliceIterator(nil)
+func (e EmptyKVStore) Iterator(start, end []byte) (Iterator, error) {
+	return NewSliceIterator(nil), nil
 }
 
 // ReverseIterator is always empty
-func (e EmptyKVStore) ReverseIterator(start, end []byte) Iterator {
-	return NewSliceIterator(nil)
+func (e EmptyKVStore) ReverseIterator(start, end []byte) (Iterator, error) {
+	return NewSliceIterator(nil), nil
 }
 
 // NewBatch returns a batch that can write to this tree later
@@ -112,14 +113,14 @@ type Op struct {
 }
 
 // Apply performs the stored operation on a writeable store
-func (o Op) Apply(out SetDeleter) {
+func (o Op) Apply(out SetDeleter) error {
 	switch o.kind {
 	case setKind:
-		out.Set(o.key, o.value)
+		return out.Set(o.key, o.value)
 	case delKind:
-		out.Delete(o.key)
+		return out.Delete(o.key)
 	default:
-		panic(fmt.Sprintf("Unknown kind: %d", o.kind))
+		return fmt.Errorf("Unknown kind: %d", o.kind)
 	}
 }
 
@@ -153,8 +154,6 @@ func DelOp(key []byte) Op {
 // NonAtomicBatch just piles up ops and executes them later
 // on the underlying store. Can be used when there is no better
 // option (for in-memory stores).
-//
-// NOTE: Never use this for KVStores that are persistent
 type NonAtomicBatch struct {
 	out SetDeleter
 	ops []Op
@@ -171,30 +170,36 @@ func NewNonAtomicBatch(out SetDeleter) *NonAtomicBatch {
 }
 
 // Set adds a set operation to the batch
-func (b *NonAtomicBatch) Set(key, value []byte) {
+func (b *NonAtomicBatch) Set(key, value []byte) error {
 	set := Op{
 		kind:  setKind,
 		key:   key,
 		value: value,
 	}
 	b.ops = append(b.ops, set)
+	return nil
 }
 
 // Delete adds a delete operation to the batch
-func (b *NonAtomicBatch) Delete(key []byte) {
+func (b *NonAtomicBatch) Delete(key []byte) error {
 	del := Op{
 		kind: delKind,
 		key:  key,
 	}
 	b.ops = append(b.ops, del)
+	return nil
 }
 
 // Write writes all the ops to the underlying store and resets
-func (b *NonAtomicBatch) Write() {
+func (b *NonAtomicBatch) Write() error {
 	for _, Op := range b.ops {
-		Op.Apply(b.out)
+		err := Op.Apply(b.out)
+		if err != nil {
+			return err
+		}
 	}
 	b.ops = nil
+	return nil
 }
 
 // ShowOps is instrumentation for testing,

--- a/store/helpers.go
+++ b/store/helpers.go
@@ -32,26 +32,20 @@ func (s *SliceIterator) Valid() bool {
 //
 // If Valid returns false, this method will panic.
 func (s *SliceIterator) Next() error {
-	s.assertValid()
+	if s.idx >= len(s.data) {
+		return errors.Wrap(errors.ErrDatabase, "Passed end of slice")
+	}
 	s.idx++
 	return nil
 }
 
-func (s *SliceIterator) assertValid() {
-	if s.idx >= len(s.data) {
-		panic("Passed end of slice")
-	}
-}
-
 // Key returns the key of the cursor.
 func (s *SliceIterator) Key() (key []byte) {
-	s.assertValid()
 	return s.data[s.idx].Key
 }
 
 // Value returns the value of the cursor.
 func (s *SliceIterator) Value() (value []byte) {
-	s.assertValid()
 	return s.data[s.idx].Value
 }
 

--- a/store/helpers_test.go
+++ b/store/helpers_test.go
@@ -37,4 +37,8 @@ func TestSliceIterator(t *testing.T) {
 	if it.Valid() {
 		t.Fatal("closed iterator must be invalid")
 	}
+	err := it.Next()
+	if err == nil {
+		t.Fatal("Callin Next on invalid iterator must return error")
+	}
 }

--- a/store/iavl/adapter.go
+++ b/store/iavl/adapter.go
@@ -1,11 +1,11 @@
 package iavl
 
 import (
-	"fmt"
-
-	"github.com/iov-one/weave/store"
 	"github.com/tendermint/iavl"
 	dbm "github.com/tendermint/tendermint/libs/db"
+
+	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/store"
 )
 
 // TODO: make these configurable?
@@ -54,8 +54,8 @@ func MockCommitStore() CommitStore {
 // Returns nil iff key doesn't exist.
 // Returns error on nil key.
 func (s CommitStore) Get(key []byte) ([]byte, error) {
-	if key == nil { // TODO: len(key) == 0 ?
-		return nil, fmt.Errorf("nil key")
+	if len(key) == 0 {
+		return nil, errors.Wrapf(errors.ErrDatabase, "nil key")
 	}
 	version := int64(s.tree.Version())
 	_, val := s.tree.GetVersioned(key, version)

--- a/store/iavl/adapter.go
+++ b/store/iavl/adapter.go
@@ -55,7 +55,7 @@ func MockCommitStore() CommitStore {
 // Returns error on nil key.
 func (s CommitStore) Get(key []byte) ([]byte, error) {
 	if len(key) == 0 {
-		return nil, errors.Wrapf(errors.ErrDatabase, "nil key")
+		return nil, errors.Wrap(errors.ErrDatabase, "nil key")
 	}
 	version := int64(s.tree.Version())
 	_, val := s.tree.GetVersioned(key, version)

--- a/store/iavl/adapter_test.go
+++ b/store/iavl/adapter_test.go
@@ -37,6 +37,7 @@ func makeCommitStore() (CommitStore, func()) {
 }
 
 func assertGetHas(t testing.TB, kv store.ReadOnlyKVStore, key, val []byte, has bool) {
+	t.Helper()
 	got, err := kv.Get(key)
 	assert.Nil(t, err)
 	assert.Equal(t, val, got)

--- a/store/iavl/adapter_test.go
+++ b/store/iavl/adapter_test.go
@@ -36,6 +36,15 @@ func makeCommitStore() (CommitStore, func()) {
 	return commit, close
 }
 
+func assertGetHas(t testing.TB, kv store.ReadOnlyKVStore, key, val []byte, has bool) {
+	got, err := kv.Get(key)
+	assert.Nil(t, err)
+	assert.Equal(t, val, got)
+	exists, err := kv.Has(key)
+	assert.Nil(t, err)
+	assert.Equal(t, has, exists)
+}
+
 // TestCacheGetSet does basic sanity checks on our cache
 //
 // Other tests should handle deletes, setting same value,
@@ -47,54 +56,52 @@ func TestCacheGetSet(t *testing.T) {
 	// make sure the btree is empty at start but returns results
 	// that are written to it
 	k, v := []byte("french"), []byte("fry")
-	assert.Nil(t, base.Get(k))
-	assert.Equal(t, base.Has(k), false)
-	base.Set(k, v)
-	assert.Equal(t, v, base.Get(k))
-	assert.Equal(t, base.Has(k), true)
+	assertGetHas(t, base, k, nil, false)
+	err := base.Set(k, v)
+	assert.Nil(t, err)
+	assertGetHas(t, base, k, v, true)
 
 	// now layer another btree on top and make sure that we get
 	// base data
 	cache := base.CacheWrap()
-	assert.Equal(t, v, cache.Get(k))
-	assert.Equal(t, cache.Has(k), true)
+	assertGetHas(t, cache, k, v, true)
 
 	// writing more data is only visible in the cache
 	k2, v2 := []byte("LA"), []byte("Dodgers")
-	assert.Nil(t, cache.Get(k2))
-	assert.Equal(t, cache.Has(k2), false)
-	cache.Set(k2, v2)
-	assert.Equal(t, v2, cache.Get(k2))
-	assert.Nil(t, base.Get(k2))
-	assert.Equal(t, cache.Has(k2), true)
-	assert.Equal(t, base.Has(k2), false)
+	assertGetHas(t, cache, k2, nil, false)
+	err = cache.Set(k2, v2)
+	assert.Nil(t, err)
+	assertGetHas(t, cache, k2, v2, true)
+	assertGetHas(t, base, k2, nil, false)
 
 	// we can write the cache to the base layer...
-	cache.Write()
-	assert.Equal(t, v, base.Get(k))
-	assert.Equal(t, v2, base.Get(k2))
-	assert.Equal(t, base.Has(k), true)
-	assert.Equal(t, base.Has(k2), true)
+	err = cache.Write()
+	assert.Nil(t, err)
+	assertGetHas(t, base, k, v, true)
+	assertGetHas(t, base, k2, v2, true)
 
 	// we can discard one
 	k3, v3 := []byte("Bayern"), []byte("Munich")
 	c2 := base.CacheWrap()
-	assert.Equal(t, v, c2.Get(k))
-	assert.Equal(t, v2, c2.Get(k2))
-	c2.Set(k3, v3)
+	assertGetHas(t, c2, k, v, true)
+	assertGetHas(t, c2, k2, v2, true)
+	err = c2.Set(k3, v3)
+	assert.Nil(t, err)
 	c2.Discard()
 
 	// and commit another
 	c3 := base.CacheWrap()
-	assert.Equal(t, v, c3.Get(k))
-	assert.Equal(t, v2, c3.Get(k2))
-	c3.Delete(k)
-	c3.Write()
+	assertGetHas(t, c3, k, v, true)
+	assertGetHas(t, c3, k2, v2, true)
+	err = c3.Delete(k)
+	assert.Nil(t, err)
+	err = c3.Write()
+	assert.Nil(t, err)
 
 	// make sure it commits proper
-	assert.Nil(t, base.Get(k))
-	assert.Equal(t, v2, base.Get(k2))
-	assert.Nil(t, base.Get(k3))
+	assertGetHas(t, c2, k, nil, false)
+	assertGetHas(t, c2, k2, v2, true)
+	assertGetHas(t, c2, k3, nil, false)
 }
 
 // TestCacheConflicts checks that we can handle
@@ -133,29 +140,19 @@ func TestCacheConflicts(t *testing.T) {
 
 			// now check the parent is unaffected
 			for _, q := range tc.parentQueries {
-				res := parent.Get(q.Key)
-				assert.Equal(t, q.Value, res)
-				has := parent.Has(q.Key)
-				assert.Equal(t, q.Value != nil, has)
+				assertGetHas(t, parent, q.Key, q.Value, q.Value != nil)
 			}
 
 			// the child shows changes
 			for _, q := range tc.childQueries {
-				res := child.Get(q.Key)
-				assert.Equal(t, q.Value, res)
-				has := child.Has(q.Key)
-				assert.Equal(t, q.Value != nil, has)
+				assertGetHas(t, child, q.Key, q.Value, q.Value != nil)
 			}
 
 			// write child to parent and make sure it also shows proper data
 			child.Write()
 			for _, q := range tc.childQueries {
-				res := parent.Get(q.Key)
-				assert.Equal(t, q.Value, res)
-				has := parent.Has(q.Key)
-				assert.Equal(t, q.Value != nil, has)
+				assertGetHas(t, parent, q.Key, q.Value, q.Value != nil)
 			}
-
 			close()
 		})
 	}
@@ -188,7 +185,8 @@ func TestCommitOverwrite(t *testing.T) {
 			// only one to trigger a cleanup
 			commit.numHistory = 1
 
-			id := commit.LatestVersion()
+			id, err := commit.LatestVersion()
+			assert.Nil(t, err)
 			assert.Equal(t, int64(0), id.Version)
 			if len(id.Hash) != 0 {
 				t.Fatal("hash is not empty")
@@ -200,7 +198,8 @@ func TestCommitOverwrite(t *testing.T) {
 			}
 			// write data to backing store
 			parent.Write()
-			id = commit.Commit()
+			id, err = commit.Commit()
+			assert.Nil(t, err)
 			assert.Equal(t, int64(1), id.Version)
 			if len(id.Hash) == 0 {
 				t.Fatal("hash is empty")
@@ -217,29 +216,21 @@ func TestCommitOverwrite(t *testing.T) {
 
 			// now check that side gets unmodified parent state
 			for _, q := range tc.parentQueries {
-				res := side.Get(q.Key)
-				assert.Equal(t, q.Value, res)
-				has := side.Has(q.Key)
-				assert.Equal(t, q.Value != nil, has)
+				assertGetHas(t, side, q.Key, q.Value, q.Value != nil)
 			}
 
 			// the child shows changes
 			for _, q := range tc.childQueries {
-				res := child.Get(q.Key)
-				assert.Equal(t, q.Value, res)
-				has := child.Has(q.Key)
-				assert.Equal(t, q.Value != nil, has)
+				assertGetHas(t, child, q.Key, q.Value, q.Value != nil)
 			}
 
 			// write child to parent and make sure it also shows proper data
 			child.Write()
 			for _, q := range tc.childQueries {
-				res := side.Get(q.Key)
-				assert.Equal(t, q.Value, res)
-				has := side.Has(q.Key)
-				assert.Equal(t, q.Value != nil, has)
+				assertGetHas(t, side, q.Key, q.Value, q.Value != nil)
 			}
-			id = commit.Commit()
+			id, err = commit.Commit()
+			assert.Nil(t, err)
 			assert.Equal(t, int64(2), id.Version)
 
 			close()
@@ -468,11 +459,13 @@ type rangeQuery struct {
 func (q rangeQuery) check(t testing.TB, kv store.KVStore, msg string) {
 	t.Helper()
 	var iter store.Iterator
+	var err error
 	if q.reverse {
-		iter = kv.ReverseIterator(q.start, q.end)
+		iter, err = kv.ReverseIterator(q.start, q.end)
 	} else {
-		iter = kv.Iterator(q.start, q.end)
+		iter, err = kv.Iterator(q.start, q.end)
 	}
+	assert.Nil(t, err)
 
 	// Make sure proper iteration works.
 	for i := 0; i < len(q.expected); i++ {

--- a/store/recorder.go
+++ b/store/recorder.go
@@ -40,22 +40,21 @@ var _ KVStore = (*recordingStore)(nil)
 // KVPairs returns the content of changes as KVPairs
 // Key is the merkle store key that changes.
 // Value is "s" or "d" for set or delete.
+// TODO: don't use map as return value!!
 func (r *recordingStore) KVPairs() map[string][]byte {
 	return r.changes
 }
 
 // Set records the changes while performing
-//
-// TODO: record new value???
-func (r *recordingStore) Set(key, value []byte) {
+func (r *recordingStore) Set(key, value []byte) error {
 	r.changes[string(key)] = value
-	r.KVStore.Set(key, value)
+	return r.KVStore.Set(key, value)
 }
 
 // Delete records the changes while performing
-func (r *recordingStore) Delete(key []byte) {
+func (r *recordingStore) Delete(key []byte) error {
 	r.changes[string(key)] = nil
-	r.KVStore.Delete(key)
+	return r.KVStore.Delete(key)
 }
 
 // NewBatch makes sure all writes go through this one
@@ -81,6 +80,7 @@ var _ CacheableKVStore = (*cacheableRecordingStore)(nil)
 // KVPairs returns the content of changes as KVPairs
 // Key is the merkle store key that changes.
 // Value is the value writen (for set), or nil (for delete)
+// TODO: don't use map as return value!!
 func (r *cacheableRecordingStore) KVPairs() map[string][]byte {
 	return r.changes
 }
@@ -88,15 +88,15 @@ func (r *cacheableRecordingStore) KVPairs() map[string][]byte {
 // Set records the changes while performing
 //
 // TODO: record new value???
-func (r *cacheableRecordingStore) Set(key, value []byte) {
+func (r *cacheableRecordingStore) Set(key, value []byte) error {
 	r.changes[string(key)] = value
-	r.CacheableKVStore.Set(key, value)
+	return r.CacheableKVStore.Set(key, value)
 }
 
 // Delete records the changes while performing
-func (r *cacheableRecordingStore) Delete(key []byte) {
+func (r *cacheableRecordingStore) Delete(key []byte) error {
 	r.changes[string(key)] = nil
-	r.CacheableKVStore.Delete(key)
+	return r.CacheableKVStore.Delete(key)
 }
 
 // NewBatch makes sure all writes go through this one
@@ -123,17 +123,17 @@ type recorderBatch struct {
 
 var _ Batch = (*recorderBatch)(nil)
 
-func (r *recorderBatch) Set(key, value []byte) {
+func (r *recorderBatch) Set(key, value []byte) error {
 	r.changes[string(key)] = value
-	r.b.Set(key, value)
+	return r.b.Set(key, value)
 }
 
 // Delete records the changes while performing
-func (r *recorderBatch) Delete(key []byte) {
+func (r *recorderBatch) Delete(key []byte) error {
 	r.changes[string(key)] = nil
-	r.b.Delete(key)
+	return r.b.Delete(key)
 }
 
-func (r *recorderBatch) Write() {
-	r.b.Write()
+func (r *recorderBatch) Write() error {
+	return r.b.Write()
 }

--- a/x/distribution/model.go
+++ b/x/distribution/model.go
@@ -109,7 +109,10 @@ func NewRevenueBucket() *RevenueBucket {
 // Create adds given revenue instance to the store and returns the ID of the
 // newly inserted entity.
 func (b *RevenueBucket) Create(db weave.KVStore, rev *Revenue) (orm.Object, error) {
-	key := b.idSeq.NextVal(db)
+	key, err := b.idSeq.NextVal(db)
+	if err != nil {
+		return nil, err
+	}
 	obj := orm.NewSimpleObj(key, rev)
 	return obj, b.Bucket.Save(db, obj)
 }

--- a/x/escrow/handler.go
+++ b/x/escrow/handler.go
@@ -79,7 +79,10 @@ func (h CreateEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore, tx wea
 		Timeout:   msg.Timeout,
 		Memo:      msg.Memo,
 	}
-	obj := h.bucket.Build(db, escrow)
+	obj, err := h.bucket.Build(db, escrow)
+	if err != nil {
+		return nil, err
+	}
 
 	// deposit amounts
 	escrowAddr := Condition(obj.Key()).Address()

--- a/x/escrow/init.go
+++ b/x/escrow/init.go
@@ -39,7 +39,10 @@ func (i *Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
 		if err := escr.Validate(); err != nil {
 			return errors.Wrapf(err, "invalid escrow at position: %d ", j)
 		}
-		obj := bucket.Build(db, &escr)
+		obj, err := bucket.Build(db, &escr)
+		if err != nil {
+			return err
+		}
 		if err := bucket.Save(db, obj); err != nil {
 			return err
 		}

--- a/x/escrow/model.go
+++ b/x/escrow/model.go
@@ -165,9 +165,12 @@ func idxArbiter(obj orm.Object) ([]byte, error) {
 
 // Build assigns an ID to given escrow instance and returns it as an orm
 // Object. It does not persist the escrow in the store.
-func (b Bucket) Build(db weave.KVStore, escrow *Escrow) orm.Object {
-	key := b.idSeq.NextVal(db)
-	return orm.NewSimpleObj(key, escrow)
+func (b Bucket) Build(db weave.KVStore, escrow *Escrow) (orm.Object, error) {
+	key, err := b.idSeq.NextVal(db)
+	if err != nil {
+		return nil, err
+	}
+	return orm.NewSimpleObj(key, escrow), nil
 }
 
 // Save enforces the proper type

--- a/x/gov/bucket.go
+++ b/x/gov/bucket.go
@@ -23,9 +23,12 @@ func NewElectorateBucket() *ElectorateBucket {
 
 // Build assigns an ID to given electorate instance and returns it as an orm
 // Object. It does not persist the object in the store.
-func (b *ElectorateBucket) Build(db weave.KVStore, e *Electorate) orm.Object {
-	key := b.idSeq.NextVal(db)
-	return orm.NewSimpleObj(key, e)
+func (b *ElectorateBucket) Build(db weave.KVStore, e *Electorate) (orm.Object, error) {
+	key, err := b.idSeq.NextVal(db)
+	if err != nil {
+		return nil, err
+	}
+	return orm.NewSimpleObj(key, e), nil
 }
 
 // GetElectorate loads the electorate for the given id. If it does not exist then ErrNotFound is returned.
@@ -61,9 +64,12 @@ func NewElectionRulesBucket() *ElectionRulesBucket {
 
 // Build assigns an ID to given election rule instance and returns it as an orm
 // Object. It does not persist the object in the store.
-func (b *ElectionRulesBucket) Build(db weave.KVStore, r *ElectionRule) orm.Object {
-	key := b.idSeq.NextVal(db)
-	return orm.NewSimpleObj(key, r)
+func (b *ElectionRulesBucket) Build(db weave.KVStore, r *ElectionRule) (orm.Object, error) {
+	key, err := b.idSeq.NextVal(db)
+	if err != nil {
+		return nil, err
+	}
+	return orm.NewSimpleObj(key, r), nil
 }
 
 // GetElectionRule loads the electorate for the given id. If it does not exist then ErrNotFound is returned.
@@ -99,9 +105,12 @@ func NewProposalBucket() *ProposalBucket {
 
 // Build assigns an ID to given proposal instance and returns it as an orm
 // Object. It does not persist the object in the store.
-func (b *ProposalBucket) Build(db weave.KVStore, e *TextProposal) orm.Object {
-	key := b.idSeq.NextVal(db)
-	return orm.NewSimpleObj(key, e)
+func (b *ProposalBucket) Build(db weave.KVStore, e *TextProposal) (orm.Object, error) {
+	key, err := b.idSeq.NextVal(db)
+	if err != nil {
+		return nil, err
+	}
+	return orm.NewSimpleObj(key, e), nil
 }
 
 // GetTextProposal loads the proposal for the given id. If it does not exist then ErrNotFound is returned.

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -235,7 +235,10 @@ func (h TextProposalHandler) Deliver(ctx weave.Context, db weave.KVStore, tx wea
 		Result: TextProposal_Undefined,
 	}
 
-	obj := h.propBucket.Build(db, proposal)
+	obj, err := h.propBucket.Build(db, proposal)
+	if err != nil {
+		return nil, err
+	}
 	if err := h.propBucket.Save(db, obj); err != nil {
 		return nil, errors.Wrap(err, "failed to persist proposal")
 	}

--- a/x/gov/init.go
+++ b/x/gov/init.go
@@ -56,7 +56,10 @@ func (*Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
 		if err := electorate.Validate(); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("electorate #%d is invalid", i))
 		}
-		obj := electBucket.Build(db, &electorate)
+		obj, err := electBucket.Build(db, &electorate)
+		if err != nil {
+			return err
+		}
 		if err := electBucket.Save(db, obj); err != nil {
 			return err
 		}
@@ -72,7 +75,10 @@ func (*Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
 		if err := rule.Validate(); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("eletionRule #%d is invalid", i))
 		}
-		obj := rulesBucket.Build(db, &rule)
+		obj, err := rulesBucket.Build(db, &rule)
+		if err != nil {
+			return err
+		}
 		if err := rulesBucket.Save(db, obj); err != nil {
 			return err
 		}

--- a/x/multisig/decorator_test.go
+++ b/x/multisig/decorator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/weavetest"
+	"github.com/iov-one/weave/weavetest/assert"
 	"github.com/iov-one/weave/x"
 )
 
@@ -170,7 +171,8 @@ func createContract(t testing.TB, db weave.KVStore, c Contract) []byte {
 	t.Helper()
 
 	b := NewContractBucket()
-	obj := b.Build(db, &c)
+	obj, err := b.Build(db, &c)
+	assert.Nil(t, err)
 	if err := b.Save(db, obj); err != nil {
 		t.Fatalf("cannot create a contract: %s", err)
 	}

--- a/x/multisig/handlers.go
+++ b/x/multisig/handlers.go
@@ -48,7 +48,10 @@ func (h CreateContractMsgHandler) Deliver(ctx weave.Context, db weave.KVStore, t
 		AdminThreshold:      msg.AdminThreshold,
 	}
 
-	obj := h.bucket.Build(db, contract)
+	obj, err := h.bucket.Build(db, contract)
+	if err != nil {
+		return nil, err
+	}
 	if err = h.bucket.Save(db, obj); err != nil {
 		return nil, err
 	}

--- a/x/multisig/handlers_test.go
+++ b/x/multisig/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/weavetest"
+	"github.com/iov-one/weave/weavetest/assert"
 )
 
 func TestCreateContractHandler(t *testing.T) {
@@ -245,7 +246,7 @@ func TestUpdateContractHandler(t *testing.T) {
 			tx := &weavetest.Tx{Msg: tc.Msg}
 
 			b := NewContractBucket()
-			err := b.Save(db, b.Build(db, &Contract{
+			contract, err := b.Build(db, &Contract{
 				Participants: []*Participant{
 					{Power: 1, Signature: alice},
 					{Power: 2, Signature: bobby},
@@ -253,10 +254,10 @@ func TestUpdateContractHandler(t *testing.T) {
 				},
 				ActivationThreshold: 2,
 				AdminThreshold:      3,
-			}))
-			if err != nil {
-				t.Fatalf("cannot create a contract: %s", err)
-			}
+			})
+			assert.Nil(t, err)
+			err = b.Save(db, contract)
+			assert.Nil(t, err)
 
 			cache := db.CacheWrap()
 			if _, err := rt.Check(ctx, cache, tx); !tc.WantCheckErr.Is(err) {

--- a/x/multisig/init.go
+++ b/x/multisig/init.go
@@ -37,7 +37,10 @@ func (*Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
 			ActivationThreshold: c.ActivationThreshold,
 			AdminThreshold:      c.AdminThreshold,
 		}
-		obj := bucket.Build(db, &contract)
+		obj, err := bucket.Build(db, &contract)
+		if err != nil {
+			return err
+		}
 		if err := bucket.Save(db, obj); err != nil {
 			return err
 		}

--- a/x/multisig/model.go
+++ b/x/multisig/model.go
@@ -92,9 +92,12 @@ func (b ContractBucket) Save(db weave.KVStore, obj orm.Object) error {
 
 // Build assigns an ID to given contract instance and returns it as an orm
 // Object. It does not persist the escrow in the store.
-func (b ContractBucket) Build(db weave.KVStore, c *Contract) orm.Object {
-	key := b.idSeq.NextVal(db)
-	return orm.NewSimpleObj(key, c)
+func (b ContractBucket) Build(db weave.KVStore, c *Contract) (orm.Object, error) {
+	key, err := b.idSeq.NextVal(db)
+	if err != nil {
+		return nil, err
+	}
+	return orm.NewSimpleObj(key, c), nil
 }
 
 // GetContract returns a contract with given ID.

--- a/x/paychan/model.go
+++ b/x/paychan/model.go
@@ -61,7 +61,10 @@ func NewPaymentChannelBucket() PaymentChannelBucket {
 // Create adds given payment store entity to the store and returns the ID of
 // the newly inserted entity.
 func (b *PaymentChannelBucket) Create(db weave.KVStore, pc *PaymentChannel) (orm.Object, error) {
-	key := b.idSeq.NextVal(db)
+	key, err := b.idSeq.NextVal(db)
+	if err != nil {
+		return nil, err
+	}
 	obj := orm.NewSimpleObj(key, pc)
 	return obj, b.Bucket.Save(db, obj)
 }

--- a/x/utils/savepoint_test.go
+++ b/x/utils/savepoint_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/store"
-	"github.com/stretchr/testify/assert"
+	"github.com/iov-one/weave/weavetest/assert"
 )
 
 func TestSavepoint(t *testing.T) {
@@ -97,16 +97,26 @@ func TestSavepoint(t *testing.T) {
 			}
 
 			if tc.isError {
-				assert.Error(t, err)
+				if err == nil {
+					t.Fatalf("Expected error")
+				}
 			} else {
-				assert.NoError(t, err)
+				assert.Nil(t, err)
 			}
 
 			for _, k := range tc.written {
-				assert.True(t, kv.Has(k), "%x", k)
+				has, err := kv.Has(k)
+				assert.Nil(t, err)
+				if !has {
+					t.Errorf("Didn't write key: %X", k)
+				}
 			}
 			for _, k := range tc.missing {
-				assert.False(t, kv.Has(k), "%x", k)
+				has, err := kv.Has(k)
+				assert.Nil(t, err)
+				if has {
+					t.Errorf("Wrote missing value: %X", k)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Closes #546 

This updates all kvstore interfaces to return a second error return value so we never need to panic. This is mainly in preparation for out-of-process stores, but did remove a few panics from our code as well.

In the process, I replaced some usages of testify/assert with weavetest and stdlib.

This compiles and tests pass. 
I did my best effort on properly wrapping error types.

Look forward to review feedback
