### PR TITLE
Schema migration issue 564

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 
 ## HEAD
 
+- Added `migration` package. Schema versioning can be implemented by relying on
+  functionality provided by this package.
 - `gconf` package was reimplemented from scratch
 - `x/cash` is using new `gconf` package for configuration. New genesis path is
-  used. To update genesis file, replace "gconf": { "cash:xyz": "foo" } 
+  used. To update genesis file, replace "gconf": { "cash:xyz": "foo" }
   with "conf": { "cash": { "xyz": "foo" } }
 - Tests were cleaned up and no use testify or convey packages. A new package
   `weavetest/assert` contains test helpers
@@ -14,7 +16,8 @@
 - Introducing go modules instead of dep
 - Removed support for go 1.10
 - Added support for go 1.12
-- Bumped minimum required version of go to 1.11.4+ as otherwise some commands fail because of go mod constraints
+- Bumped minimum required version of go to 1.11.4+ as otherwise some commands
+  fail because of go mod constraints
 
 
 ## 0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## HEAD
 
+
 - Added `migration` package. Schema versioning can be implemented by relying on
   functionality provided by this package.
 - `gconf` package was reimplemented from scratch
@@ -18,6 +19,13 @@
 - Added support for go 1.12
 - Bumped minimum required version of go to 1.11.4+ as otherwise some commands
   fail because of go mod constraints
+
+Breaking changes
+
+- x/cash is using schema versioned model and messages
+- x/paychan is using schema versioned model and messages
+- x/escrow is using schema versioned model and messages
+- x/distribution is using schema versioned model and messages
 
 
 ## 0.13.0

--- a/cmd/bcpd/app/init.go
+++ b/cmd/bcpd/app/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/commands/server"
 	"github.com/iov-one/weave/crypto"
+	"github.com/iov-one/weave/migration"
 	"github.com/iov-one/weave/x/cash"
 	"github.com/iov-one/weave/x/currency"
 	"github.com/iov-one/weave/x/distribution"
@@ -82,6 +83,7 @@ func GenerateApp(options *server.Options) (abci.Application, error) {
 		return nil, err
 	}
 	application.WithInit(app.ChainInitializers(
+		&migration.Initializer{},
 		&multisig.Initializer{},
 		&cash.Initializer{},
 		&currency.Initializer{},

--- a/cmd/bnsd/client/tx.go
+++ b/cmd/bnsd/client/tx.go
@@ -20,10 +20,11 @@ func BuildSendTx(src, dest weave.Address, amount coin.Coin, memo string) *app.Tx
 	return &app.Tx{
 		Sum: &app.Tx_SendMsg{
 			SendMsg: &cash.SendMsg{
-				Src:    src,
-				Dest:   dest,
-				Amount: &amount,
-				Memo:   memo,
+				Metadata: &weave.Metadata{Schema: 1},
+				Src:      src,
+				Dest:     dest,
+				Amount:   &amount,
+				Memo:     memo,
 			},
 			// TODO: add fees, etc...
 		},

--- a/cmd/bnsd/scenarios/distribution_test.go
+++ b/cmd/bnsd/scenarios/distribution_test.go
@@ -21,7 +21,8 @@ func TestRevenueDistribution(t *testing.T) {
 	newRevenueTx := &bnsdApp.Tx{
 		Sum: &bnsdApp.Tx_NewRevenueMsg{
 			NewRevenueMsg: &distribution.NewRevenueMsg{
-				Admin: admin.PublicKey().Address(),
+				Metadata: &weave.Metadata{Schema: 1},
+				Admin:    admin.PublicKey().Address(),
 				Recipients: []*distribution.Recipient{
 					{Address: recipients[0], Weight: 1},
 					{Address: recipients[1], Weight: 2},
@@ -87,6 +88,7 @@ func TestRevenueDistribution(t *testing.T) {
 	resetRevenueTx := &bnsdApp.Tx{
 		Sum: &bnsdApp.Tx_ResetRevenueMsg{
 			ResetRevenueMsg: &distribution.ResetRevenueMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
 				RevenueID: revenueID,
 				Recipients: []*distribution.Recipient{
 					{Address: recipients[0], Weight: 321},
@@ -139,6 +141,7 @@ func TestRevenueDistribution(t *testing.T) {
 	distributeTx := &bnsdApp.Tx{
 		Sum: &bnsdApp.Tx_DistributeMsg{
 			DistributeMsg: &distribution.DistributeMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
 				RevenueID: revenueID,
 			},
 		},

--- a/cmd/bnsd/scenarios/escrow_test.go
+++ b/cmd/bnsd/scenarios/escrow_test.go
@@ -3,6 +3,7 @@ package scenarios
 import (
 	"testing"
 
+	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/cmd/bnsd/app"
 	"github.com/iov-one/weave/cmd/bnsd/client"
 	"github.com/iov-one/weave/coin"
@@ -35,6 +36,7 @@ func TestEscrowRelease(t *testing.T) {
 	releaseEscrowTX := &app.Tx{
 		Sum: &app.Tx_ReleaseEscrowMsg{
 			ReleaseEscrowMsg: &escrow.ReleaseEscrowMsg{
+				Metadata: &weave.Metadata{Schema: 1},
 				EscrowId: escrowID,
 				Amount:   []*coin.Coin{{Ticker: "IOV", Whole: 1}},
 			},

--- a/docs/proto/index.html
+++ b/docs/proto/index.html
@@ -175,6 +175,44 @@
         
           
           <li>
+            <a href="#codec.proto">codec.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#weave.Metadata"><span class="badge">M</span>Metadata</a>
+                </li>
+              
+              
+              
+              
+            </ul>
+          </li>
+        
+          
+          <li>
+            <a href="#migration%2fcodec.proto">migration/codec.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#migration.Configuration"><span class="badge">M</span>Configuration</a>
+                </li>
+              
+                <li>
+                  <a href="#migration.Schema"><span class="badge">M</span>Schema</a>
+                </li>
+              
+                <li>
+                  <a href="#migration.UpgradeSchemaMsg"><span class="badge">M</span>UpgradeSchemaMsg</a>
+                </li>
+              
+              
+              
+              
+            </ul>
+          </li>
+        
+          
+          <li>
             <a href="#cmd%2fbnsd%2fapp%2fcodec.proto">cmd/bnsd/app/codec.proto</a>
             <ul>
               
@@ -225,44 +263,6 @@
         
           
           <li>
-            <a href="#crypto%2fmodels.proto">crypto/models.proto</a>
-            <ul>
-              
-                <li>
-                  <a href="#crypto.PrivateKey"><span class="badge">M</span>PrivateKey</a>
-                </li>
-              
-                <li>
-                  <a href="#crypto.PublicKey"><span class="badge">M</span>PublicKey</a>
-                </li>
-              
-                <li>
-                  <a href="#crypto.Signature"><span class="badge">M</span>Signature</a>
-                </li>
-              
-              
-              
-              
-            </ul>
-          </li>
-        
-          
-          <li>
-            <a href="#app%2fresults.proto">app/results.proto</a>
-            <ul>
-              
-                <li>
-                  <a href="#app.ResultSet"><span class="badge">M</span>ResultSet</a>
-                </li>
-              
-              
-              
-              
-            </ul>
-          </li>
-        
-          
-          <li>
             <a href="#coin%2fcodec.proto">coin/codec.proto</a>
             <ul>
               
@@ -297,23 +297,11 @@
         
           
           <li>
-            <a href="#x%2fnamecoin%2fcodec.proto">x/namecoin/codec.proto</a>
+            <a href="#app%2fresults.proto">app/results.proto</a>
             <ul>
               
                 <li>
-                  <a href="#namecoin.NewTokenMsg"><span class="badge">M</span>NewTokenMsg</a>
-                </li>
-              
-                <li>
-                  <a href="#namecoin.SetWalletNameMsg"><span class="badge">M</span>SetWalletNameMsg</a>
-                </li>
-              
-                <li>
-                  <a href="#namecoin.Token"><span class="badge">M</span>Token</a>
-                </li>
-              
-                <li>
-                  <a href="#namecoin.Wallet"><span class="badge">M</span>Wallet</a>
+                  <a href="#app.ResultSet"><span class="badge">M</span>ResultSet</a>
                 </li>
               
               
@@ -324,120 +312,19 @@
         
           
           <li>
-            <a href="#x%2fnft%2fcodec.proto">x/nft/codec.proto</a>
+            <a href="#crypto%2fmodels.proto">crypto/models.proto</a>
             <ul>
               
                 <li>
-                  <a href="#nft.ActionApprovals"><span class="badge">M</span>ActionApprovals</a>
+                  <a href="#crypto.PrivateKey"><span class="badge">M</span>PrivateKey</a>
                 </li>
               
                 <li>
-                  <a href="#nft.AddApprovalMsg"><span class="badge">M</span>AddApprovalMsg</a>
+                  <a href="#crypto.PublicKey"><span class="badge">M</span>PublicKey</a>
                 </li>
               
                 <li>
-                  <a href="#nft.Approval"><span class="badge">M</span>Approval</a>
-                </li>
-              
-                <li>
-                  <a href="#nft.ApprovalOptions"><span class="badge">M</span>ApprovalOptions</a>
-                </li>
-              
-                <li>
-                  <a href="#nft.NonFungibleToken"><span class="badge">M</span>NonFungibleToken</a>
-                </li>
-              
-                <li>
-                  <a href="#nft.RemoveApprovalMsg"><span class="badge">M</span>RemoveApprovalMsg</a>
-                </li>
-              
-              
-              
-              
-            </ul>
-          </li>
-        
-          
-          <li>
-            <a href="#x%2fcash%2fcodec.proto">x/cash/codec.proto</a>
-            <ul>
-              
-                <li>
-                  <a href="#cash.Configuration"><span class="badge">M</span>Configuration</a>
-                </li>
-              
-                <li>
-                  <a href="#cash.ConfigurationMsg"><span class="badge">M</span>ConfigurationMsg</a>
-                </li>
-              
-                <li>
-                  <a href="#cash.FeeInfo"><span class="badge">M</span>FeeInfo</a>
-                </li>
-              
-                <li>
-                  <a href="#cash.SendMsg"><span class="badge">M</span>SendMsg</a>
-                </li>
-              
-                <li>
-                  <a href="#cash.Set"><span class="badge">M</span>Set</a>
-                </li>
-              
-              
-              
-              
-            </ul>
-          </li>
-        
-          
-          <li>
-            <a href="#x%2fdistribution%2fcodec.proto">x/distribution/codec.proto</a>
-            <ul>
-              
-                <li>
-                  <a href="#distribution.DistributeMsg"><span class="badge">M</span>DistributeMsg</a>
-                </li>
-              
-                <li>
-                  <a href="#distribution.NewRevenueMsg"><span class="badge">M</span>NewRevenueMsg</a>
-                </li>
-              
-                <li>
-                  <a href="#distribution.Recipient"><span class="badge">M</span>Recipient</a>
-                </li>
-              
-                <li>
-                  <a href="#distribution.ResetRevenueMsg"><span class="badge">M</span>ResetRevenueMsg</a>
-                </li>
-              
-                <li>
-                  <a href="#distribution.Revenue"><span class="badge">M</span>Revenue</a>
-                </li>
-              
-              
-              
-              
-            </ul>
-          </li>
-        
-          
-          <li>
-            <a href="#x%2fmultisig%2fcodec.proto">x/multisig/codec.proto</a>
-            <ul>
-              
-                <li>
-                  <a href="#multisig.Contract"><span class="badge">M</span>Contract</a>
-                </li>
-              
-                <li>
-                  <a href="#multisig.CreateContractMsg"><span class="badge">M</span>CreateContractMsg</a>
-                </li>
-              
-                <li>
-                  <a href="#multisig.Participant"><span class="badge">M</span>Participant</a>
-                </li>
-              
-                <li>
-                  <a href="#multisig.UpdateContractMsg"><span class="badge">M</span>UpdateContractMsg</a>
+                  <a href="#crypto.Signature"><span class="badge">M</span>Signature</a>
                 </li>
               
               
@@ -453,21 +340,6 @@
               
                 <li>
                   <a href="#msgfee.MsgFee"><span class="badge">M</span>MsgFee</a>
-                </li>
-              
-              
-              
-              
-            </ul>
-          </li>
-        
-          
-          <li>
-            <a href="#x%2fbatch%2fcodec.proto">x/batch/codec.proto</a>
-            <ul>
-              
-                <li>
-                  <a href="#batch.ByteArrayList"><span class="badge">M</span>ByteArrayList</a>
                 </li>
               
               
@@ -509,23 +381,27 @@
         
           
           <li>
-            <a href="#x%2fvalidators%2fcodec.proto">x/validators/codec.proto</a>
+            <a href="#x%2fcash%2fcodec.proto">x/cash/codec.proto</a>
             <ul>
               
                 <li>
-                  <a href="#validators.Accounts"><span class="badge">M</span>Accounts</a>
+                  <a href="#cash.Configuration"><span class="badge">M</span>Configuration</a>
                 </li>
               
                 <li>
-                  <a href="#validators.Pubkey"><span class="badge">M</span>Pubkey</a>
+                  <a href="#cash.ConfigurationMsg"><span class="badge">M</span>ConfigurationMsg</a>
                 </li>
               
                 <li>
-                  <a href="#validators.SetValidatorsMsg"><span class="badge">M</span>SetValidatorsMsg</a>
+                  <a href="#cash.FeeInfo"><span class="badge">M</span>FeeInfo</a>
                 </li>
               
                 <li>
-                  <a href="#validators.ValidatorUpdate"><span class="badge">M</span>ValidatorUpdate</a>
+                  <a href="#cash.SendMsg"><span class="badge">M</span>SendMsg</a>
+                </li>
+              
+                <li>
+                  <a href="#cash.Set"><span class="badge">M</span>Set</a>
                 </li>
               
               
@@ -536,27 +412,23 @@
         
           
           <li>
-            <a href="#x%2fpaychan%2fcodec.proto">x/paychan/codec.proto</a>
+            <a href="#x%2fmultisig%2fcodec.proto">x/multisig/codec.proto</a>
             <ul>
               
                 <li>
-                  <a href="#paychan.ClosePaymentChannelMsg"><span class="badge">M</span>ClosePaymentChannelMsg</a>
+                  <a href="#multisig.Contract"><span class="badge">M</span>Contract</a>
                 </li>
               
                 <li>
-                  <a href="#paychan.CreatePaymentChannelMsg"><span class="badge">M</span>CreatePaymentChannelMsg</a>
+                  <a href="#multisig.CreateContractMsg"><span class="badge">M</span>CreateContractMsg</a>
                 </li>
               
                 <li>
-                  <a href="#paychan.Payment"><span class="badge">M</span>Payment</a>
+                  <a href="#multisig.Participant"><span class="badge">M</span>Participant</a>
                 </li>
               
                 <li>
-                  <a href="#paychan.PaymentChannel"><span class="badge">M</span>PaymentChannel</a>
-                </li>
-              
-                <li>
-                  <a href="#paychan.TransferPaymentChannelMsg"><span class="badge">M</span>TransferPaymentChannelMsg</a>
+                  <a href="#multisig.UpdateContractMsg"><span class="badge">M</span>UpdateContractMsg</a>
                 </li>
               
               
@@ -586,19 +458,73 @@
         
           
           <li>
-            <a href="#x%2fsigs%2fcodec.proto">x/sigs/codec.proto</a>
+            <a href="#x%2fbatch%2fcodec.proto">x/batch/codec.proto</a>
             <ul>
               
                 <li>
-                  <a href="#sigs.BumpSequenceMsg"><span class="badge">M</span>BumpSequenceMsg</a>
+                  <a href="#batch.ByteArrayList"><span class="badge">M</span>ByteArrayList</a>
+                </li>
+              
+              
+              
+              
+            </ul>
+          </li>
+        
+          
+          <li>
+            <a href="#x%2fvalidators%2fcodec.proto">x/validators/codec.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#validators.Accounts"><span class="badge">M</span>Accounts</a>
                 </li>
               
                 <li>
-                  <a href="#sigs.StdSignature"><span class="badge">M</span>StdSignature</a>
+                  <a href="#validators.Pubkey"><span class="badge">M</span>Pubkey</a>
                 </li>
               
                 <li>
-                  <a href="#sigs.UserData"><span class="badge">M</span>UserData</a>
+                  <a href="#validators.SetValidatorsMsg"><span class="badge">M</span>SetValidatorsMsg</a>
+                </li>
+              
+                <li>
+                  <a href="#validators.ValidatorUpdate"><span class="badge">M</span>ValidatorUpdate</a>
+                </li>
+              
+              
+              
+              
+            </ul>
+          </li>
+        
+          
+          <li>
+            <a href="#x%2fnft%2fcodec.proto">x/nft/codec.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#nft.ActionApprovals"><span class="badge">M</span>ActionApprovals</a>
+                </li>
+              
+                <li>
+                  <a href="#nft.AddApprovalMsg"><span class="badge">M</span>AddApprovalMsg</a>
+                </li>
+              
+                <li>
+                  <a href="#nft.Approval"><span class="badge">M</span>Approval</a>
+                </li>
+              
+                <li>
+                  <a href="#nft.ApprovalOptions"><span class="badge">M</span>ApprovalOptions</a>
+                </li>
+              
+                <li>
+                  <a href="#nft.NonFungibleToken"><span class="badge">M</span>NonFungibleToken</a>
+                </li>
+              
+                <li>
+                  <a href="#nft.RemoveApprovalMsg"><span class="badge">M</span>RemoveApprovalMsg</a>
                 </li>
               
               
@@ -682,10 +608,270 @@
             </ul>
           </li>
         
+          
+          <li>
+            <a href="#x%2fpaychan%2fcodec.proto">x/paychan/codec.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#paychan.ClosePaymentChannelMsg"><span class="badge">M</span>ClosePaymentChannelMsg</a>
+                </li>
+              
+                <li>
+                  <a href="#paychan.CreatePaymentChannelMsg"><span class="badge">M</span>CreatePaymentChannelMsg</a>
+                </li>
+              
+                <li>
+                  <a href="#paychan.Payment"><span class="badge">M</span>Payment</a>
+                </li>
+              
+                <li>
+                  <a href="#paychan.PaymentChannel"><span class="badge">M</span>PaymentChannel</a>
+                </li>
+              
+                <li>
+                  <a href="#paychan.TransferPaymentChannelMsg"><span class="badge">M</span>TransferPaymentChannelMsg</a>
+                </li>
+              
+              
+              
+              
+            </ul>
+          </li>
+        
+          
+          <li>
+            <a href="#x%2fdistribution%2fcodec.proto">x/distribution/codec.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#distribution.DistributeMsg"><span class="badge">M</span>DistributeMsg</a>
+                </li>
+              
+                <li>
+                  <a href="#distribution.NewRevenueMsg"><span class="badge">M</span>NewRevenueMsg</a>
+                </li>
+              
+                <li>
+                  <a href="#distribution.Recipient"><span class="badge">M</span>Recipient</a>
+                </li>
+              
+                <li>
+                  <a href="#distribution.ResetRevenueMsg"><span class="badge">M</span>ResetRevenueMsg</a>
+                </li>
+              
+                <li>
+                  <a href="#distribution.Revenue"><span class="badge">M</span>Revenue</a>
+                </li>
+              
+              
+              
+              
+            </ul>
+          </li>
+        
+          
+          <li>
+            <a href="#x%2fsigs%2fcodec.proto">x/sigs/codec.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#sigs.BumpSequenceMsg"><span class="badge">M</span>BumpSequenceMsg</a>
+                </li>
+              
+                <li>
+                  <a href="#sigs.StdSignature"><span class="badge">M</span>StdSignature</a>
+                </li>
+              
+                <li>
+                  <a href="#sigs.UserData"><span class="badge">M</span>UserData</a>
+                </li>
+              
+              
+              
+              
+            </ul>
+          </li>
+        
+          
+          <li>
+            <a href="#x%2fnamecoin%2fcodec.proto">x/namecoin/codec.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#namecoin.NewTokenMsg"><span class="badge">M</span>NewTokenMsg</a>
+                </li>
+              
+                <li>
+                  <a href="#namecoin.SetWalletNameMsg"><span class="badge">M</span>SetWalletNameMsg</a>
+                </li>
+              
+                <li>
+                  <a href="#namecoin.Token"><span class="badge">M</span>Token</a>
+                </li>
+              
+                <li>
+                  <a href="#namecoin.Wallet"><span class="badge">M</span>Wallet</a>
+                </li>
+              
+              
+              
+              
+            </ul>
+          </li>
+        
         <li><a href="#scalar-value-types">Scalar Value Types</a></li>
       </ul>
     </div>
 
+    
+      
+      <div class="file-heading">
+        <h2 id="codec.proto">codec.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="weave.Metadata">Metadata</h3>
+        <p>Metadata is expected to be the first argument of every message or model. It</p><p>contains all essential attributes.</p><p>Each protobuf message should be declared with the first attribute being</p><p>weave.Metadata metadata = 1;</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>schema</td>
+                  <td><a href="#uint32">uint32</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="migration/codec.proto">migration/codec.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="migration.Configuration">Configuration</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>admin</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p>Admin holds the address of the administrator allowed to upgrade schema
+versions. If you wish to permit more than one entity to be an admin, use
+multisig. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="migration.Schema">Schema</h3>
+        <p>Schema declares the maxiumum supported schema version for a package.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>pkg</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Pkg holds the name of the package that this migration is declared for.
+For example, for extension `x/myext` package value is `myext` </p></td>
+                </tr>
+              
+                <tr>
+                  <td>version</td>
+                  <td><a href="#uint32">uint32</a></td>
+                  <td></td>
+                  <td><p>Version holds the highest supported schema version. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="migration.UpgradeSchemaMsg">UpgradeSchemaMsg</h3>
+        <p>UpgradeSchemaMsg is a request to upgrade schema version of a given package</p><p>by one version.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>pkg</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Name of the package that schema version upgrade is made for. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+
+      
+
+      
     
       
       <div class="file-heading">
@@ -853,7 +1039,8 @@
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -904,7 +1091,8 @@
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -938,7 +1126,8 @@ blockchain. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -982,7 +1171,8 @@ blockchain. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -1019,7 +1209,8 @@ blockchain. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -1042,7 +1233,8 @@ blockchain. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -1072,127 +1264,8 @@ blockchain. </p></td>
               
             </tbody>
           </table>
-        
 
-        
-      
-
-      
-
-      
-
-      
-    
-      
-      <div class="file-heading">
-        <h2 id="crypto/models.proto">crypto/models.proto</h2><a href="#title">Top</a>
-      </div>
-      <p></p>
-
-      
-        <h3 id="crypto.PrivateKey">PrivateKey</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>ed25519</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="crypto.PublicKey">PublicKey</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>ed25519</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="crypto.Signature">Signature</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>ed25519</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-
-      
-
-      
-
-      
-    
-      
-      <div class="file-heading">
-        <h2 id="app/results.proto">app/results.proto</h2><a href="#title">Top</a>
-      </div>
-      <p></p>
-
-      
-        <h3 id="app.ResultSet">ResultSet</h3>
-        <p>ResultSet contains a list of keys or values</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>results</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td>repeated</td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
+          
 
         
       
@@ -1245,7 +1318,8 @@ all Coins of the same currency can be combined </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -1282,7 +1356,8 @@ all Coins of the same currency can be combined </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -1305,7 +1380,8 @@ all Coins of the same currency can be combined </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -1318,13 +1394,13 @@ all Coins of the same currency can be combined </p></td>
     
       
       <div class="file-heading">
-        <h2 id="x/namecoin/codec.proto">x/namecoin/codec.proto</h2><a href="#title">Top</a>
+        <h2 id="app/results.proto">app/results.proto</h2><a href="#title">Top</a>
       </div>
       <p></p>
 
       
-        <h3 id="namecoin.NewTokenMsg">NewTokenMsg</h3>
-        <p>NewTokenMsg will register a new token.</p><p>This must not conflict with any existing ticker,</p><p>and should be limited to privledged users.</p>
+        <h3 id="app.ResultSet">ResultSet</h3>
+        <p>ResultSet contains a list of keys or values</p>
 
         
           <table class="field-table">
@@ -1334,34 +1410,59 @@ all Coins of the same currency can be combined </p></td>
             <tbody>
               
                 <tr>
-                  <td>ticker</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
+                  <td>results</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td>repeated</td>
                   <td><p> </p></td>
                 </tr>
               
-                <tr>
-                  <td>name</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="crypto/models.proto">crypto/models.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="crypto.PrivateKey">PrivateKey</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
               
                 <tr>
-                  <td>sig_figs</td>
-                  <td><a href="#int32">int32</a></td>
+                  <td>ed25519</td>
+                  <td><a href="#bytes">bytes</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
-        <h3 id="namecoin.SetWalletNameMsg">SetWalletNameMsg</h3>
-        <p>SetWalletNameMsg will set the name on an existing</p><p>wallet. Can only be performed if the wallet name is empty.</p>
+        <h3 id="crypto.PublicKey">PublicKey</h3>
+        <p></p>
 
         
           <table class="field-table">
@@ -1371,27 +1472,170 @@ all Coins of the same currency can be combined </p></td>
             <tbody>
               
                 <tr>
-                  <td>address</td>
+                  <td>ed25519</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="crypto.Signature">Signature</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>ed25519</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="x/msgfee/codec.proto">x/msgfee/codec.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="msgfee.MsgFee">MsgFee</h3>
+        <p>MsgFee represents a fee for a single message that must be paid in order for</p><p>the message to be processed.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>msg_path</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>fee</td>
+                  <td><a href="#coin.Coin">coin.Coin</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="x/escrow/codec.proto">x/escrow/codec.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="escrow.CreateEscrowMsg">CreateEscrowMsg</h3>
+        <p>CreateEscrowMsg is a request to create an Escrow with some tokens.</p><p>If sender is not defined, it defaults to the first signer</p><p>The rest must be defined</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>src</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
               
                 <tr>
-                  <td>name</td>
-                  <td><a href="#string">string</a></td>
+                  <td>arbiter</td>
+                  <td><a href="#bytes">bytes</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
               
+                <tr>
+                  <td>recipient</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>amount</td>
+                  <td><a href="#coin.Coin">coin.Coin</a></td>
+                  <td>repeated</td>
+                  <td><p>amount may contain multiple token types </p></td>
+                </tr>
+              
+                <tr>
+                  <td>timeout</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td></td>
+                  <td><p>Timeout represents wall clock time. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>memo</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>max length 128 character </p></td>
+                </tr>
+              
             </tbody>
           </table>
-        
+
+          
 
         
       
-        <h3 id="namecoin.Token">Token</h3>
-        <p>Token contains information about a registered currency</p>
+        <h3 id="escrow.Escrow">Escrow</h3>
+        <p>Escrow holds some coins.</p><p>The arbiter or sender can release them to the recipient.</p><p>The recipient can return them to the sender.</p><p>Upon timeout, they will be returned to the sender.</p><p>Note that if the arbiter is a Hashlock permission, we have</p><p>an HTLC ;)</p>
 
         
           <table class="field-table">
@@ -1401,27 +1645,62 @@ all Coins of the same currency can be combined </p></td>
             <tbody>
               
                 <tr>
-                  <td>name</td>
-                  <td><a href="#string">string</a></td>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
               
                 <tr>
-                  <td>sig_figs</td>
-                  <td><a href="#int32">int32</a></td>
+                  <td>sender</td>
+                  <td><a href="#bytes">bytes</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
               
+                <tr>
+                  <td>arbiter</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>recipient</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>timeout</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td></td>
+                  <td><p>If unreleased before timeout, escrow will return to sender.
+Timeout represents wall clock time as read from the block header. Timeout
+is represented using POSIX time format.
+Expiration time is inclusive meaning that the escrow expires as soon as
+the current time is equal or greater than timeout value.
+nonexpired: [created, timeout)
+expired: [timeout, infinity) </p></td>
+                </tr>
+              
+                <tr>
+                  <td>memo</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>max length 128 character </p></td>
+                </tr>
+              
             </tbody>
           </table>
-        
+
+          
 
         
       
-        <h3 id="namecoin.Wallet">Wallet</h3>
-        <p>Wallet has a name and a set of coins</p>
+        <h3 id="escrow.ReleaseEscrowMsg">ReleaseEscrowMsg</h3>
+        <p>ReleaseEscrowMsg releases the content to the recipient.</p><p>Must be authorized by sender or arbiter.</p><p>If amount not provided, defaults to entire escrow,</p><p>May be a subset of the current balance.</p>
 
         
           <table class="field-table">
@@ -1431,41 +1710,35 @@ all Coins of the same currency can be combined </p></td>
             <tbody>
               
                 <tr>
-                  <td>coins</td>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>escrow_id</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>amount</td>
                   <td><a href="#coin.Coin">coin.Coin</a></td>
                   <td>repeated</td>
                   <td><p> </p></td>
                 </tr>
               
-                <tr>
-                  <td>name</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
             </tbody>
           </table>
-        
+
+          
 
         
       
-
-      
-
-      
-
-      
-    
-      
-      <div class="file-heading">
-        <h2 id="x/nft/codec.proto">x/nft/codec.proto</h2><a href="#title">Top</a>
-      </div>
-      <p></p>
-
-      
-        <h3 id="nft.ActionApprovals">ActionApprovals</h3>
-        <p>ActionApprovals are used to control permissions and validate that a user can</p><p>execute given operation.</p>
+        <h3 id="escrow.ReturnEscrowMsg">ReturnEscrowMsg</h3>
+        <p>ReturnEscrowMsg returns the content to the sender.</p><p>Must be authorized by the sender or an expired timeout</p>
 
         
           <table class="field-table">
@@ -1475,27 +1748,28 @@ all Coins of the same currency can be combined </p></td>
             <tbody>
               
                 <tr>
-                  <td>action</td>
-                  <td><a href="#string">string</a></td>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
               
                 <tr>
-                  <td>approvals</td>
-                  <td><a href="#nft.Approval">Approval</a></td>
-                  <td>repeated</td>
+                  <td>escrow_id</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
                   <td><p> </p></td>
                 </tr>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
-        <h3 id="nft.AddApprovalMsg">AddApprovalMsg</h3>
-        <p></p>
+        <h3 id="escrow.UpdateEscrowPartiesMsg">UpdateEscrowPartiesMsg</h3>
+        <p>UpdateEscrowPartiesMsg changes any of the parties of the escrow:</p><p>sender, arbiter, recipient. This must be authorized by the current</p><p>holder of that position (eg. only sender can update sender).</p><p>Represents delegating responsibility</p>
 
         
           <table class="field-table">
@@ -1505,198 +1779,44 @@ all Coins of the same currency can be combined </p></td>
             <tbody>
               
                 <tr>
-                  <td>id</td>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>escrow_id</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
               
                 <tr>
-                  <td>address</td>
+                  <td>sender</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
               
                 <tr>
-                  <td>action</td>
-                  <td><a href="#string">string</a></td>
+                  <td>arbiter</td>
+                  <td><a href="#bytes">bytes</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
               
                 <tr>
-                  <td>options</td>
-                  <td><a href="#nft.ApprovalOptions">ApprovalOptions</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>t</td>
-                  <td><a href="#string">string</a></td>
+                  <td>recipient</td>
+                  <td><a href="#bytes">bytes</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
               
             </tbody>
           </table>
-        
 
-        
-      
-        <h3 id="nft.Approval">Approval</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>address</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>options</td>
-                  <td><a href="#nft.ApprovalOptions">ApprovalOptions</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="nft.ApprovalOptions">ApprovalOptions</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>until_block_height</td>
-                  <td><a href="#int64">int64</a></td>
-                  <td></td>
-                  <td><p>Until block height is used to mark blochain height until which an
-approval is valid. This can be used to define an approval expiration. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>count</td>
-                  <td><a href="#int64">int64</a></td>
-                  <td></td>
-                  <td><p>Count is defining how many times an approval can be used. Each approval
-test decrese the counter. Once the counter reaches value 0, an approval
-is considered expired and can no longer be used.
-Use -1 to bypass count expiration. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>immutable</td>
-                  <td><a href="#bool">bool</a></td>
-                  <td></td>
-                  <td><p>Immutable is a flag that prevents an option to be modified. Once
-created, cannot be altered. For example, counter state cannot be
-changed. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="nft.NonFungibleToken">NonFungibleToken</h3>
-        <p>NonFungibleToken is a message that must be incuded by any concrete NFT</p><p>implementation. Usually it is the first attirbute called `base`.</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>id</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p>ID is the address of this token. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>owner</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p>Owner is the address of the token owner. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>action_approvals</td>
-                  <td><a href="#nft.ActionApprovals">ActionApprovals</a></td>
-                  <td>repeated</td>
-                  <td><p>Action approvals is a list of permissions. In order for operation to
-succeed, all action approvals validation must pass. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="nft.RemoveApprovalMsg">RemoveApprovalMsg</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>id</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>address</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>action</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>t</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
+          
 
         
       
@@ -1747,7 +1867,8 @@ succeed, all action approvals validation must pass. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -1765,12 +1886,13 @@ succeed, all action approvals validation must pass. </p></td>
                   <td>patch</td>
                   <td><a href="#cash.Configuration">Configuration</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>TODO: add schema uint32 here </p></td>
                 </tr>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -1783,6 +1905,13 @@ succeed, all action approvals validation must pass. </p></td>
               <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
             </thead>
             <tbody>
+              
+                <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
               
                 <tr>
                   <td>payer</td>
@@ -1800,7 +1929,8 @@ succeed, all action approvals validation must pass. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -1813,6 +1943,13 @@ succeed, all action approvals validation must pass. </p></td>
               <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
             </thead>
             <tbody>
+              
+                <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
               
                 <tr>
                   <td>src</td>
@@ -1851,7 +1988,8 @@ succeed, all action approvals validation must pass. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -1866,6 +2004,13 @@ succeed, all action approvals validation must pass. </p></td>
             <tbody>
               
                 <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
                   <td>coins</td>
                   <td><a href="#coin.Coin">coin.Coin</a></td>
                   <td>repeated</td>
@@ -1874,179 +2019,8 @@ succeed, all action approvals validation must pass. </p></td>
               
             </tbody>
           </table>
-        
 
-        
-      
-
-      
-
-      
-
-      
-    
-      
-      <div class="file-heading">
-        <h2 id="x/distribution/codec.proto">x/distribution/codec.proto</h2><a href="#title">Top</a>
-      </div>
-      <p></p>
-
-      
-        <h3 id="distribution.DistributeMsg">DistributeMsg</h3>
-        <p>DistributeMsg is a request to distribute all funds collected within a single</p><p>revenue instance. Revenue is distributed between recipients. Request must be</p><p>signed using admin key.</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>revenue_id</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p>Revenue ID reference an ID of a revenue instance that the collected fees
-should be distributed between recipients. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="distribution.NewRevenueMsg">NewRevenueMsg</h3>
-        <p>NewRevenueMsg is issuing the creation of a new revenue stream instance.</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>admin</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p>Admin key belongs to the governance entities. It can be used to transfer
-stored amount to an another account.
-While not enforced it is best to use a multisig contract here. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>recipients</td>
-                  <td><a href="#distribution.Recipient">Recipient</a></td>
-                  <td>repeated</td>
-                  <td><p>Recipients holds any number of addresses that the collected revenue is
-distributed to. Must be at least one. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="distribution.Recipient">Recipient</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>address</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p>An address that the funds should be transferred to.
-This should not be the validator addresses, as the keys used to sign
-blocks should never be in a wallet. This can be the wallets of the admins
-of the validators. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>weight</td>
-                  <td><a href="#int32">int32</a></td>
-                  <td></td>
-                  <td><p>Weight defines what part of the total revenue goes to this recipient.
-Each recipient receives part of the total revenue amount proportional to
-the weight. For example, if there are two recipients with weights 1 and 2
-accordingly, distribution will be 1/3 to the first address and 2/3 to the
-second one. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="distribution.ResetRevenueMsg">ResetRevenueMsg</h3>
-        <p>ResetRevenueMsg change the configuration of a revenue instance.</p><p>To assure recipients that they will receive money, every revenue update is</p><p>forcing funds distribution. Before applying any change all funds stored by</p><p>the revenue account are distributed using old configuration. Only when the</p><p>collected revenue amount is equal to zero the change is applied.</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>revenue_id</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p>Revenue ID reference an ID of a revenue instance that is updated. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>recipients</td>
-                  <td><a href="#distribution.Recipient">Recipient</a></td>
-                  <td>repeated</td>
-                  <td><p>Recipients holds any number of addresses that the collected revenue is
-distributed to. Must be at least one. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="distribution.Revenue">Revenue</h3>
-        <p>Revenue represents an account with funds collected from the fees. This is a</p><p>temporary account used for storing fees that are later distributed between</p><p>the owners.</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>admin</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p>Admin key belongs to the governance entities. It can be used to transfer
-stored amount to an another account.
-While not enforced it is best to use a multisig contract here. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>recipients</td>
-                  <td><a href="#distribution.Recipient">Recipient</a></td>
-                  <td>repeated</td>
-                  <td><p>Recipients holds any number of addresses that the collected revenue is
-distributed to. Must be at least one. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
+          
 
         
       
@@ -2102,7 +2076,8 @@ computed as the sum of weights of all participating signatures. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -2139,7 +2114,8 @@ computed as the sum of weights of all participating signatures. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -2169,7 +2145,8 @@ computed as the sum of weights of all participating signatures. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -2213,682 +2190,8 @@ computed as the sum of weights of all participating signatures. </p></td>
               
             </tbody>
           </table>
-        
 
-        
-      
-
-      
-
-      
-
-      
-    
-      
-      <div class="file-heading">
-        <h2 id="x/msgfee/codec.proto">x/msgfee/codec.proto</h2><a href="#title">Top</a>
-      </div>
-      <p></p>
-
-      
-        <h3 id="msgfee.MsgFee">MsgFee</h3>
-        <p>MsgFee represents a fee for a single message that must be paid in order for</p><p>the message to be processed.</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>msg_path</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>fee</td>
-                  <td><a href="#coin.Coin">coin.Coin</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-
-      
-
-      
-
-      
-    
-      
-      <div class="file-heading">
-        <h2 id="x/batch/codec.proto">x/batch/codec.proto</h2><a href="#title">Top</a>
-      </div>
-      <p></p>
-
-      
-        <h3 id="batch.ByteArrayList">ByteArrayList</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>elements</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td>repeated</td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-
-      
-
-      
-
-      
-    
-      
-      <div class="file-heading">
-        <h2 id="x/escrow/codec.proto">x/escrow/codec.proto</h2><a href="#title">Top</a>
-      </div>
-      <p></p>
-
-      
-        <h3 id="escrow.CreateEscrowMsg">CreateEscrowMsg</h3>
-        <p>CreateEscrowMsg is a request to create an Escrow with some tokens.</p><p>If sender is not defined, it defaults to the first signer</p><p>The rest must be defined</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>src</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>arbiter</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>recipient</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>amount</td>
-                  <td><a href="#coin.Coin">coin.Coin</a></td>
-                  <td>repeated</td>
-                  <td><p>amount may contain multiple token types </p></td>
-                </tr>
-              
-                <tr>
-                  <td>timeout</td>
-                  <td><a href="#int64">int64</a></td>
-                  <td></td>
-                  <td><p>Timeout represents wall clock time. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>memo</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>max length 128 character </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="escrow.Escrow">Escrow</h3>
-        <p>Escrow holds some coins.</p><p>The arbiter or sender can release them to the recipient.</p><p>The recipient can return them to the sender.</p><p>Upon timeout, they will be returned to the sender.</p><p>Note that if the arbiter is a Hashlock permission, we have</p><p>an HTLC ;)</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>sender</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>arbiter</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>recipient</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>timeout</td>
-                  <td><a href="#int64">int64</a></td>
-                  <td></td>
-                  <td><p>If unreleased before timeout, escrow will return to sender.
-Timeout represents wall clock time as read from the block header. Timeout
-is represented using POSIX time format.
-Expiration time is inclusive meaning that the escrow expires as soon as
-the current time is equal or greater than timeout value.
-nonexpired: [created, timeout)
-expired: [timeout, infinity) </p></td>
-                </tr>
-              
-                <tr>
-                  <td>memo</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>max length 128 character </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="escrow.ReleaseEscrowMsg">ReleaseEscrowMsg</h3>
-        <p>ReleaseEscrowMsg releases the content to the recipient.</p><p>Must be authorized by sender or arbiter.</p><p>If amount not provided, defaults to entire escrow,</p><p>May be a subset of the current balance.</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>escrow_id</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>amount</td>
-                  <td><a href="#coin.Coin">coin.Coin</a></td>
-                  <td>repeated</td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="escrow.ReturnEscrowMsg">ReturnEscrowMsg</h3>
-        <p>ReturnEscrowMsg returns the content to the sender.</p><p>Must be authorized by the sender or an expired timeout</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>escrow_id</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="escrow.UpdateEscrowPartiesMsg">UpdateEscrowPartiesMsg</h3>
-        <p>UpdateEscrowPartiesMsg changes any of the parties of the escrow:</p><p>sender, arbiter, recipient. This must be authorized by the current</p><p>holder of that position (eg. only sender can update sender).</p><p>Represents delegating responsibility</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>escrow_id</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>sender</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>arbiter</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>recipient</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-
-      
-
-      
-
-      
-    
-      
-      <div class="file-heading">
-        <h2 id="x/validators/codec.proto">x/validators/codec.proto</h2><a href="#title">Top</a>
-      </div>
-      <p></p>
-
-      
-        <h3 id="validators.Accounts">Accounts</h3>
-        <p>Accounts is a list of accounts allowed to update validators</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>addresses</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td>repeated</td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="validators.Pubkey">Pubkey</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>type</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>data</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="validators.SetValidatorsMsg">SetValidatorsMsg</h3>
-        <p>This message is designed to update validator power</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>validator_updates</td>
-                  <td><a href="#validators.ValidatorUpdate">ValidatorUpdate</a></td>
-                  <td>repeated</td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="validators.ValidatorUpdate">ValidatorUpdate</h3>
-        <p>ValidatorUpdate</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>pubkey</td>
-                  <td><a href="#validators.Pubkey">Pubkey</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>power</td>
-                  <td><a href="#int64">int64</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-
-      
-
-      
-
-      
-    
-      
-      <div class="file-heading">
-        <h2 id="x/paychan/codec.proto">x/paychan/codec.proto</h2><a href="#title">Top</a>
-      </div>
-      <p></p>
-
-      
-        <h3 id="paychan.ClosePaymentChannelMsg">ClosePaymentChannelMsg</h3>
-        <p>ClosePaymentChannelMsg close a payment channel and release remaining founds</p><p>by sending them back to the sender account.</p><p>Recipient account can close channel at any moment.</p><p>Sender can close channel only if the timeout chain height was reached.</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>channel_id</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>memo</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>Max length 128 character. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="paychan.CreatePaymentChannelMsg">CreatePaymentChannelMsg</h3>
-        <p>CreatePaymentChannelMsg creates a new payment channel that can be used to</p><p>transfer value between two parties.</p><p>Total amount will be taken from the senders account and allocated for user</p><p>in the transactions done via created payment channel.</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>src</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p>Sender address (weave.Address). </p></td>
-                </tr>
-              
-                <tr>
-                  <td>sender_pubkey</td>
-                  <td><a href="#crypto.PublicKey">crypto.PublicKey</a></td>
-                  <td></td>
-                  <td><p>Sender public key is for validating transfer message signature. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>recipient</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p>Recipient address  (weave.Address). </p></td>
-                </tr>
-              
-                <tr>
-                  <td>total</td>
-                  <td><a href="#coin.Coin">coin.Coin</a></td>
-                  <td></td>
-                  <td><p>Maximum amount that can be transferred via this channel. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>timeout</td>
-                  <td><a href="#int64">int64</a></td>
-                  <td></td>
-                  <td><p>Absolute block height value. If reached, channel can be closed by
-anyone. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>memo</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>Max length 128 character. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="paychan.Payment">Payment</h3>
-        <p>Payment is created by the sender. Sender should give the message to the</p><p>recipient, so that it can be redeemed at any time.</p><p>Each Payment should be created with amount greater than the previous one.</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>chain_id</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>channel_id</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>amount</td>
-                  <td><a href="#coin.Coin">coin.Coin</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>memo</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>Max length 128 character. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="paychan.PaymentChannel">PaymentChannel</h3>
-        <p>PaymentChannel holds the state of a payment channel during its lifetime.</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>src</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p>Sender is the source that the founds are allocated from (weave.Address). </p></td>
-                </tr>
-              
-                <tr>
-                  <td>sender_pubkey</td>
-                  <td><a href="#crypto.PublicKey">crypto.PublicKey</a></td>
-                  <td></td>
-                  <td><p>Sender public key is a key that must be used to verify signature of
-transfer message. Sender creates signed transfer messages and gives them
-to the recipient. Signature prevents from altering transfer message. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>recipient</td>
-                  <td><a href="#bytes">bytes</a></td>
-                  <td></td>
-                  <td><p>Recipient is the party that receives payments through this channel
-(weave.Address). </p></td>
-                </tr>
-              
-                <tr>
-                  <td>total</td>
-                  <td><a href="#coin.Coin">coin.Coin</a></td>
-                  <td></td>
-                  <td><p>Total represents a maximum value that can be transferred via this
-payment channel. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>timeout</td>
-                  <td><a href="#int64">int64</a></td>
-                  <td></td>
-                  <td><p>Absolute block height value. If reached, channel can be closed by
-sender. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>memo</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>Max length 128 character. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>transferred</td>
-                  <td><a href="#coin.Coin">coin.Coin</a></td>
-                  <td></td>
-                  <td><p>Transferred represents total amount that was transferred using allocated
-(total) value. Transferred must never exceed total value. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
-
-        
-      
-        <h3 id="paychan.TransferPaymentChannelMsg">TransferPaymentChannelMsg</h3>
-        <p>TransferPaymentChannelMsg binds Payment with a signature created using</p><p>senders private key.</p><p>Signature is there to ensure that payment message was not altered.</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>payment</td>
-                  <td><a href="#paychan.Payment">Payment</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>signature</td>
-                  <td><a href="#crypto.Signature">crypto.Signature</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-        
+          
 
         
       
@@ -2932,7 +2235,8 @@ sender. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -2955,7 +2259,8 @@ sender. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -2968,13 +2273,13 @@ sender. </p></td>
     
       
       <div class="file-heading">
-        <h2 id="x/sigs/codec.proto">x/sigs/codec.proto</h2><a href="#title">Top</a>
+        <h2 id="x/batch/codec.proto">x/batch/codec.proto</h2><a href="#title">Top</a>
       </div>
       <p></p>
 
       
-        <h3 id="sigs.BumpSequenceMsg">BumpSequenceMsg</h3>
-        <p>BumpSequenceMsg increments a sequence counter by given amount for a user</p><p>that signed the transaction.</p>
+        <h3 id="batch.ByteArrayList">ByteArrayList</h3>
+        <p></p>
 
         
           <table class="field-table">
@@ -2984,24 +2289,35 @@ sender. </p></td>
             <tbody>
               
                 <tr>
-                  <td>increment</td>
-                  <td><a href="#uint32">uint32</a></td>
-                  <td></td>
-                  <td><p>Increment represents the value by which a sequence value will be
-increased. Minumum value is one and maxium value must not be greater than
-1000.
-Each transaction increments the sequence by one. This value represents the
-total increment value, including the default increment. </p></td>
+                  <td>elements</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
                 </tr>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
-        <h3 id="sigs.StdSignature">StdSignature</h3>
-        <p>StdSignature represents the signature, the identity of the signer</p><p>(the Pubkey), and a sequence number to prevent replay attacks.</p><p>A given signer must submit transactions with the sequence number</p><p>increasing by 1 each time (starting at 0)</p>
+
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="x/validators/codec.proto">x/validators/codec.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="validators.Accounts">Accounts</h3>
+        <p>Accounts is a list of accounts allowed to update validators</p>
 
         
           <table class="field-table">
@@ -3011,34 +2327,121 @@ total increment value, including the default increment. </p></td>
             <tbody>
               
                 <tr>
-                  <td>sequence</td>
+                  <td>addresses</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="validators.Pubkey">Pubkey</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>type</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>data</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="validators.SetValidatorsMsg">SetValidatorsMsg</h3>
+        <p>This message is designed to update validator power</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>validator_updates</td>
+                  <td><a href="#validators.ValidatorUpdate">ValidatorUpdate</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="validators.ValidatorUpdate">ValidatorUpdate</h3>
+        <p>ValidatorUpdate</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>pubkey</td>
+                  <td><a href="#validators.Pubkey">Pubkey</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>power</td>
                   <td><a href="#int64">int64</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
               
-                <tr>
-                  <td>pubkey</td>
-                  <td><a href="#crypto.PublicKey">crypto.PublicKey</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>signature</td>
-                  <td><a href="#crypto.Signature">crypto.Signature</a></td>
-                  <td></td>
-                  <td><p>Removed Address, Pubkey is more powerful </p></td>
-                </tr>
-              
             </tbody>
           </table>
-        
+
+          
 
         
       
-        <h3 id="sigs.UserData">UserData</h3>
-        <p>UserData just stores the data and is used for serialization.</p><p>Key is the Address (PubKey.Permission().Address())</p><p>Note: This should not be created from outside the module,</p><p>User is the entry point you want</p>
+
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="x/nft/codec.proto">x/nft/codec.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="nft.ActionApprovals">ActionApprovals</h3>
+        <p>ActionApprovals are used to control permissions and validate that a user can</p><p>execute given operation.</p>
 
         
           <table class="field-table">
@@ -3048,22 +2451,234 @@ total increment value, including the default increment. </p></td>
             <tbody>
               
                 <tr>
-                  <td>pubkey</td>
-                  <td><a href="#crypto.PublicKey">crypto.PublicKey</a></td>
+                  <td>action</td>
+                  <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
               
                 <tr>
-                  <td>sequence</td>
-                  <td><a href="#int64">int64</a></td>
+                  <td>approvals</td>
+                  <td><a href="#nft.Approval">Approval</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="nft.AddApprovalMsg">AddApprovalMsg</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>id</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>address</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>action</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>options</td>
+                  <td><a href="#nft.ApprovalOptions">ApprovalOptions</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>t</td>
+                  <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
               
             </tbody>
           </table>
+
+          
+
         
+      
+        <h3 id="nft.Approval">Approval</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>address</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>options</td>
+                  <td><a href="#nft.ApprovalOptions">ApprovalOptions</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="nft.ApprovalOptions">ApprovalOptions</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>until_block_height</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td></td>
+                  <td><p>Until block height is used to mark blochain height until which an
+approval is valid. This can be used to define an approval expiration. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>count</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td></td>
+                  <td><p>Count is defining how many times an approval can be used. Each approval
+test decrese the counter. Once the counter reaches value 0, an approval
+is considered expired and can no longer be used.
+Use -1 to bypass count expiration. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>immutable</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>Immutable is a flag that prevents an option to be modified. Once
+created, cannot be altered. For example, counter state cannot be
+changed. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="nft.NonFungibleToken">NonFungibleToken</h3>
+        <p>NonFungibleToken is a message that must be incuded by any concrete NFT</p><p>implementation. Usually it is the first attirbute called `base`.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>id</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p>ID is the address of this token. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>owner</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p>Owner is the address of the token owner. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>action_approvals</td>
+                  <td><a href="#nft.ActionApprovals">ActionApprovals</a></td>
+                  <td>repeated</td>
+                  <td><p>Action approvals is a list of permissions. In order for operation to
+succeed, all action approvals validation must pass. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="nft.RemoveApprovalMsg">RemoveApprovalMsg</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>id</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>address</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>action</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>t</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
 
         
       
@@ -3136,7 +2751,8 @@ When not set it will default to the main signer. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -3159,7 +2775,8 @@ When not set it will default to the main signer. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -3207,7 +2824,8 @@ of the eligible voters. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -3237,7 +2855,8 @@ of the eligible voters. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -3281,7 +2900,8 @@ of the eligible voters. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -3311,7 +2931,8 @@ of the eligible voters. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -3334,7 +2955,8 @@ of the eligible voters. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -3386,7 +3008,8 @@ proposal this value must be exceeded. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -3481,7 +3104,8 @@ to be included in the election. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -3522,7 +3146,8 @@ of the eligible voters. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -3552,7 +3177,8 @@ of the eligible voters. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -3582,7 +3208,8 @@ of the eligible voters. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -3620,7 +3247,8 @@ must be included in the electorate for a valid vote. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -3731,6 +3359,747 @@ is Withdrawn.</p></td>
             
           </tbody>
         </table>
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="x/paychan/codec.proto">x/paychan/codec.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="paychan.ClosePaymentChannelMsg">ClosePaymentChannelMsg</h3>
+        <p>ClosePaymentChannelMsg close a payment channel and release remaining founds</p><p>by sending them back to the sender account.</p><p>Recipient account can close channel at any moment.</p><p>Sender can close channel only if the timeout chain height was reached.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>channel_id</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>memo</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Max length 128 character. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="paychan.CreatePaymentChannelMsg">CreatePaymentChannelMsg</h3>
+        <p>CreatePaymentChannelMsg creates a new payment channel that can be used to</p><p>transfer value between two parties.</p><p>Total amount will be taken from the senders account and allocated for user</p><p>in the transactions done via created payment channel.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>src</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p>Sender address (weave.Address). </p></td>
+                </tr>
+              
+                <tr>
+                  <td>sender_pubkey</td>
+                  <td><a href="#crypto.PublicKey">crypto.PublicKey</a></td>
+                  <td></td>
+                  <td><p>Sender public key is for validating transfer message signature. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>recipient</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p>Recipient address  (weave.Address). </p></td>
+                </tr>
+              
+                <tr>
+                  <td>total</td>
+                  <td><a href="#coin.Coin">coin.Coin</a></td>
+                  <td></td>
+                  <td><p>Maximum amount that can be transferred via this channel. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>timeout</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td></td>
+                  <td><p>Absolute block height value. If reached, channel can be closed by
+anyone. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>memo</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Max length 128 character. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="paychan.Payment">Payment</h3>
+        <p>Payment is created by the sender. Sender should give the message to the</p><p>recipient, so that it can be redeemed at any time.</p><p>Each Payment should be created with amount greater than the previous one.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>chain_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>channel_id</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>amount</td>
+                  <td><a href="#coin.Coin">coin.Coin</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>memo</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Max length 128 character. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="paychan.PaymentChannel">PaymentChannel</h3>
+        <p>PaymentChannel holds the state of a payment channel during its lifetime.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>src</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p>Sender is the source that the founds are allocated from. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>sender_pubkey</td>
+                  <td><a href="#crypto.PublicKey">crypto.PublicKey</a></td>
+                  <td></td>
+                  <td><p>Sender public key is a key that must be used to verify signature of
+transfer message. Sender creates signed transfer messages and gives them
+to the recipient. Signature prevents from altering transfer message. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>recipient</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p>Recipient is the party that receives payments through this channel </p></td>
+                </tr>
+              
+                <tr>
+                  <td>total</td>
+                  <td><a href="#coin.Coin">coin.Coin</a></td>
+                  <td></td>
+                  <td><p>Total represents a maximum value that can be transferred via this
+payment channel. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>timeout</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td></td>
+                  <td><p>Absolute block height value. If reached, channel can be closed by
+sender. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>memo</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Max length 128 character. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>transferred</td>
+                  <td><a href="#coin.Coin">coin.Coin</a></td>
+                  <td></td>
+                  <td><p>Transferred represents total amount that was transferred using allocated
+(total) value. Transferred must never exceed total value. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="paychan.TransferPaymentChannelMsg">TransferPaymentChannelMsg</h3>
+        <p>TransferPaymentChannelMsg binds Payment with a signature created using</p><p>senders private key.</p><p>Signature is there to ensure that payment message was not altered.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>payment</td>
+                  <td><a href="#paychan.Payment">Payment</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>signature</td>
+                  <td><a href="#crypto.Signature">crypto.Signature</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="x/distribution/codec.proto">x/distribution/codec.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="distribution.DistributeMsg">DistributeMsg</h3>
+        <p>DistributeMsg is a request to distribute all funds collected within a single</p><p>revenue instance. Revenue is distributed between recipients. Request must be</p><p>signed using admin key.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>revenue_id</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p>Revenue ID reference an ID of a revenue instance that the collected fees
+should be distributed between recipients. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="distribution.NewRevenueMsg">NewRevenueMsg</h3>
+        <p>NewRevenueMsg is issuing the creation of a new revenue stream instance.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>admin</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p>Admin key belongs to the governance entities. It can be used to transfer
+stored amount to an another account.
+While not enforced it is best to use a multisig contract here. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>recipients</td>
+                  <td><a href="#distribution.Recipient">Recipient</a></td>
+                  <td>repeated</td>
+                  <td><p>Recipients holds any number of addresses that the collected revenue is
+distributed to. Must be at least one. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="distribution.Recipient">Recipient</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>address</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p>An address that the funds should be transferred to.
+This should not be the validator addresses, as the keys used to sign
+blocks should never be in a wallet. This can be the wallets of the admins
+of the validators. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>weight</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Weight defines what part of the total revenue goes to this recipient.
+Each recipient receives part of the total revenue amount proportional to
+the weight. For example, if there are two recipients with weights 1 and 2
+accordingly, distribution will be 1/3 to the first address and 2/3 to the
+second one. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="distribution.ResetRevenueMsg">ResetRevenueMsg</h3>
+        <p>ResetRevenueMsg change the configuration of a revenue instance.</p><p>To assure recipients that they will receive money, every revenue update is</p><p>forcing funds distribution. Before applying any change all funds stored by</p><p>the revenue account are distributed using old configuration. Only when the</p><p>collected revenue amount is equal to zero the change is applied.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>revenue_id</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p>Revenue ID reference an ID of a revenue instance that is updated. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>recipients</td>
+                  <td><a href="#distribution.Recipient">Recipient</a></td>
+                  <td>repeated</td>
+                  <td><p>Recipients holds any number of addresses that the collected revenue is
+distributed to. Must be at least one. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="distribution.Revenue">Revenue</h3>
+        <p>Revenue represents an account with funds collected from the fees. This is a</p><p>temporary account used for storing fees that are later distributed between</p><p>the owners.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>metadata</td>
+                  <td><a href="#weave.Metadata">weave.Metadata</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>admin</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p>Admin key belongs to the governance entities. It can be used to transfer
+stored amount to an another account.
+While not enforced it is best to use a multisig contract here. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>recipients</td>
+                  <td><a href="#distribution.Recipient">Recipient</a></td>
+                  <td>repeated</td>
+                  <td><p>Recipients holds any number of addresses that the collected revenue is
+distributed to. Must be at least one. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="x/sigs/codec.proto">x/sigs/codec.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="sigs.BumpSequenceMsg">BumpSequenceMsg</h3>
+        <p>BumpSequenceMsg increments a sequence counter by given amount for a user</p><p>that signed the transaction.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>increment</td>
+                  <td><a href="#uint32">uint32</a></td>
+                  <td></td>
+                  <td><p>Increment represents the value by which a sequence value will be
+increased. Minumum value is one and maxium value must not be greater than
+1000.
+Each transaction increments the sequence by one. This value represents the
+total increment value, including the default increment. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="sigs.StdSignature">StdSignature</h3>
+        <p>StdSignature represents the signature, the identity of the signer</p><p>(the Pubkey), and a sequence number to prevent replay attacks.</p><p>A given signer must submit transactions with the sequence number</p><p>increasing by 1 each time (starting at 0)</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>sequence</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>pubkey</td>
+                  <td><a href="#crypto.PublicKey">crypto.PublicKey</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>signature</td>
+                  <td><a href="#crypto.Signature">crypto.Signature</a></td>
+                  <td></td>
+                  <td><p>Removed Address, Pubkey is more powerful </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="sigs.UserData">UserData</h3>
+        <p>UserData just stores the data and is used for serialization.</p><p>Key is the Address (PubKey.Permission().Address())</p><p>Note: This should not be created from outside the module,</p><p>User is the entry point you want</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>pubkey</td>
+                  <td><a href="#crypto.PublicKey">crypto.PublicKey</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>sequence</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="x/namecoin/codec.proto">x/namecoin/codec.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="namecoin.NewTokenMsg">NewTokenMsg</h3>
+        <p>NewTokenMsg will register a new token.</p><p>This must not conflict with any existing ticker,</p><p>and should be limited to privledged users.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>ticker</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>sig_figs</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="namecoin.SetWalletNameMsg">SetWalletNameMsg</h3>
+        <p>SetWalletNameMsg will set the name on an existing</p><p>wallet. Can only be performed if the wallet name is empty.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>address</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="namecoin.Token">Token</h3>
+        <p>Token contains information about a registered currency</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>sig_figs</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="namecoin.Wallet">Wallet</h3>
+        <p>Wallet has a name and a set of coins</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>coins</td>
+                  <td><a href="#coin.Coin">coin.Coin</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
       
 
       

--- a/examples/mycoind/app/app_test.go
+++ b/examples/mycoind/app/app_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/commands/server"
 	"github.com/iov-one/weave/crypto"
+	"github.com/iov-one/weave/migration"
 	"github.com/iov-one/weave/x/cash"
 	"github.com/iov-one/weave/x/sigs"
 	"github.com/stretchr/testify/assert"
@@ -44,6 +45,26 @@ func testInitChain(t *testing.T, myApp app.BaseApp, addr string) {
 				CollectorAddress: fromHex(t, "3b11c732b8fc1f09beb34031302fe2ab347c5c14"),
 				MinimalFee:       coin.Coin{Whole: 0}, // no fee
 			},
+			"migration": migration.Configuration{
+				Admin: fromHex(t, "3b11c732b8fc1f09beb34031302fe2ab347c5c14"),
+			},
+		},
+		"initialize_schema": []dict{
+			dict{"ver": 1, "pkg": "batch"},
+			dict{"ver": 1, "pkg": "cash"},
+			dict{"ver": 1, "pkg": "currency"},
+			dict{"ver": 1, "pkg": "distribution"},
+			dict{"ver": 1, "pkg": "escrow"},
+			dict{"ver": 1, "pkg": "gov"},
+			dict{"ver": 1, "pkg": "hashlock"},
+			dict{"ver": 1, "pkg": "msgfee"},
+			dict{"ver": 1, "pkg": "multisig"},
+			dict{"ver": 1, "pkg": "namecoin"},
+			dict{"ver": 1, "pkg": "nft"},
+			dict{"ver": 1, "pkg": "paychan"},
+			dict{"ver": 1, "pkg": "sigs"},
+			dict{"ver": 1, "pkg": "utils"},
+			dict{"ver": 1, "pkg": "validators"},
 		},
 	})
 	if err != nil {
@@ -104,8 +125,9 @@ func testSendTx(t *testing.T, myApp app.BaseApp, h int64,
 	sender *crypto.PrivateKey, rcpt weave.Address, seq int64) abci.ResponseDeliverTx {
 
 	msg := &cash.SendMsg{
-		Src:  sender.PublicKey().Address(),
-		Dest: rcpt,
+		Metadata: &weave.Metadata{Schema: 1},
+		Src:      sender.PublicKey().Address(),
+		Dest:     rcpt,
 		Amount: &coin.Coin{
 			Whole:  amount,
 			Ticker: ticker,

--- a/examples/mycoind/app/init.go
+++ b/examples/mycoind/app/init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iov-one/weave/commands/server"
 	"github.com/iov-one/weave/crypto"
 	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/migration"
 	"github.com/iov-one/weave/x/cash"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
@@ -83,6 +84,7 @@ func GenerateApp(options *server.Options) (abci.Application, error) {
 		return nil, err
 	}
 	application.WithInit(app.ChainInitializers(
+		&migration.Initializer{},
 		&cash.Initializer{},
 	))
 

--- a/migration/handler.go
+++ b/migration/handler.go
@@ -6,6 +6,12 @@ import (
 	"github.com/iov-one/weave/x"
 )
 
+// SchemaMigratingHandler returns a weave handler that will ensure incomming
+// messages are in the curren schema version format. If a message in older
+// schema is handled then it is first being migrated. Messages that cannot be
+// migrated to current schema version are returning migration error. This
+// functionality is executed before the decorated handler and it is completely
+// transpared to the wrapped handler.
 func SchemaMigratingHandler(packageName string, h weave.Handler) weave.Handler {
 	return &schemaMigratingHandler{
 		handler:     h,

--- a/migration/orm.go
+++ b/migration/orm.go
@@ -64,7 +64,7 @@ func (svb Bucket) migrate(db weave.ReadOnlyKVStore, obj orm.Object) error {
 	}
 	currSchemaVer, err := svb.schema.CurrentSchema(db, svb.packageName)
 	if err != nil {
-		return errors.Wrap(err, "current model schema")
+		return errors.Wrapf(err, "current schema version of package %q", svb.packageName)
 	}
 
 	meta := m.GetMetadata()
@@ -77,6 +77,7 @@ func (svb Bucket) migrate(db weave.ReadOnlyKVStore, obj orm.Object) error {
 	// version.
 	if meta.Schema == 0 {
 		meta.Schema = currSchemaVer
+		return nil
 	}
 
 	if meta.Schema > currSchemaVer {
@@ -88,4 +89,14 @@ func (svb Bucket) migrate(db weave.ReadOnlyKVStore, obj orm.Object) error {
 		return errors.Wrap(err, "schema migration")
 	}
 	return nil
+}
+
+func (svb Bucket) WithIndex(name string, indexer orm.Indexer, unique bool) orm.Bucket {
+	svb.Bucket = svb.Bucket.WithIndex(name, indexer, unique)
+	return svb
+}
+
+func (svb Bucket) WithMultiKeyIndex(name string, indexer orm.MultiKeyIndexer, unique bool) orm.Bucket {
+	svb.Bucket = svb.Bucket.WithMultiKeyIndex(name, indexer, unique)
+	return svb
 }

--- a/scripts/build_protodocs.sh
+++ b/scripts/build_protodocs.sh
@@ -11,5 +11,5 @@ FILES=$(./scripts/cleaned_protos.sh "${OUT_DIR}")
 HERE=`pwd`
 (
     cd "$OUT_DIR"
-    protoc -I=. -I="$HERE/vendor" --doc_out="$HERE/docs/proto/" --doc_opt=html,index.html $FILES
+    protoc -I=. -I $GOPATH/src -I="$HERE/vendor" --doc_out="$HERE/docs/proto/" --doc_opt=html,index.html $FILES
 )

--- a/x/cash/codec.pb.go
+++ b/x/cash/codec.pb.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_iov_one_weave "github.com/iov-one/weave"
+	weave "github.com/iov-one/weave"
 	coin "github.com/iov-one/weave/coin"
 	io "io"
 	math "math"
@@ -27,7 +28,8 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 // Set may contain Coin of many different currencies.
 // It handles adding and subtracting sets of currencies.
 type Set struct {
-	Coins []*coin.Coin `protobuf:"bytes,1,rep,name=coins,proto3" json:"coins,omitempty"`
+	Metadata *weave.Metadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	Coins    []*coin.Coin    `protobuf:"bytes,2,rep,name=coins,proto3" json:"coins,omitempty"`
 }
 
 func (m *Set) Reset()         { *m = Set{} }
@@ -63,6 +65,13 @@ func (m *Set) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_Set proto.InternalMessageInfo
 
+func (m *Set) GetMetadata() *weave.Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
+
 func (m *Set) GetCoins() []*coin.Coin {
 	if m != nil {
 		return m.Coins
@@ -76,13 +85,14 @@ func (m *Set) GetCoins() []*coin.Coin {
 // ref is optional binary data, that can refer to another
 // eg. tx hash
 type SendMsg struct {
-	Src    github_com_iov_one_weave.Address `protobuf:"bytes,1,opt,name=src,proto3,casttype=github.com/iov-one/weave.Address" json:"src,omitempty"`
-	Dest   github_com_iov_one_weave.Address `protobuf:"bytes,2,opt,name=dest,proto3,casttype=github.com/iov-one/weave.Address" json:"dest,omitempty"`
-	Amount *coin.Coin                       `protobuf:"bytes,3,opt,name=amount,proto3" json:"amount,omitempty"`
+	Metadata *weave.Metadata                  `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	Src      github_com_iov_one_weave.Address `protobuf:"bytes,2,opt,name=src,proto3,casttype=github.com/iov-one/weave.Address" json:"src,omitempty"`
+	Dest     github_com_iov_one_weave.Address `protobuf:"bytes,3,opt,name=dest,proto3,casttype=github.com/iov-one/weave.Address" json:"dest,omitempty"`
+	Amount   *coin.Coin                       `protobuf:"bytes,4,opt,name=amount,proto3" json:"amount,omitempty"`
 	// max length 128 character
-	Memo string `protobuf:"bytes,4,opt,name=memo,proto3" json:"memo,omitempty"`
+	Memo string `protobuf:"bytes,5,opt,name=memo,proto3" json:"memo,omitempty"`
 	// max length 64 bytes
-	Ref []byte `protobuf:"bytes,5,opt,name=ref,proto3" json:"ref,omitempty"`
+	Ref []byte `protobuf:"bytes,6,opt,name=ref,proto3" json:"ref,omitempty"`
 }
 
 func (m *SendMsg) Reset()         { *m = SendMsg{} }
@@ -117,6 +127,13 @@ func (m *SendMsg) XXX_DiscardUnknown() {
 }
 
 var xxx_messageInfo_SendMsg proto.InternalMessageInfo
+
+func (m *SendMsg) GetMetadata() *weave.Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
 
 func (m *SendMsg) GetSrc() github_com_iov_one_weave.Address {
 	if m != nil {
@@ -156,8 +173,9 @@ func (m *SendMsg) GetRef() []byte {
 // FeeInfo records who pays what fees to have this
 // message processed
 type FeeInfo struct {
-	Payer []byte     `protobuf:"bytes,1,opt,name=payer,proto3" json:"payer,omitempty"`
-	Fees  *coin.Coin `protobuf:"bytes,2,opt,name=fees,proto3" json:"fees,omitempty"`
+	Metadata *weave.Metadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	Payer    []byte          `protobuf:"bytes,2,opt,name=payer,proto3" json:"payer,omitempty"`
+	Fees     *coin.Coin      `protobuf:"bytes,3,opt,name=fees,proto3" json:"fees,omitempty"`
 }
 
 func (m *FeeInfo) Reset()         { *m = FeeInfo{} }
@@ -192,6 +210,13 @@ func (m *FeeInfo) XXX_DiscardUnknown() {
 }
 
 var xxx_messageInfo_FeeInfo proto.InternalMessageInfo
+
+func (m *FeeInfo) GetMetadata() *weave.Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
 
 func (m *FeeInfo) GetPayer() []byte {
 	if m != nil {
@@ -269,7 +294,8 @@ func (m *Configuration) GetMinimalFee() coin.Coin {
 }
 
 type ConfigurationMsg struct {
-	Patch *Configuration `protobuf:"bytes,1,opt,name=patch,proto3" json:"patch,omitempty"`
+	// TODO: add schema uint32 here
+	Patch *Configuration `protobuf:"bytes,2,opt,name=patch,proto3" json:"patch,omitempty"`
 }
 
 func (m *ConfigurationMsg) Reset()         { *m = ConfigurationMsg{} }
@@ -323,33 +349,35 @@ func init() {
 func init() { proto.RegisterFile("x/cash/codec.proto", fileDescriptor_7149e4b58e322390) }
 
 var fileDescriptor_7149e4b58e322390 = []byte{
-	// 416 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x52, 0x41, 0x6b, 0xd4, 0x40,
-	0x14, 0xde, 0x31, 0xd9, 0x16, 0xdf, 0x2a, 0xac, 0xa3, 0x87, 0xd0, 0x43, 0x1a, 0x82, 0xe0, 0xf6,
-	0xd0, 0x04, 0x2b, 0x88, 0x08, 0x22, 0x6e, 0xa1, 0xe0, 0xc1, 0x83, 0xe9, 0x0f, 0x28, 0xd9, 0xc9,
-	0x4b, 0x76, 0x60, 0x33, 0xaf, 0xcc, 0x4c, 0x5a, 0xfd, 0x17, 0xfe, 0x29, 0xa1, 0xc7, 0x7a, 0xf3,
-	0x54, 0x64, 0xf7, 0x5f, 0x78, 0x92, 0x99, 0x2c, 0xd2, 0x08, 0x42, 0x7b, 0x7b, 0xdf, 0xf7, 0xbe,
-	0x6f, 0xe6, 0x7d, 0x6f, 0x06, 0xf8, 0x97, 0x5c, 0x94, 0x66, 0x99, 0x0b, 0xaa, 0x50, 0x64, 0xe7,
-	0x9a, 0x2c, 0xf1, 0xd0, 0x31, 0x7b, 0x07, 0x8d, 0xb4, 0xcb, 0x6e, 0x91, 0x09, 0x6a, 0x73, 0x49,
-	0x17, 0x87, 0xa4, 0x30, 0xbf, 0xc4, 0xf2, 0x02, 0x73, 0x41, 0x52, 0xdd, 0x36, 0xec, 0x1d, 0xde,
-	0x92, 0x36, 0xd4, 0x50, 0xee, 0xe9, 0x45, 0x57, 0x7b, 0xe4, 0x81, 0xaf, 0x7a, 0x79, 0xfa, 0x02,
-	0x82, 0x53, 0xb4, 0x3c, 0x81, 0xb1, 0x3b, 0xc9, 0x44, 0x2c, 0x09, 0x66, 0x93, 0x23, 0xc8, 0x1c,
-	0xca, 0x8e, 0x49, 0xaa, 0xa2, 0x6f, 0xa4, 0xdf, 0x19, 0xec, 0x9e, 0xa2, 0xaa, 0x3e, 0x99, 0x86,
-	0xbf, 0x86, 0xc0, 0x68, 0x11, 0xb1, 0x84, 0xcd, 0x1e, 0xcd, 0x9f, 0xff, 0xbe, 0xd9, 0x4f, 0xfe,
-	0x37, 0x5f, 0xf6, 0xa1, 0xaa, 0x34, 0x1a, 0x53, 0x38, 0x03, 0x7f, 0x03, 0x61, 0x85, 0xc6, 0x46,
-	0x0f, 0xee, 0x61, 0xf4, 0x0e, 0x9e, 0xc2, 0x4e, 0xd9, 0x52, 0xa7, 0x6c, 0x14, 0x24, 0xec, 0x9f,
-	0x01, 0xb7, 0x1d, 0xce, 0x21, 0x6c, 0xb1, 0xa5, 0x28, 0x4c, 0xd8, 0xec, 0x61, 0xe1, 0x6b, 0x3e,
-	0x85, 0x40, 0x63, 0x1d, 0x8d, 0xdd, 0x85, 0x85, 0x2b, 0xd3, 0xf7, 0xb0, 0x7b, 0x82, 0xf8, 0x51,
-	0xd5, 0xc4, 0x9f, 0xc1, 0xf8, 0xbc, 0xfc, 0x8a, 0xba, 0x0f, 0x52, 0xf4, 0x80, 0xc7, 0x10, 0xd6,
-	0x88, 0xc6, 0x0f, 0x39, 0xbc, 0xc8, 0xf3, 0xe9, 0x0f, 0x06, 0x8f, 0x8f, 0x49, 0xd5, 0xb2, 0xe9,
-	0x74, 0x69, 0x25, 0x29, 0xfe, 0x16, 0xc6, 0x74, 0xa9, 0x50, 0xdf, 0x2b, 0x57, 0x6f, 0xe1, 0x9f,
-	0xe1, 0x89, 0xa0, 0xd5, 0x0a, 0x85, 0x25, 0x7d, 0x56, 0xf6, 0x3d, 0x9f, 0xf1, 0xae, 0xe7, 0x4c,
-	0xff, 0xda, 0xb7, 0x0c, 0x7f, 0x09, 0x93, 0x56, 0x2a, 0xd9, 0x96, 0xab, 0xb3, 0x1a, 0xd1, 0xaf,
-	0x63, 0x90, 0x63, 0x1e, 0x5e, 0xdd, 0xec, 0x8f, 0x0a, 0xd8, 0x8a, 0x4e, 0x10, 0xd3, 0x77, 0x30,
-	0x1d, 0x44, 0x72, 0x8f, 0x7c, 0xe0, 0xb6, 0x63, 0xc5, 0xd2, 0x6f, 0x67, 0x72, 0xf4, 0x34, 0x73,
-	0x3f, 0x31, 0x1b, 0xc8, 0x8a, 0x5e, 0x31, 0x8f, 0xae, 0xd6, 0x31, 0xbb, 0x5e, 0xc7, 0xec, 0xd7,
-	0x3a, 0x66, 0xdf, 0x36, 0xf1, 0xe8, 0x7a, 0x13, 0x8f, 0x7e, 0x6e, 0xe2, 0xd1, 0x62, 0xc7, 0xff,
-	0xb2, 0x57, 0x7f, 0x02, 0x00, 0x00, 0xff, 0xff, 0x12, 0xfd, 0x38, 0xb1, 0xdb, 0x02, 0x00, 0x00,
+	// 447 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x93, 0xcf, 0x6e, 0xd3, 0x40,
+	0x10, 0xc6, 0xb3, 0xb5, 0x93, 0xc2, 0x04, 0x44, 0x58, 0x38, 0x58, 0x3d, 0xb8, 0x96, 0xd5, 0x43,
+	0x2a, 0xd4, 0xb5, 0x08, 0x12, 0x42, 0x48, 0x1c, 0x48, 0xa5, 0x4a, 0x1c, 0x7a, 0xc0, 0xe5, 0x5e,
+	0x6d, 0xec, 0xb1, 0x63, 0x29, 0xde, 0xa9, 0xbc, 0x9b, 0x16, 0xde, 0x82, 0xc7, 0xea, 0xb1, 0xdc,
+	0x38, 0x55, 0x28, 0x79, 0x03, 0x8e, 0x9c, 0xd0, 0xae, 0x43, 0x95, 0x08, 0x81, 0x9a, 0xdb, 0xfc,
+	0xf9, 0x7d, 0x3b, 0xfb, 0x8d, 0x76, 0x81, 0x7f, 0x4e, 0x32, 0xa9, 0xa7, 0x49, 0x46, 0x39, 0x66,
+	0xe2, 0xa2, 0x21, 0x43, 0xdc, 0xb7, 0x95, 0xbd, 0x83, 0xb2, 0x32, 0xd3, 0xf9, 0x44, 0x64, 0x54,
+	0x27, 0x15, 0x5d, 0x1e, 0x91, 0xc2, 0xe4, 0x0a, 0xe5, 0x25, 0xae, 0xb3, 0x7b, 0x87, 0xff, 0xa1,
+	0x2a, 0xb5, 0x81, 0x1e, 0xad, 0xa1, 0x25, 0x95, 0x94, 0xb8, 0xf2, 0x64, 0x5e, 0xb8, 0xcc, 0x25,
+	0x2e, 0x6a, 0xf1, 0xf8, 0x13, 0x78, 0x67, 0x68, 0xf8, 0x0b, 0x78, 0x50, 0xa3, 0x91, 0xb9, 0x34,
+	0x32, 0x60, 0x11, 0x1b, 0xf6, 0x47, 0x4f, 0x84, 0x1b, 0x20, 0x4e, 0x57, 0xe5, 0xf4, 0x0e, 0xe0,
+	0x11, 0x74, 0xed, 0x58, 0x1d, 0xec, 0x44, 0xde, 0xb0, 0x3f, 0x02, 0x61, 0x33, 0x71, 0x4c, 0x95,
+	0x4a, 0xdb, 0x46, 0xfc, 0x93, 0xc1, 0xee, 0x19, 0xaa, 0xfc, 0x54, 0x97, 0xdb, 0x1d, 0xfd, 0x1a,
+	0x3c, 0xdd, 0x64, 0xc1, 0x4e, 0xc4, 0x86, 0x8f, 0xc6, 0x07, 0xbf, 0x6e, 0xf7, 0xa3, 0x7f, 0x39,
+	0x17, 0xef, 0xf3, 0xbc, 0x41, 0xad, 0x53, 0x2b, 0xe0, 0x6f, 0xc0, 0xcf, 0x51, 0x9b, 0xc0, 0xdb,
+	0x42, 0xe8, 0x14, 0x3c, 0x86, 0x9e, 0xac, 0x69, 0xae, 0x4c, 0xe0, 0xbb, 0xcb, 0xad, 0xbb, 0x59,
+	0x75, 0x38, 0x07, 0xbf, 0xc6, 0x9a, 0x82, 0x6e, 0xc4, 0x86, 0x0f, 0x53, 0x17, 0xf3, 0x01, 0x78,
+	0x0d, 0x16, 0x41, 0xcf, 0x0e, 0x4c, 0x6d, 0x18, 0xcf, 0x60, 0xf7, 0x04, 0xf1, 0x83, 0x2a, 0x68,
+	0x3b, 0xcf, 0xcf, 0xa1, 0x7b, 0x21, 0xbf, 0x60, 0xd3, 0xba, 0x4e, 0xdb, 0x84, 0x87, 0xe0, 0x17,
+	0x88, 0xda, 0x39, 0xda, 0xbc, 0x95, 0xab, 0xc7, 0xdf, 0x18, 0x3c, 0x3e, 0x26, 0x55, 0x54, 0xe5,
+	0xbc, 0x91, 0xa6, 0x22, 0xc5, 0xdf, 0x42, 0x97, 0xae, 0xd4, 0x9f, 0x73, 0xee, 0xb9, 0x84, 0x56,
+	0xc2, 0x3f, 0xc2, 0xd3, 0x8c, 0x66, 0x33, 0xcc, 0x0c, 0x35, 0xe7, 0xb2, 0xed, 0x6d, 0xb5, 0xcc,
+	0xc1, 0x9d, 0x7c, 0x55, 0xe1, 0x2f, 0xa1, 0x5f, 0x57, 0xaa, 0xaa, 0xe5, 0xec, 0xbc, 0x40, 0xfc,
+	0x7b, 0xbb, 0x63, 0xff, 0xfa, 0x76, 0xbf, 0x93, 0xc2, 0x0a, 0x3a, 0x41, 0x8c, 0xdf, 0xc1, 0x60,
+	0xc3, 0x92, 0x7d, 0x3e, 0x87, 0x76, 0x3b, 0x26, 0x9b, 0x3a, 0x57, 0xfd, 0xd1, 0x33, 0x61, 0xbf,
+	0x8d, 0xd8, 0xc0, 0xd2, 0x96, 0x18, 0x07, 0xd7, 0x8b, 0x90, 0xdd, 0x2c, 0x42, 0xf6, 0x63, 0x11,
+	0xb2, 0xaf, 0xcb, 0xb0, 0x73, 0xb3, 0x0c, 0x3b, 0xdf, 0x97, 0x61, 0x67, 0xd2, 0x73, 0x8f, 0xfd,
+	0xd5, 0xef, 0x00, 0x00, 0x00, 0xff, 0xff, 0x23, 0xb0, 0xf7, 0x8d, 0x88, 0x03, 0x00, 0x00,
 }
 
 func (m *Set) Marshal() (dAtA []byte, err error) {
@@ -367,9 +395,19 @@ func (m *Set) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.Metadata != nil {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(m.Metadata.Size()))
+		n1, err := m.Metadata.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n1
+	}
 	if len(m.Coins) > 0 {
 		for _, msg := range m.Coins {
-			dAtA[i] = 0xa
+			dAtA[i] = 0x12
 			i++
 			i = encodeVarintCodec(dAtA, i, uint64(msg.Size()))
 			n, err := msg.MarshalTo(dAtA[i:])
@@ -397,36 +435,46 @@ func (m *SendMsg) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.Src) > 0 {
+	if m.Metadata != nil {
 		dAtA[i] = 0xa
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(m.Metadata.Size()))
+		n2, err := m.Metadata.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n2
+	}
+	if len(m.Src) > 0 {
+		dAtA[i] = 0x12
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Src)))
 		i += copy(dAtA[i:], m.Src)
 	}
 	if len(m.Dest) > 0 {
-		dAtA[i] = 0x12
+		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Dest)))
 		i += copy(dAtA[i:], m.Dest)
 	}
 	if m.Amount != nil {
-		dAtA[i] = 0x1a
+		dAtA[i] = 0x22
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(m.Amount.Size()))
-		n1, err := m.Amount.MarshalTo(dAtA[i:])
+		n3, err := m.Amount.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n1
+		i += n3
 	}
 	if len(m.Memo) > 0 {
-		dAtA[i] = 0x22
+		dAtA[i] = 0x2a
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Memo)))
 		i += copy(dAtA[i:], m.Memo)
 	}
 	if len(m.Ref) > 0 {
-		dAtA[i] = 0x2a
+		dAtA[i] = 0x32
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Ref)))
 		i += copy(dAtA[i:], m.Ref)
@@ -449,21 +497,31 @@ func (m *FeeInfo) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.Payer) > 0 {
+	if m.Metadata != nil {
 		dAtA[i] = 0xa
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(m.Metadata.Size()))
+		n4, err := m.Metadata.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n4
+	}
+	if len(m.Payer) > 0 {
+		dAtA[i] = 0x12
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Payer)))
 		i += copy(dAtA[i:], m.Payer)
 	}
 	if m.Fees != nil {
-		dAtA[i] = 0x12
+		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(m.Fees.Size()))
-		n2, err := m.Fees.MarshalTo(dAtA[i:])
+		n5, err := m.Fees.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n2
+		i += n5
 	}
 	return i, nil
 }
@@ -498,11 +556,11 @@ func (m *Configuration) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintCodec(dAtA, i, uint64(m.MinimalFee.Size()))
-	n3, err := m.MinimalFee.MarshalTo(dAtA[i:])
+	n6, err := m.MinimalFee.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n3
+	i += n6
 	return i, nil
 }
 
@@ -522,14 +580,14 @@ func (m *ConfigurationMsg) MarshalTo(dAtA []byte) (int, error) {
 	var l int
 	_ = l
 	if m.Patch != nil {
-		dAtA[i] = 0xa
+		dAtA[i] = 0x12
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(m.Patch.Size()))
-		n4, err := m.Patch.MarshalTo(dAtA[i:])
+		n7, err := m.Patch.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n4
+		i += n7
 	}
 	return i, nil
 }
@@ -549,6 +607,10 @@ func (m *Set) Size() (n int) {
 	}
 	var l int
 	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.Size()
+		n += 1 + l + sovCodec(uint64(l))
+	}
 	if len(m.Coins) > 0 {
 		for _, e := range m.Coins {
 			l = e.Size()
@@ -564,6 +626,10 @@ func (m *SendMsg) Size() (n int) {
 	}
 	var l int
 	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.Size()
+		n += 1 + l + sovCodec(uint64(l))
+	}
 	l = len(m.Src)
 	if l > 0 {
 		n += 1 + l + sovCodec(uint64(l))
@@ -593,6 +659,10 @@ func (m *FeeInfo) Size() (n int) {
 	}
 	var l int
 	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.Size()
+		n += 1 + l + sovCodec(uint64(l))
+	}
 	l = len(m.Payer)
 	if l > 0 {
 		n += 1 + l + sovCodec(uint64(l))
@@ -679,6 +749,42 @@ func (m *Set) Unmarshal(dAtA []byte) error {
 		}
 		switch fieldNum {
 		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCodec
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &weave.Metadata{}
+			}
+			if err := m.Metadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Coins", wireType)
 			}
@@ -767,6 +873,42 @@ func (m *SendMsg) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCodec
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &weave.Metadata{}
+			}
+			if err := m.Metadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Src", wireType)
 			}
 			var byteLen int
@@ -799,7 +941,7 @@ func (m *SendMsg) Unmarshal(dAtA []byte) error {
 				m.Src = []byte{}
 			}
 			iNdEx = postIndex
-		case 2:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Dest", wireType)
 			}
@@ -833,7 +975,7 @@ func (m *SendMsg) Unmarshal(dAtA []byte) error {
 				m.Dest = []byte{}
 			}
 			iNdEx = postIndex
-		case 3:
+		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
 			}
@@ -869,7 +1011,7 @@ func (m *SendMsg) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 4:
+		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Memo", wireType)
 			}
@@ -901,7 +1043,7 @@ func (m *SendMsg) Unmarshal(dAtA []byte) error {
 			}
 			m.Memo = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 5:
+		case 6:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Ref", wireType)
 			}
@@ -990,6 +1132,42 @@ func (m *FeeInfo) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCodec
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &weave.Metadata{}
+			}
+			if err := m.Metadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Payer", wireType)
 			}
 			var byteLen int
@@ -1022,7 +1200,7 @@ func (m *FeeInfo) Unmarshal(dAtA []byte) error {
 				m.Payer = []byte{}
 			}
 			iNdEx = postIndex
-		case 2:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Fees", wireType)
 			}
@@ -1265,7 +1443,7 @@ func (m *ConfigurationMsg) Unmarshal(dAtA []byte) error {
 			return fmt.Errorf("proto: ConfigurationMsg: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 1:
+		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Patch", wireType)
 			}

--- a/x/cash/codec.proto
+++ b/x/cash/codec.proto
@@ -2,13 +2,17 @@ syntax = "proto3";
 
 package cash;
 
+import "github.com/iov-one/weave/codec.proto";
 import "github.com/iov-one/weave/coin/codec.proto";
+
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 // Set may contain Coin of many different currencies.
 // It handles adding and subtracting sets of currencies.
 message Set {
-  repeated coin.Coin coins = 1;
+  weave.Metadata metadata = 1;
+
+  repeated coin.Coin coins = 2;
 }
 
 // SendMsg is a request to move these coins from the given
@@ -17,20 +21,24 @@ message Set {
 // ref is optional binary data, that can refer to another
 // eg. tx hash
 message SendMsg {
-  bytes src = 1 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
-  bytes dest = 2 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
-  coin.Coin amount = 3;
+  weave.Metadata metadata = 1;
+
+  bytes src = 2 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
+  bytes dest = 3 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
+  coin.Coin amount = 4;
   // max length 128 character
-  string memo = 4;
+  string memo = 5;
   // max length 64 bytes
-  bytes ref = 5;
+  bytes ref = 6;
 }
 
 // FeeInfo records who pays what fees to have this
 // message processed
 message FeeInfo {
-  bytes payer = 1;
-  coin.Coin fees = 2;
+  weave.Metadata metadata = 1;
+
+  bytes payer = 2;
+  coin.Coin fees = 3;
 }
 
 
@@ -42,5 +50,6 @@ message Configuration {
 }
 
 message ConfigurationMsg {
-  Configuration patch = 1;
+  // TODO: add schema uint32 here
+  Configuration patch = 2;
 }

--- a/x/cash/controller_test.go
+++ b/x/cash/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/iov-one/weave"
 	coin "github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/migration"
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/weavetest"
 )
@@ -109,6 +110,7 @@ func TestIssueCoins(t *testing.T) {
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
 			kv := store.MemStore()
+			migration.MustInitPkg(kv, "cash")
 
 			for i, issue := range tc.issue {
 				if err := controller.CoinMint(kv, issue.addr, issue.amount); !issue.wantErr.Is(err) {
@@ -208,6 +210,7 @@ func TestMoveCoins(t *testing.T) {
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
 			kv := store.MemStore()
+			migration.MustInitPkg(kv, "cash")
 
 			if err := controller.CoinMint(kv, tc.issue.addr, tc.issue.amount); !tc.issue.wantErr.Is(err) {
 				t.Fatalf("unexpected coin minting error: %+v", err)
@@ -241,6 +244,8 @@ func TestMoveCoins(t *testing.T) {
 
 func TestBalance(t *testing.T) {
 	store := store.MemStore()
+	migration.MustInitPkg(store, "cash")
+
 	ctrl := NewController(NewBucket())
 
 	addr1 := weavetest.NewCondition().Address()

--- a/x/cash/dynamicfee_test.go
+++ b/x/cash/dynamicfee_test.go
@@ -7,6 +7,7 @@ import (
 	coin "github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/gconf"
+	"github.com/iov-one/weave/migration"
 	"github.com/iov-one/weave/orm"
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/weavetest"
@@ -193,6 +194,7 @@ func TestDynamicFeeDecorator(t *testing.T) {
 			tx := &txMock{info: &FeeInfo{Fees: &tc.txFee}}
 
 			db := store.MemStore()
+			migration.MustInitPkg(db, "cash")
 
 			config := Configuration{
 				CollectorAddress: collectorAddr,

--- a/x/cash/handler.go
+++ b/x/cash/handler.go
@@ -4,15 +4,17 @@ import (
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/gconf"
+	"github.com/iov-one/weave/migration"
 	"github.com/iov-one/weave/x"
 )
 
 // RegisterRoutes will instantiate and register
 // all handlers in this package
 func RegisterRoutes(r weave.Registry, auth x.Authenticator, control Controller) {
-
-	r.Handle(pathSendMsg, NewSendHandler(auth, control))
-	r.Handle(pathConfigurationUpdateMsg, NewConfigHandler(auth))
+	r.Handle(pathSendMsg, migration.SchemaMigratingHandler("cash",
+		NewSendHandler(auth, control)))
+	r.Handle(pathConfigurationUpdateMsg, migration.SchemaMigratingHandler("cash",
+		NewConfigHandler(auth)))
 }
 
 // RegisterQuery will register this bucket as "/wallets"

--- a/x/cash/handler_test.go
+++ b/x/cash/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/iov-one/weave"
 	coin "github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/migration"
 	"github.com/iov-one/weave/orm"
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/weavetest"
@@ -88,6 +89,7 @@ func TestSend(t *testing.T) {
 			h := NewSendHandler(auth, controller)
 
 			kv := store.MemStore()
+			migration.MustInitPkg(kv, "cash")
 			bucket := NewBucket()
 			for _, wallet := range tc.initState {
 				if err := bucket.Save(kv, wallet); err != nil {

--- a/x/cash/init_test.go
+++ b/x/cash/init_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/iov-one/weave"
 	coin "github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/migration"
 	"github.com/iov-one/weave/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,6 +77,7 @@ func TestInitState(t *testing.T) {
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
 			kv := store.MemStore()
+			migration.MustInitPkg(kv, "cash")
 			bucket := NewBucket()
 			err := init.FromGenesis(tc.opts, kv)
 			if tc.isError {

--- a/x/cash/msg.go
+++ b/x/cash/msg.go
@@ -4,7 +4,12 @@ import (
 	"github.com/iov-one/weave"
 	coin "github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/migration"
 )
+
+func init() {
+	migration.MustRegister(1, &SendMsg{}, migration.NoModification)
+}
 
 // Ensure we implement the Msg interface
 var _ weave.Msg = (*SendMsg)(nil)

--- a/x/cash/msg_test.go
+++ b/x/cash/msg_test.go
@@ -20,55 +20,63 @@ func TestValidateSendMsg(t *testing.T) {
 	}{
 		"success": {
 			msg: &SendMsg{
-				Amount: coin.NewCoinp(10, 0, "FOO"),
-				Dest:   addr1,
-				Src:    addr2,
-				Memo:   "some memo message",
-				Ref:    []byte("some reference"),
+				Metadata: &weave.Metadata{Schema: 1},
+				Amount:   coin.NewCoinp(10, 0, "FOO"),
+				Dest:     addr1,
+				Src:      addr2,
+				Memo:     "some memo message",
+				Ref:      []byte("some reference"),
 			},
 			wantErr: nil,
 		},
 		"success with minimal amount of data": {
 			msg: &SendMsg{
-				Amount: coin.NewCoinp(10, 0, "FOO"),
-				Dest:   addr1,
-				Src:    addr2,
+				Metadata: &weave.Metadata{Schema: 1},
+				Amount:   coin.NewCoinp(10, 0, "FOO"),
+				Dest:     addr1,
+				Src:      addr2,
 			},
 			wantErr: nil,
 		},
 		"empty message": {
-			msg:     &SendMsg{},
+			msg: &SendMsg{
+				Metadata: &weave.Metadata{Schema: 1},
+			},
 			wantErr: errors.ErrInvalidAmount,
 		},
 		"missing source": {
 			msg: &SendMsg{
-				Amount: coin.NewCoinp(10, 0, "FOO"),
-				Dest:   addr1,
+				Metadata: &weave.Metadata{Schema: 1},
+				Amount:   coin.NewCoinp(10, 0, "FOO"),
+				Dest:     addr1,
 			},
 			wantErr: errors.ErrEmpty,
 		},
 		"missing destination": {
 			msg: &SendMsg{
-				Amount: coin.NewCoinp(10, 0, "FOO"),
-				Src:    addr2,
+				Metadata: &weave.Metadata{Schema: 1},
+				Amount:   coin.NewCoinp(10, 0, "FOO"),
+				Src:      addr2,
 			},
 			wantErr: errors.ErrEmpty,
 		},
 		"reference too long": {
 			msg: &SendMsg{
-				Amount: coin.NewCoinp(10, 0, "FOO"),
-				Dest:   addr1,
-				Src:    addr2,
-				Ref:    []byte(strings.Repeat("x", maxRefSize+1)),
+				Metadata: &weave.Metadata{Schema: 1},
+				Amount:   coin.NewCoinp(10, 0, "FOO"),
+				Dest:     addr1,
+				Src:      addr2,
+				Ref:      []byte(strings.Repeat("x", maxRefSize+1)),
 			},
 			wantErr: errors.ErrInvalidState,
 		},
 		"memo too long": {
 			msg: &SendMsg{
-				Amount: coin.NewCoinp(10, 0, "FOO"),
-				Dest:   addr1,
-				Src:    addr2,
-				Memo:   strings.Repeat("x", maxMemoSize+1),
+				Metadata: &weave.Metadata{Schema: 1},
+				Amount:   coin.NewCoinp(10, 0, "FOO"),
+				Dest:     addr1,
+				Src:      addr2,
+				Memo:     strings.Repeat("x", maxMemoSize+1),
 			},
 			wantErr: errors.ErrInvalidState,
 		},
@@ -92,38 +100,45 @@ func TestValidateFeeTx(t *testing.T) {
 	}{
 		"success": {
 			info: &FeeInfo{
-				Fees:  coin.NewCoinp(1, 0, "IOV"),
-				Payer: addr1,
+				Metadata: &weave.Metadata{Schema: 1},
+				Fees:     coin.NewCoinp(1, 0, "IOV"),
+				Payer:    addr1,
 			},
 			wantErr: nil,
 		},
 		"empty": {
-			info:    &FeeInfo{},
+			info: &FeeInfo{
+				Metadata: &weave.Metadata{Schema: 1},
+			},
 			wantErr: errors.ErrInvalidAmount,
 		},
 		"no fee": {
 			info: &FeeInfo{
-				Payer: addr1,
+				Metadata: &weave.Metadata{Schema: 1},
+				Payer:    addr1,
 			},
 			wantErr: errors.ErrInvalidAmount,
 		},
 		"no payer": {
 			info: &FeeInfo{
-				Fees: coin.NewCoinp(10, 0, "IOV"),
+				Metadata: &weave.Metadata{Schema: 1},
+				Fees:     coin.NewCoinp(10, 0, "IOV"),
 			},
 			wantErr: errors.ErrEmpty,
 		},
 		"negative fee": {
 			info: &FeeInfo{
-				Fees:  coin.NewCoinp(-10, 0, "IOV"),
-				Payer: addr1,
+				Metadata: &weave.Metadata{Schema: 1},
+				Fees:     coin.NewCoinp(-10, 0, "IOV"),
+				Payer:    addr1,
 			},
 			wantErr: errors.ErrInvalidAmount,
 		},
 		"invalid fee ticker": {
 			info: &FeeInfo{
-				Fees:  coin.NewCoinp(10, 0, "foobar"),
-				Payer: addr1,
+				Metadata: &weave.Metadata{Schema: 1},
+				Fees:     coin.NewCoinp(10, 0, "foobar"),
+				Payer:    addr1,
 			},
 			wantErr: errors.ErrCurrency,
 		},

--- a/x/distribution/codec.pb.go
+++ b/x/distribution/codec.pb.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_iov_one_weave "github.com/iov-one/weave"
+	weave "github.com/iov-one/weave"
 	io "io"
 	math "math"
 )
@@ -27,13 +28,14 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 // temporary account used for storing fees that are later distributed between
 // the owners.
 type Revenue struct {
+	Metadata *weave.Metadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// Admin key belongs to the governance entities. It can be used to transfer
 	// stored amount to an another account.
 	// While not enforced it is best to use a multisig contract here.
-	Admin github_com_iov_one_weave.Address `protobuf:"bytes,1,opt,name=admin,proto3,casttype=github.com/iov-one/weave.Address" json:"admin,omitempty"`
+	Admin github_com_iov_one_weave.Address `protobuf:"bytes,2,opt,name=admin,proto3,casttype=github.com/iov-one/weave.Address" json:"admin,omitempty"`
 	// Recipients holds any number of addresses that the collected revenue is
 	// distributed to. Must be at least one.
-	Recipients []*Recipient `protobuf:"bytes,2,rep,name=recipients,proto3" json:"recipients,omitempty"`
+	Recipients []*Recipient `protobuf:"bytes,3,rep,name=recipients,proto3" json:"recipients,omitempty"`
 }
 
 func (m *Revenue) Reset()         { *m = Revenue{} }
@@ -68,6 +70,13 @@ func (m *Revenue) XXX_DiscardUnknown() {
 }
 
 var xxx_messageInfo_Revenue proto.InternalMessageInfo
+
+func (m *Revenue) GetMetadata() *weave.Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
 
 func (m *Revenue) GetAdmin() github_com_iov_one_weave.Address {
 	if m != nil {
@@ -146,13 +155,14 @@ func (m *Recipient) GetWeight() int32 {
 
 // NewRevenueMsg is issuing the creation of a new revenue stream instance.
 type NewRevenueMsg struct {
+	Metadata *weave.Metadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// Admin key belongs to the governance entities. It can be used to transfer
 	// stored amount to an another account.
 	// While not enforced it is best to use a multisig contract here.
-	Admin github_com_iov_one_weave.Address `protobuf:"bytes,1,opt,name=admin,proto3,casttype=github.com/iov-one/weave.Address" json:"admin,omitempty"`
+	Admin github_com_iov_one_weave.Address `protobuf:"bytes,2,opt,name=admin,proto3,casttype=github.com/iov-one/weave.Address" json:"admin,omitempty"`
 	// Recipients holds any number of addresses that the collected revenue is
 	// distributed to. Must be at least one.
-	Recipients []*Recipient `protobuf:"bytes,2,rep,name=recipients,proto3" json:"recipients,omitempty"`
+	Recipients []*Recipient `protobuf:"bytes,3,rep,name=recipients,proto3" json:"recipients,omitempty"`
 }
 
 func (m *NewRevenueMsg) Reset()         { *m = NewRevenueMsg{} }
@@ -188,6 +198,13 @@ func (m *NewRevenueMsg) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_NewRevenueMsg proto.InternalMessageInfo
 
+func (m *NewRevenueMsg) GetMetadata() *weave.Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
+
 func (m *NewRevenueMsg) GetAdmin() github_com_iov_one_weave.Address {
 	if m != nil {
 		return m.Admin
@@ -206,9 +223,10 @@ func (m *NewRevenueMsg) GetRecipients() []*Recipient {
 // revenue instance. Revenue is distributed between recipients. Request must be
 // signed using admin key.
 type DistributeMsg struct {
+	Metadata *weave.Metadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// Revenue ID reference an ID of a revenue instance that the collected fees
 	// should be distributed between recipients.
-	RevenueID []byte `protobuf:"bytes,1,opt,name=revenue_id,json=revenueId,proto3" json:"revenue_id,omitempty"`
+	RevenueID []byte `protobuf:"bytes,2,opt,name=revenue_id,json=revenueId,proto3" json:"revenue_id,omitempty"`
 }
 
 func (m *DistributeMsg) Reset()         { *m = DistributeMsg{} }
@@ -244,6 +262,13 @@ func (m *DistributeMsg) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DistributeMsg proto.InternalMessageInfo
 
+func (m *DistributeMsg) GetMetadata() *weave.Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
+
 func (m *DistributeMsg) GetRevenueID() []byte {
 	if m != nil {
 		return m.RevenueID
@@ -257,11 +282,12 @@ func (m *DistributeMsg) GetRevenueID() []byte {
 // the revenue account are distributed using old configuration. Only when the
 // collected revenue amount is equal to zero the change is applied.
 type ResetRevenueMsg struct {
+	Metadata *weave.Metadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// Revenue ID reference an ID of a revenue instance that is updated.
-	RevenueID []byte `protobuf:"bytes,1,opt,name=revenue_id,json=revenueId,proto3" json:"revenue_id,omitempty"`
+	RevenueID []byte `protobuf:"bytes,2,opt,name=revenue_id,json=revenueId,proto3" json:"revenue_id,omitempty"`
 	// Recipients holds any number of addresses that the collected revenue is
 	// distributed to. Must be at least one.
-	Recipients []*Recipient `protobuf:"bytes,2,rep,name=recipients,proto3" json:"recipients,omitempty"`
+	Recipients []*Recipient `protobuf:"bytes,3,rep,name=recipients,proto3" json:"recipients,omitempty"`
 }
 
 func (m *ResetRevenueMsg) Reset()         { *m = ResetRevenueMsg{} }
@@ -297,6 +323,13 @@ func (m *ResetRevenueMsg) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ResetRevenueMsg proto.InternalMessageInfo
 
+func (m *ResetRevenueMsg) GetMetadata() *weave.Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
+
 func (m *ResetRevenueMsg) GetRevenueID() []byte {
 	if m != nil {
 		return m.RevenueID
@@ -322,27 +355,30 @@ func init() {
 func init() { proto.RegisterFile("x/distribution/codec.proto", fileDescriptor_186299c22854933b) }
 
 var fileDescriptor_186299c22854933b = []byte{
-	// 313 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x92, 0xbf, 0x4a, 0xc3, 0x40,
-	0x1c, 0xc7, 0x7b, 0x95, 0xb6, 0xf4, 0x6c, 0x11, 0x32, 0x68, 0xe8, 0x70, 0x0d, 0xc1, 0x21, 0x83,
-	0x4d, 0x40, 0x07, 0x41, 0x50, 0xb0, 0x74, 0xe9, 0xa0, 0xc3, 0xbd, 0x80, 0x24, 0xb9, 0x9f, 0xe9,
-	0x0d, 0xcd, 0x95, 0xdc, 0x25, 0xe9, 0xe4, 0xe4, 0x03, 0xf8, 0x58, 0x8e, 0x1d, 0x9d, 0x8a, 0x24,
-	0x6f, 0xe1, 0x24, 0x5e, 0x12, 0xc9, 0x5a, 0x17, 0xb7, 0xfb, 0xf1, 0xfd, 0xc3, 0xe7, 0x0b, 0x87,
-	0x27, 0x5b, 0x8f, 0x71, 0xa9, 0x12, 0x1e, 0xa4, 0x8a, 0x8b, 0xd8, 0x0b, 0x05, 0x83, 0xd0, 0xdd,
-	0x24, 0x42, 0x09, 0x63, 0xd4, 0x56, 0x26, 0xb3, 0x88, 0xab, 0x55, 0x1a, 0xb8, 0xa1, 0x58, 0x7b,
-	0x91, 0x88, 0x84, 0xa7, 0x4d, 0x41, 0xfa, 0xac, 0x2f, 0x7d, 0xe8, 0x57, 0x15, 0xb6, 0x5f, 0xf0,
-	0x80, 0x42, 0x06, 0x71, 0x0a, 0xc6, 0x0d, 0xee, 0xf9, 0x6c, 0xcd, 0x63, 0x13, 0x59, 0xc8, 0x19,
-	0xcd, 0xcf, 0xbf, 0xf6, 0x53, 0xab, 0x55, 0xc6, 0x45, 0x36, 0x13, 0x31, 0x78, 0x39, 0xf8, 0x19,
-	0xb8, 0xf7, 0x8c, 0x25, 0x20, 0x25, 0xad, 0x22, 0xc6, 0x35, 0xc6, 0x09, 0x84, 0x7c, 0xc3, 0x21,
-	0x56, 0xd2, 0xec, 0x5a, 0x47, 0xce, 0xf1, 0xe5, 0x99, 0xdb, 0x06, 0x73, 0x69, 0xa3, 0xd3, 0x96,
-	0xd5, 0x0e, 0xf1, 0xf0, 0x57, 0x30, 0xee, 0xf0, 0xc0, 0xaf, 0x7a, 0x0f, 0x62, 0x68, 0x42, 0xc6,
-	0x29, 0xee, 0xe7, 0xc0, 0xa3, 0x95, 0x32, 0xbb, 0x16, 0x72, 0x7a, 0xb4, 0xbe, 0xec, 0x57, 0x84,
-	0xc7, 0x8f, 0x90, 0xd7, 0x43, 0x1f, 0x64, 0xf4, 0x3f, 0x5b, 0x6f, 0xf1, 0x78, 0xd1, 0xb8, 0x34,
-	0xc5, 0xc5, 0x4f, 0x93, 0x66, 0x7a, 0xe2, 0xac, 0x46, 0x19, 0x17, 0xfb, 0xe9, 0xb0, 0x26, 0x5d,
-	0x2e, 0xe8, 0xb0, 0x36, 0x2c, 0x99, 0xbd, 0xc5, 0x27, 0x14, 0x24, 0xa8, 0xd6, 0x8c, 0x83, 0x0a,
-	0xfe, 0x0c, 0x3e, 0x37, 0xdf, 0x0b, 0x82, 0x76, 0x05, 0x41, 0x9f, 0x05, 0x41, 0x6f, 0x25, 0xe9,
-	0xec, 0x4a, 0xd2, 0xf9, 0x28, 0x49, 0x27, 0xe8, 0xeb, 0x5f, 0x74, 0xf5, 0x1d, 0x00, 0x00, 0xff,
-	0xff, 0xd6, 0x63, 0x52, 0xb0, 0xa0, 0x02, 0x00, 0x00,
+	// 353 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xaa, 0xd0, 0x4f, 0xc9,
+	0x2c, 0x2e, 0x29, 0xca, 0x4c, 0x2a, 0x2d, 0xc9, 0xcc, 0xcf, 0xd3, 0x4f, 0xce, 0x4f, 0x49, 0x4d,
+	0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0xe2, 0x41, 0x96, 0x91, 0x52, 0x49, 0xcf, 0x2c, 0xc9,
+	0x28, 0x4d, 0xd2, 0x4b, 0xce, 0xcf, 0xd5, 0xcf, 0xcc, 0x2f, 0xd3, 0xcd, 0xcf, 0x4b, 0xd5, 0x2f,
+	0x4f, 0x4d, 0x2c, 0x4b, 0x45, 0xd6, 0x23, 0xa5, 0x8b, 0xa4, 0x2a, 0x3d, 0x3f, 0x3d, 0x5f, 0x1f,
+	0x2c, 0x9c, 0x54, 0x9a, 0x06, 0xe6, 0x81, 0x39, 0x60, 0x16, 0x44, 0xb9, 0xd2, 0x6a, 0x46, 0x2e,
+	0xf6, 0xa0, 0xd4, 0xb2, 0xd4, 0xbc, 0xd2, 0x54, 0x21, 0x6d, 0x2e, 0x8e, 0xdc, 0xd4, 0x92, 0xc4,
+	0x94, 0xc4, 0x92, 0x44, 0x09, 0x46, 0x05, 0x46, 0x0d, 0x6e, 0x23, 0x7e, 0x3d, 0xb0, 0x05, 0x7a,
+	0xbe, 0x50, 0xe1, 0x20, 0xb8, 0x02, 0x21, 0x2b, 0x2e, 0xd6, 0xc4, 0x94, 0xdc, 0xcc, 0x3c, 0x09,
+	0x26, 0x05, 0x46, 0x0d, 0x1e, 0x27, 0x95, 0x5f, 0xf7, 0xe4, 0x15, 0x70, 0x39, 0x50, 0xcf, 0x31,
+	0x25, 0xa5, 0x28, 0xb5, 0xb8, 0x38, 0x08, 0xa2, 0x45, 0xc8, 0x9c, 0x8b, 0xab, 0x28, 0x35, 0x39,
+	0xb3, 0x20, 0x33, 0x35, 0xaf, 0xa4, 0x58, 0x82, 0x59, 0x81, 0x59, 0x83, 0xdb, 0x48, 0x5c, 0x0f,
+	0xd9, 0xb3, 0x7a, 0x41, 0x30, 0xf9, 0x20, 0x24, 0xa5, 0x4a, 0xc9, 0x5c, 0x9c, 0x70, 0x09, 0x21,
+	0x3b, 0x2e, 0xf6, 0x44, 0x88, 0xb9, 0x60, 0xd7, 0x12, 0xeb, 0x06, 0x98, 0x26, 0x21, 0x31, 0x2e,
+	0xb6, 0xf2, 0xd4, 0xcc, 0xf4, 0x8c, 0x12, 0xb0, 0x17, 0x58, 0x83, 0xa0, 0x3c, 0xa5, 0x8d, 0x8c,
+	0x5c, 0xbc, 0x7e, 0xa9, 0xe5, 0xd0, 0x50, 0xf1, 0x2d, 0x4e, 0x1f, 0x02, 0x01, 0x93, 0xc5, 0xc5,
+	0xeb, 0x02, 0x53, 0x45, 0xba, 0x93, 0x75, 0x40, 0xd6, 0x82, 0x7d, 0x1b, 0x9f, 0x99, 0x02, 0x75,
+	0x37, 0xef, 0xa3, 0x7b, 0xf2, 0x9c, 0xd0, 0x30, 0xf0, 0x74, 0x09, 0xe2, 0x84, 0x2a, 0xf0, 0x4c,
+	0x51, 0x5a, 0xca, 0xc8, 0xc5, 0x1f, 0x94, 0x5a, 0x9c, 0x5a, 0x42, 0x6e, 0x08, 0x91, 0x64, 0x1d,
+	0xd9, 0x61, 0xe2, 0x24, 0x71, 0xe2, 0x91, 0x1c, 0xe3, 0x85, 0x47, 0x72, 0x8c, 0x0f, 0x1e, 0xc9,
+	0x31, 0x4e, 0x78, 0x2c, 0xc7, 0x70, 0xe1, 0xb1, 0x1c, 0xc3, 0x8d, 0xc7, 0x72, 0x0c, 0x49, 0x6c,
+	0xe0, 0xb4, 0x6f, 0x0c, 0x08, 0x00, 0x00, 0xff, 0xff, 0xd4, 0xb3, 0x6e, 0x91, 0x7c, 0x03, 0x00,
+	0x00,
 }
 
 func (m *Revenue) Marshal() (dAtA []byte, err error) {
@@ -360,15 +396,25 @@ func (m *Revenue) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.Admin) > 0 {
+	if m.Metadata != nil {
 		dAtA[i] = 0xa
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(m.Metadata.Size()))
+		n1, err := m.Metadata.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n1
+	}
+	if len(m.Admin) > 0 {
+		dAtA[i] = 0x12
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Admin)))
 		i += copy(dAtA[i:], m.Admin)
 	}
 	if len(m.Recipients) > 0 {
 		for _, msg := range m.Recipients {
-			dAtA[i] = 0x12
+			dAtA[i] = 0x1a
 			i++
 			i = encodeVarintCodec(dAtA, i, uint64(msg.Size()))
 			n, err := msg.MarshalTo(dAtA[i:])
@@ -425,15 +471,25 @@ func (m *NewRevenueMsg) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.Admin) > 0 {
+	if m.Metadata != nil {
 		dAtA[i] = 0xa
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(m.Metadata.Size()))
+		n2, err := m.Metadata.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n2
+	}
+	if len(m.Admin) > 0 {
+		dAtA[i] = 0x12
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Admin)))
 		i += copy(dAtA[i:], m.Admin)
 	}
 	if len(m.Recipients) > 0 {
 		for _, msg := range m.Recipients {
-			dAtA[i] = 0x12
+			dAtA[i] = 0x1a
 			i++
 			i = encodeVarintCodec(dAtA, i, uint64(msg.Size()))
 			n, err := msg.MarshalTo(dAtA[i:])
@@ -461,8 +517,18 @@ func (m *DistributeMsg) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.RevenueID) > 0 {
+	if m.Metadata != nil {
 		dAtA[i] = 0xa
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(m.Metadata.Size()))
+		n3, err := m.Metadata.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n3
+	}
+	if len(m.RevenueID) > 0 {
+		dAtA[i] = 0x12
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.RevenueID)))
 		i += copy(dAtA[i:], m.RevenueID)
@@ -485,15 +551,25 @@ func (m *ResetRevenueMsg) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.RevenueID) > 0 {
+	if m.Metadata != nil {
 		dAtA[i] = 0xa
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(m.Metadata.Size()))
+		n4, err := m.Metadata.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n4
+	}
+	if len(m.RevenueID) > 0 {
+		dAtA[i] = 0x12
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.RevenueID)))
 		i += copy(dAtA[i:], m.RevenueID)
 	}
 	if len(m.Recipients) > 0 {
 		for _, msg := range m.Recipients {
-			dAtA[i] = 0x12
+			dAtA[i] = 0x1a
 			i++
 			i = encodeVarintCodec(dAtA, i, uint64(msg.Size()))
 			n, err := msg.MarshalTo(dAtA[i:])
@@ -521,6 +597,10 @@ func (m *Revenue) Size() (n int) {
 	}
 	var l int
 	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.Size()
+		n += 1 + l + sovCodec(uint64(l))
+	}
 	l = len(m.Admin)
 	if l > 0 {
 		n += 1 + l + sovCodec(uint64(l))
@@ -556,6 +636,10 @@ func (m *NewRevenueMsg) Size() (n int) {
 	}
 	var l int
 	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.Size()
+		n += 1 + l + sovCodec(uint64(l))
+	}
 	l = len(m.Admin)
 	if l > 0 {
 		n += 1 + l + sovCodec(uint64(l))
@@ -575,6 +659,10 @@ func (m *DistributeMsg) Size() (n int) {
 	}
 	var l int
 	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.Size()
+		n += 1 + l + sovCodec(uint64(l))
+	}
 	l = len(m.RevenueID)
 	if l > 0 {
 		n += 1 + l + sovCodec(uint64(l))
@@ -588,6 +676,10 @@ func (m *ResetRevenueMsg) Size() (n int) {
 	}
 	var l int
 	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.Size()
+		n += 1 + l + sovCodec(uint64(l))
+	}
 	l = len(m.RevenueID)
 	if l > 0 {
 		n += 1 + l + sovCodec(uint64(l))
@@ -645,6 +737,42 @@ func (m *Revenue) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCodec
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &weave.Metadata{}
+			}
+			if err := m.Metadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Admin", wireType)
 			}
 			var byteLen int
@@ -677,7 +805,7 @@ func (m *Revenue) Unmarshal(dAtA []byte) error {
 				m.Admin = []byte{}
 			}
 			iNdEx = postIndex
-		case 2:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Recipients", wireType)
 			}
@@ -872,6 +1000,42 @@ func (m *NewRevenueMsg) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCodec
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &weave.Metadata{}
+			}
+			if err := m.Metadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Admin", wireType)
 			}
 			var byteLen int
@@ -904,7 +1068,7 @@ func (m *NewRevenueMsg) Unmarshal(dAtA []byte) error {
 				m.Admin = []byte{}
 			}
 			iNdEx = postIndex
-		case 2:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Recipients", wireType)
 			}
@@ -993,6 +1157,42 @@ func (m *DistributeMsg) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCodec
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &weave.Metadata{}
+			}
+			if err := m.Metadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field RevenueID", wireType)
 			}
 			var byteLen int
@@ -1080,6 +1280,42 @@ func (m *ResetRevenueMsg) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCodec
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &weave.Metadata{}
+			}
+			if err := m.Metadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field RevenueID", wireType)
 			}
 			var byteLen int
@@ -1112,7 +1348,7 @@ func (m *ResetRevenueMsg) Unmarshal(dAtA []byte) error {
 				m.RevenueID = []byte{}
 			}
 			iNdEx = postIndex
-		case 2:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Recipients", wireType)
 			}

--- a/x/distribution/codec.proto
+++ b/x/distribution/codec.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package distribution;
 
+import "github.com/iov-one/weave/codec.proto";
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 
@@ -9,13 +10,15 @@ import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 // temporary account used for storing fees that are later distributed between
 // the owners.
 message Revenue {
+  weave.Metadata metadata = 1;
+
   // Admin key belongs to the governance entities. It can be used to transfer
   // stored amount to an another account.
   // While not enforced it is best to use a multisig contract here.
-  bytes admin = 1 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
+  bytes admin = 2 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
   // Recipients holds any number of addresses that the collected revenue is
   // distributed to. Must be at least one.
-  repeated Recipient recipients = 2;
+  repeated Recipient recipients = 3;
 }
 
 message Recipient {
@@ -35,22 +38,26 @@ message Recipient {
 
 // NewRevenueMsg is issuing the creation of a new revenue stream instance.
 message NewRevenueMsg {
+  weave.Metadata metadata = 1;
+
   // Admin key belongs to the governance entities. It can be used to transfer
   // stored amount to an another account.
   // While not enforced it is best to use a multisig contract here.
-  bytes admin = 1 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
+  bytes admin = 2 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
   // Recipients holds any number of addresses that the collected revenue is
   // distributed to. Must be at least one.
-  repeated Recipient recipients = 2;
+  repeated Recipient recipients = 3;
 }
 
 // DistributeMsg is a request to distribute all funds collected within a single
 // revenue instance. Revenue is distributed between recipients. Request must be
 // signed using admin key.
 message DistributeMsg {
+  weave.Metadata metadata = 1;
+
   // Revenue ID reference an ID of a revenue instance that the collected fees
   // should be distributed between recipients.
-  bytes revenue_id = 1 [(gogoproto.customname) = "RevenueID"];
+  bytes revenue_id = 2 [(gogoproto.customname) = "RevenueID"];
 }
 
 // ResetRevenueMsg change the configuration of a revenue instance.
@@ -59,9 +66,11 @@ message DistributeMsg {
 // the revenue account are distributed using old configuration. Only when the
 // collected revenue amount is equal to zero the change is applied.
 message ResetRevenueMsg {
+  weave.Metadata metadata = 1;
+
   // Revenue ID reference an ID of a revenue instance that is updated.
-  bytes revenue_id = 1 [(gogoproto.customname) = "RevenueID"];
+  bytes revenue_id = 2 [(gogoproto.customname) = "RevenueID"];
   // Recipients holds any number of addresses that the collected revenue is
   // distributed to. Must be at least one.
-  repeated Recipient recipients = 2;
+  repeated Recipient recipients = 3;
 }

--- a/x/distribution/handler_test.go
+++ b/x/distribution/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iov-one/weave/app"
 	"github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/migration"
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/weavetest"
 	"github.com/iov-one/weave/x/cash"
@@ -57,6 +58,7 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &NewRevenueMsg{
+						Metadata:   &weave.Metadata{Schema: 1},
 						Admin:      []byte("f427d624ed29c1fae0e2"),
 						Recipients: []*Recipient{},
 					},
@@ -66,7 +68,8 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &NewRevenueMsg{
-						Admin: []byte("f427d624ed29c1fae0e2"),
+						Metadata: &weave.Metadata{Schema: 1},
+						Admin:    []byte("f427d624ed29c1fae0e2"),
 						Recipients: []*Recipient{
 							{Weight: 1, Address: addr1},
 						},
@@ -76,6 +79,7 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &ResetRevenueMsg{
+						Metadata:   &weave.Metadata{Schema: 1},
 						RevenueID:  weavetest.SequenceID(1),
 						Recipients: []*Recipient{},
 					},
@@ -85,6 +89,7 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &ResetRevenueMsg{
+						Metadata:  &weave.Metadata{Schema: 1},
 						RevenueID: weavetest.SequenceID(1),
 						Recipients: []*Recipient{
 							{Weight: 1, Address: addr1},
@@ -102,6 +107,7 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &DistributeMsg{
+						Metadata:  &weave.Metadata{Schema: 1},
 						RevenueID: []byte("revenue-with-this-id-does-not-exist"),
 					},
 					blocksize:      100,
@@ -122,7 +128,8 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &NewRevenueMsg{
-						Admin: []byte("f427d624ed29c1fae0e2"),
+						Metadata: &weave.Metadata{Schema: 1},
+						Admin:    []byte("f427d624ed29c1fae0e2"),
 						Recipients: []*Recipient{
 							// There is only one recipient with a ridiculously high weight.
 							// All funds should be send to this account.
@@ -134,8 +141,11 @@ func TestHandlers(t *testing.T) {
 					wantDeliverErr: nil,
 				},
 				{
-					conditions:     []weave.Condition{src},
-					msg:            &DistributeMsg{RevenueID: weavetest.SequenceID(1)},
+					conditions: []weave.Condition{src},
+					msg: &DistributeMsg{
+						Metadata:  &weave.Metadata{Schema: 1},
+						RevenueID: weavetest.SequenceID(1),
+					},
 					blocksize:      101,
 					wantCheckErr:   nil,
 					wantDeliverErr: nil,
@@ -149,7 +159,8 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &NewRevenueMsg{
-						Admin: []byte("f427d624ed29c1fae0e2"),
+						Metadata: &weave.Metadata{Schema: 1},
+						Admin:    []byte("f427d624ed29c1fae0e2"),
 						Recipients: []*Recipient{
 							{Weight: 1, Address: addr1},
 							{Weight: 2, Address: addr2},
@@ -162,6 +173,7 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &DistributeMsg{
+						Metadata:  &weave.Metadata{Schema: 1},
 						RevenueID: weavetest.SequenceID(1),
 					},
 					blocksize:      101,
@@ -181,7 +193,8 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &NewRevenueMsg{
-						Admin: []byte("f427d624ed29c1fae0e2"),
+						Metadata: &weave.Metadata{Schema: 1},
+						Admin:    []byte("f427d624ed29c1fae0e2"),
 						Recipients: []*Recipient{
 							{Weight: 1, Address: addr1},
 							{Weight: 2, Address: addr2},
@@ -194,6 +207,7 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &DistributeMsg{
+						Metadata:  &weave.Metadata{Schema: 1},
 						RevenueID: weavetest.SequenceID(1),
 					},
 					blocksize:      101,
@@ -215,7 +229,8 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &NewRevenueMsg{
-						Admin: []byte("f427d624ed29c1fae0e2"),
+						Metadata: &weave.Metadata{Schema: 1},
+						Admin:    []byte("f427d624ed29c1fae0e2"),
 						Recipients: []*Recipient{
 							{Weight: 10000, Address: addr1},
 							{Weight: 20000, Address: addr2},
@@ -228,6 +243,7 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &DistributeMsg{
+						Metadata:  &weave.Metadata{Schema: 1},
 						RevenueID: weavetest.SequenceID(1),
 					},
 					blocksize:      101,
@@ -249,7 +265,8 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &NewRevenueMsg{
-						Admin: []byte("f427d624ed29c1fae0e2"),
+						Metadata: &weave.Metadata{Schema: 1},
+						Admin:    []byte("f427d624ed29c1fae0e2"),
 						Recipients: []*Recipient{
 							{Weight: 1, Address: addr1},
 							{Weight: 2, Address: addr2},
@@ -262,6 +279,7 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &DistributeMsg{
+						Metadata:  &weave.Metadata{Schema: 1},
 						RevenueID: weavetest.SequenceID(1),
 					},
 					blocksize:      101,
@@ -283,7 +301,8 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &NewRevenueMsg{
-						Admin: []byte("f427d624ed29c1fae0e2"),
+						Metadata: &weave.Metadata{Schema: 1},
+						Admin:    []byte("f427d624ed29c1fae0e2"),
 						Recipients: []*Recipient{
 							{Weight: 20, Address: addr1},
 							{Weight: 20, Address: addr2},
@@ -298,6 +317,7 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &ResetRevenueMsg{
+						Metadata:  &weave.Metadata{Schema: 1},
 						RevenueID: weavetest.SequenceID(1),
 						Recipients: []*Recipient{
 							{Weight: 1234, Address: addr2},
@@ -311,6 +331,7 @@ func TestHandlers(t *testing.T) {
 				{
 					conditions: []weave.Condition{src},
 					msg: &DistributeMsg{
+						Metadata:  &weave.Metadata{Schema: 1},
 						RevenueID: weavetest.SequenceID(1),
 					},
 					blocksize:      103,
@@ -324,6 +345,8 @@ func TestHandlers(t *testing.T) {
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
 			db := store.MemStore()
+
+			migration.MustInitPkg(db, "cash", "distribution")
 
 			for _, a := range tc.prepareAccounts {
 				for _, c := range a.coins {

--- a/x/distribution/init.go
+++ b/x/distribution/init.go
@@ -38,6 +38,7 @@ func (*Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
 			})
 		}
 		revenue := Revenue{
+			Metadata:   &weave.Metadata{Schema: 1},
 			Admin:      r.Admin,
 			Recipients: recipients,
 		}

--- a/x/distribution/init_test.go
+++ b/x/distribution/init_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/migration"
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/weavetest"
 )
@@ -33,6 +34,7 @@ func TestGenesisKey(t *testing.T) {
 	}
 
 	db := store.MemStore()
+	migration.MustInitPkg(db, "distribution")
 	var ini Initializer
 	if err := ini.FromGenesis(opts, db); err != nil {
 		t.Fatalf("cannot load genesis: %s", err)

--- a/x/distribution/model_test.go
+++ b/x/distribution/model_test.go
@@ -18,7 +18,8 @@ func TestRevenueValidate(t *testing.T) {
 	}{
 		"valid model": {
 			model: Revenue{
-				Admin: addr,
+				Metadata: &weave.Metadata{Schema: 1},
+				Admin:    addr,
 				Recipients: []*Recipient{
 					{Weight: 1, Address: addr},
 				},
@@ -27,7 +28,8 @@ func TestRevenueValidate(t *testing.T) {
 		},
 		"admin address must be present": {
 			model: Revenue{
-				Admin: nil,
+				Metadata: &weave.Metadata{Schema: 1},
+				Admin:    nil,
 				Recipients: []*Recipient{
 					{Weight: 1, Address: addr},
 				},
@@ -36,6 +38,7 @@ func TestRevenueValidate(t *testing.T) {
 		},
 		"at least one recipient must be given": {
 			model: Revenue{
+				Metadata:   &weave.Metadata{Schema: 1},
 				Admin:      addr,
 				Recipients: []*Recipient{},
 			},
@@ -43,7 +46,8 @@ func TestRevenueValidate(t *testing.T) {
 		},
 		"recipient weight must be greater than zero": {
 			model: Revenue{
-				Admin: addr,
+				Metadata: &weave.Metadata{Schema: 1},
+				Admin:    addr,
 				Recipients: []*Recipient{
 					{Weight: 0, Address: addr},
 				},
@@ -52,7 +56,8 @@ func TestRevenueValidate(t *testing.T) {
 		},
 		"recipient must have a valid address": {
 			model: Revenue{
-				Admin: addr,
+				Metadata: &weave.Metadata{Schema: 1},
+				Admin:    addr,
 				Recipients: []*Recipient{
 					{Weight: 2, Address: []byte("zzz")},
 				},

--- a/x/distribution/msg.go
+++ b/x/distribution/msg.go
@@ -2,7 +2,14 @@ package distribution
 
 import (
 	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/migration"
 )
+
+func init() {
+	migration.MustRegister(1, &NewRevenueMsg{}, migration.NoModification)
+	migration.MustRegister(1, &DistributeMsg{}, migration.NoModification)
+	migration.MustRegister(1, &ResetRevenueMsg{}, migration.NoModification)
+}
 
 const (
 	pathNewRevenueMsg   = "distribution/newrevenue"
@@ -11,6 +18,9 @@ const (
 )
 
 func (msg *NewRevenueMsg) Validate() error {
+	if err := msg.Metadata.Validate(); err != nil {
+		return errors.Wrap(err, "invalid metadata")
+	}
 	if err := msg.Admin.Validate(); err != nil {
 		return errors.Wrap(err, "invalid admin address")
 	}
@@ -25,6 +35,9 @@ func (NewRevenueMsg) Path() string {
 }
 
 func (msg *DistributeMsg) Validate() error {
+	if err := msg.Metadata.Validate(); err != nil {
+		return errors.Wrap(err, "invalid metadata")
+	}
 	if len(msg.RevenueID) == 0 {
 		return errors.Wrap(errors.ErrInvalidMsg, "revenue ID missing")
 	}
@@ -36,6 +49,9 @@ func (DistributeMsg) Path() string {
 }
 
 func (msg *ResetRevenueMsg) Validate() error {
+	if err := msg.Metadata.Validate(); err != nil {
+		return errors.Wrap(err, "invalid metadata")
+	}
 	if err := validateRecipients(msg.Recipients, errors.ErrInvalidMsg); err != nil {
 		return err
 	}

--- a/x/distribution/msg_test.go
+++ b/x/distribution/msg_test.go
@@ -1,1 +1,0 @@
-package distribution

--- a/x/escrow/codec.pb.go
+++ b/x/escrow/codec.pb.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_iov_one_weave "github.com/iov-one/weave"
+	weave "github.com/iov-one/weave"
 	coin "github.com/iov-one/weave/coin"
 	io "io"
 	math "math"
@@ -32,9 +33,10 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 // Note that if the arbiter is a Hashlock permission, we have
 // an HTLC ;)
 type Escrow struct {
-	Sender    github_com_iov_one_weave.Address   `protobuf:"bytes,1,opt,name=sender,proto3,casttype=github.com/iov-one/weave.Address" json:"sender,omitempty"`
-	Arbiter   github_com_iov_one_weave.Condition `protobuf:"bytes,2,opt,name=arbiter,proto3,casttype=github.com/iov-one/weave.Condition" json:"arbiter,omitempty"`
-	Recipient github_com_iov_one_weave.Address   `protobuf:"bytes,3,opt,name=recipient,proto3,casttype=github.com/iov-one/weave.Address" json:"recipient,omitempty"`
+	Metadata  *weave.Metadata                    `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	Sender    github_com_iov_one_weave.Address   `protobuf:"bytes,2,opt,name=sender,proto3,casttype=github.com/iov-one/weave.Address" json:"sender,omitempty"`
+	Arbiter   github_com_iov_one_weave.Condition `protobuf:"bytes,3,opt,name=arbiter,proto3,casttype=github.com/iov-one/weave.Condition" json:"arbiter,omitempty"`
+	Recipient github_com_iov_one_weave.Address   `protobuf:"bytes,4,opt,name=recipient,proto3,casttype=github.com/iov-one/weave.Address" json:"recipient,omitempty"`
 	// If unreleased before timeout, escrow will return to sender.
 	// Timeout represents wall clock time as read from the block header. Timeout
 	// is represented using POSIX time format.
@@ -80,6 +82,13 @@ func (m *Escrow) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_Escrow proto.InternalMessageInfo
 
+func (m *Escrow) GetMetadata() *weave.Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
+
 func (m *Escrow) GetSender() github_com_iov_one_weave.Address {
 	if m != nil {
 		return m.Sender
@@ -119,15 +128,16 @@ func (m *Escrow) GetMemo() string {
 // If sender is not defined, it defaults to the first signer
 // The rest must be defined
 type CreateEscrowMsg struct {
-	Src       github_com_iov_one_weave.Address   `protobuf:"bytes,1,opt,name=src,proto3,casttype=github.com/iov-one/weave.Address" json:"src,omitempty"`
-	Arbiter   github_com_iov_one_weave.Condition `protobuf:"bytes,2,opt,name=arbiter,proto3,casttype=github.com/iov-one/weave.Condition" json:"arbiter,omitempty"`
-	Recipient github_com_iov_one_weave.Address   `protobuf:"bytes,3,opt,name=recipient,proto3,casttype=github.com/iov-one/weave.Address" json:"recipient,omitempty"`
+	Metadata  *weave.Metadata                    `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	Src       github_com_iov_one_weave.Address   `protobuf:"bytes,2,opt,name=src,proto3,casttype=github.com/iov-one/weave.Address" json:"src,omitempty"`
+	Arbiter   github_com_iov_one_weave.Condition `protobuf:"bytes,3,opt,name=arbiter,proto3,casttype=github.com/iov-one/weave.Condition" json:"arbiter,omitempty"`
+	Recipient github_com_iov_one_weave.Address   `protobuf:"bytes,4,opt,name=recipient,proto3,casttype=github.com/iov-one/weave.Address" json:"recipient,omitempty"`
 	// amount may contain multiple token types
-	Amount []*coin.Coin `protobuf:"bytes,4,rep,name=amount,proto3" json:"amount,omitempty"`
+	Amount []*coin.Coin `protobuf:"bytes,5,rep,name=amount,proto3" json:"amount,omitempty"`
 	// Timeout represents wall clock time.
-	Timeout github_com_iov_one_weave.UnixTime `protobuf:"varint,5,opt,name=timeout,proto3,casttype=github.com/iov-one/weave.UnixTime" json:"timeout,omitempty"`
+	Timeout github_com_iov_one_weave.UnixTime `protobuf:"varint,6,opt,name=timeout,proto3,casttype=github.com/iov-one/weave.UnixTime" json:"timeout,omitempty"`
 	// max length 128 character
-	Memo string `protobuf:"bytes,6,opt,name=memo,proto3" json:"memo,omitempty"`
+	Memo string `protobuf:"bytes,7,opt,name=memo,proto3" json:"memo,omitempty"`
 }
 
 func (m *CreateEscrowMsg) Reset()         { *m = CreateEscrowMsg{} }
@@ -162,6 +172,13 @@ func (m *CreateEscrowMsg) XXX_DiscardUnknown() {
 }
 
 var xxx_messageInfo_CreateEscrowMsg proto.InternalMessageInfo
+
+func (m *CreateEscrowMsg) GetMetadata() *weave.Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
 
 func (m *CreateEscrowMsg) GetSrc() github_com_iov_one_weave.Address {
 	if m != nil {
@@ -210,8 +227,9 @@ func (m *CreateEscrowMsg) GetMemo() string {
 // If amount not provided, defaults to entire escrow,
 // May be a subset of the current balance.
 type ReleaseEscrowMsg struct {
-	EscrowId []byte       `protobuf:"bytes,1,opt,name=escrow_id,json=escrowId,proto3" json:"escrow_id,omitempty"`
-	Amount   []*coin.Coin `protobuf:"bytes,2,rep,name=amount,proto3" json:"amount,omitempty"`
+	Metadata *weave.Metadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	EscrowId []byte          `protobuf:"bytes,2,opt,name=escrow_id,json=escrowId,proto3" json:"escrow_id,omitempty"`
+	Amount   []*coin.Coin    `protobuf:"bytes,3,rep,name=amount,proto3" json:"amount,omitempty"`
 }
 
 func (m *ReleaseEscrowMsg) Reset()         { *m = ReleaseEscrowMsg{} }
@@ -247,6 +265,13 @@ func (m *ReleaseEscrowMsg) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ReleaseEscrowMsg proto.InternalMessageInfo
 
+func (m *ReleaseEscrowMsg) GetMetadata() *weave.Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
+
 func (m *ReleaseEscrowMsg) GetEscrowId() []byte {
 	if m != nil {
 		return m.EscrowId
@@ -264,7 +289,8 @@ func (m *ReleaseEscrowMsg) GetAmount() []*coin.Coin {
 // ReturnEscrowMsg returns the content to the sender.
 // Must be authorized by the sender or an expired timeout
 type ReturnEscrowMsg struct {
-	EscrowId []byte `protobuf:"bytes,1,opt,name=escrow_id,json=escrowId,proto3" json:"escrow_id,omitempty"`
+	Metadata *weave.Metadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	EscrowId []byte          `protobuf:"bytes,2,opt,name=escrow_id,json=escrowId,proto3" json:"escrow_id,omitempty"`
 }
 
 func (m *ReturnEscrowMsg) Reset()         { *m = ReturnEscrowMsg{} }
@@ -300,6 +326,13 @@ func (m *ReturnEscrowMsg) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ReturnEscrowMsg proto.InternalMessageInfo
 
+func (m *ReturnEscrowMsg) GetMetadata() *weave.Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
+
 func (m *ReturnEscrowMsg) GetEscrowId() []byte {
 	if m != nil {
 		return m.EscrowId
@@ -313,10 +346,11 @@ func (m *ReturnEscrowMsg) GetEscrowId() []byte {
 //
 // Represents delegating responsibility
 type UpdateEscrowPartiesMsg struct {
-	EscrowId  []byte                             `protobuf:"bytes,1,opt,name=escrow_id,json=escrowId,proto3" json:"escrow_id,omitempty"`
-	Sender    github_com_iov_one_weave.Address   `protobuf:"bytes,2,opt,name=sender,proto3,casttype=github.com/iov-one/weave.Address" json:"sender,omitempty"`
-	Arbiter   github_com_iov_one_weave.Condition `protobuf:"bytes,3,opt,name=arbiter,proto3,casttype=github.com/iov-one/weave.Condition" json:"arbiter,omitempty"`
-	Recipient github_com_iov_one_weave.Address   `protobuf:"bytes,4,opt,name=recipient,proto3,casttype=github.com/iov-one/weave.Address" json:"recipient,omitempty"`
+	Metadata  *weave.Metadata                    `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	EscrowId  []byte                             `protobuf:"bytes,2,opt,name=escrow_id,json=escrowId,proto3" json:"escrow_id,omitempty"`
+	Sender    github_com_iov_one_weave.Address   `protobuf:"bytes,3,opt,name=sender,proto3,casttype=github.com/iov-one/weave.Address" json:"sender,omitempty"`
+	Arbiter   github_com_iov_one_weave.Condition `protobuf:"bytes,4,opt,name=arbiter,proto3,casttype=github.com/iov-one/weave.Condition" json:"arbiter,omitempty"`
+	Recipient github_com_iov_one_weave.Address   `protobuf:"bytes,5,opt,name=recipient,proto3,casttype=github.com/iov-one/weave.Address" json:"recipient,omitempty"`
 }
 
 func (m *UpdateEscrowPartiesMsg) Reset()         { *m = UpdateEscrowPartiesMsg{} }
@@ -351,6 +385,13 @@ func (m *UpdateEscrowPartiesMsg) XXX_DiscardUnknown() {
 }
 
 var xxx_messageInfo_UpdateEscrowPartiesMsg proto.InternalMessageInfo
+
+func (m *UpdateEscrowPartiesMsg) GetMetadata() *weave.Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
 
 func (m *UpdateEscrowPartiesMsg) GetEscrowId() []byte {
 	if m != nil {
@@ -391,34 +432,36 @@ func init() {
 func init() { proto.RegisterFile("x/escrow/codec.proto", fileDescriptor_36017ee554579951) }
 
 var fileDescriptor_36017ee554579951 = []byte{
-	// 421 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x94, 0xcf, 0x8a, 0xd4, 0x40,
-	0x10, 0xc6, 0xa7, 0x93, 0x31, 0xeb, 0xb4, 0xc2, 0x4a, 0x23, 0x12, 0x56, 0xc8, 0xc4, 0xa0, 0x32,
-	0x1e, 0x36, 0x01, 0x05, 0x4f, 0x82, 0x9a, 0xc1, 0x83, 0x07, 0x41, 0x5a, 0xf7, 0x2c, 0x49, 0xba,
-	0x8c, 0x0d, 0xa6, 0x6b, 0xe8, 0xee, 0xec, 0xee, 0x63, 0xf8, 0x0a, 0xbe, 0xcd, 0x1e, 0xf7, 0xe8,
-	0x69, 0x90, 0x99, 0xa7, 0x70, 0x4e, 0xb2, 0x9d, 0x5d, 0x37, 0x97, 0xa0, 0xe3, 0x1f, 0xf0, 0xd6,
-	0xdd, 0x95, 0x5f, 0xd5, 0xc7, 0x57, 0x55, 0xa1, 0x37, 0x8f, 0x33, 0x30, 0x95, 0xc6, 0xa3, 0xac,
-	0x42, 0x01, 0x55, 0xba, 0xd0, 0x68, 0x91, 0x05, 0xdd, 0xdb, 0xde, 0x7e, 0x2d, 0xed, 0x87, 0xb6,
-	0x4c, 0x2b, 0x6c, 0xb2, 0x1a, 0x6b, 0xcc, 0x5c, 0xb8, 0x6c, 0xdf, 0xbb, 0x9b, 0xbb, 0xb8, 0x53,
-	0x87, 0xed, 0x3d, 0xe8, 0x7d, 0x2e, 0xf1, 0x70, 0x1f, 0x15, 0x64, 0x47, 0x50, 0x1c, 0x42, 0x56,
-	0xa1, 0x54, 0xfd, 0x0a, 0xc9, 0x67, 0x8f, 0x06, 0x2f, 0x5c, 0x11, 0xf6, 0x84, 0x06, 0x06, 0x94,
-	0x00, 0x1d, 0x92, 0x98, 0xcc, 0xae, 0xe7, 0x77, 0x37, 0xcb, 0x69, 0x3c, 0x94, 0x29, 0x7d, 0x2e,
-	0x84, 0x06, 0x63, 0xf8, 0x39, 0xc3, 0x9e, 0xd1, 0x9d, 0x42, 0x97, 0xd2, 0x82, 0x0e, 0x3d, 0x87,
-	0xdf, 0xdf, 0x2c, 0xa7, 0xc9, 0x20, 0x3e, 0x47, 0x25, 0xa4, 0x95, 0xa8, 0xf8, 0x05, 0xc6, 0x72,
-	0x3a, 0xd1, 0x50, 0xc9, 0x85, 0x04, 0x65, 0x43, 0x7f, 0x0b, 0x09, 0x97, 0x18, 0x7b, 0x4a, 0x77,
-	0xac, 0x6c, 0x00, 0x5b, 0x1b, 0x5e, 0x89, 0xc9, 0xcc, 0xcf, 0xef, 0x6d, 0x96, 0xd3, 0x3b, 0x83,
-	0x19, 0x0e, 0x94, 0x3c, 0x7e, 0x2b, 0x1b, 0xe0, 0x17, 0x14, 0x63, 0x74, 0xdc, 0x40, 0x83, 0x61,
-	0x10, 0x93, 0xd9, 0x84, 0xbb, 0x73, 0x72, 0xe2, 0xd1, 0xdd, 0xb9, 0x86, 0xc2, 0x42, 0xe7, 0xd4,
-	0x2b, 0x53, 0xb3, 0xc7, 0xd4, 0x37, 0xba, 0xda, 0xca, 0xa9, 0x33, 0xe0, 0x3f, 0xb1, 0x29, 0xa1,
-	0x41, 0xd1, 0x60, 0xab, 0x6c, 0x38, 0x8e, 0xfd, 0xd9, 0xb5, 0x87, 0x34, 0x3d, 0x1b, 0x8c, 0x74,
-	0x8e, 0x52, 0xf1, 0xf3, 0xc8, 0xbf, 0xb1, 0xf2, 0x0d, 0xbd, 0xc1, 0xe1, 0x23, 0x14, 0xa6, 0x67,
-	0xe5, 0x6d, 0x3a, 0xe9, 0xc6, 0xfc, 0x9d, 0x14, 0x9d, 0xa1, 0xfc, 0x6a, 0xf7, 0xf0, 0x52, 0xf4,
-	0x94, 0x7a, 0x43, 0x4a, 0x93, 0x94, 0xee, 0x72, 0xb0, 0xad, 0x56, 0xbf, 0x96, 0x33, 0xf9, 0x46,
-	0xe8, 0xad, 0x83, 0x85, 0xf8, 0xd1, 0xcf, 0xd7, 0x85, 0xb6, 0x12, 0xcc, 0x4f, 0xb5, 0x5c, 0x2e,
-	0x88, 0xf7, 0x67, 0x0b, 0xe2, 0xff, 0x85, 0xce, 0x8f, 0x7f, 0xab, 0xf3, 0x79, 0x78, 0xb2, 0x8a,
-	0xc8, 0xe9, 0x2a, 0x22, 0x5f, 0x57, 0x11, 0xf9, 0xb4, 0x8e, 0x46, 0xa7, 0xeb, 0x68, 0xf4, 0x65,
-	0x1d, 0x8d, 0xca, 0xc0, 0xfd, 0x10, 0x1e, 0x7d, 0x0f, 0x00, 0x00, 0xff, 0xff, 0x5e, 0xbd, 0x0a,
-	0x93, 0x8a, 0x04, 0x00, 0x00,
+	// 463 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x94, 0x41, 0x6b, 0xd4, 0x40,
+	0x14, 0xc7, 0x77, 0x36, 0xdb, 0x6c, 0xf7, 0x55, 0x58, 0x09, 0x22, 0xa1, 0x42, 0x36, 0x86, 0x2a,
+	0x11, 0x69, 0x02, 0x15, 0x3c, 0x09, 0xea, 0x2e, 0x1e, 0x3c, 0x14, 0x64, 0xb0, 0x27, 0x0f, 0x32,
+	0x9b, 0x79, 0xae, 0x03, 0x66, 0x66, 0x99, 0x4c, 0xda, 0x1e, 0xfd, 0x08, 0x7e, 0x0a, 0x3f, 0x8b,
+	0x27, 0xe9, 0xd1, 0xd3, 0x22, 0xbb, 0x9f, 0xc1, 0xcb, 0x9e, 0x64, 0x27, 0xdb, 0x36, 0x1e, 0x22,
+	0x6c, 0x5b, 0xc1, 0xdb, 0xcc, 0xcb, 0xff, 0x9f, 0xbc, 0xf7, 0xe3, 0xff, 0x02, 0x77, 0x4e, 0x53,
+	0x2c, 0x32, 0xad, 0x4e, 0xd2, 0x4c, 0x71, 0xcc, 0x92, 0xa9, 0x56, 0x46, 0x79, 0x6e, 0x55, 0xdb,
+	0xdd, 0x9b, 0x08, 0xf3, 0xb1, 0x1c, 0x27, 0x99, 0xca, 0x53, 0xa1, 0x8e, 0xf7, 0x95, 0xc4, 0xf4,
+	0x04, 0xd9, 0x31, 0xd6, 0xd5, 0xbb, 0x8f, 0xfe, 0xa2, 0x12, 0xf2, 0x0f, 0xe9, 0x7e, 0x4d, 0x3a,
+	0x51, 0x13, 0x95, 0xda, 0xf2, 0xb8, 0xfc, 0x60, 0x6f, 0xf6, 0x62, 0x4f, 0x95, 0x3c, 0xfa, 0xde,
+	0x06, 0xf7, 0x95, 0x6d, 0xc5, 0x7b, 0x0c, 0xdb, 0x39, 0x1a, 0xc6, 0x99, 0x61, 0x3e, 0x09, 0x49,
+	0xbc, 0x73, 0xd0, 0x4f, 0xec, 0x47, 0x92, 0xc3, 0x75, 0x99, 0x5e, 0x08, 0xbc, 0x67, 0xe0, 0x16,
+	0x28, 0x39, 0x6a, 0xbf, 0x1d, 0x92, 0xf8, 0xd6, 0x70, 0x6f, 0x39, 0x1b, 0x84, 0x4d, 0x5d, 0x26,
+	0x2f, 0x39, 0xd7, 0x58, 0x14, 0x74, 0xed, 0xf1, 0x5e, 0x40, 0x97, 0xe9, 0xb1, 0x30, 0xa8, 0x7d,
+	0xc7, 0xda, 0x1f, 0x2e, 0x67, 0x83, 0xa8, 0xd1, 0x3e, 0x52, 0x92, 0x0b, 0x23, 0x94, 0xa4, 0xe7,
+	0x36, 0x6f, 0x08, 0x3d, 0x8d, 0x99, 0x98, 0x0a, 0x94, 0xc6, 0xef, 0x6c, 0xd0, 0xc2, 0xa5, 0xcd,
+	0x7b, 0x0e, 0x5d, 0x23, 0x72, 0x54, 0xa5, 0xf1, 0xb7, 0x42, 0x12, 0x3b, 0xc3, 0x07, 0xcb, 0xd9,
+	0xe0, 0x7e, 0xe3, 0x1b, 0x8e, 0xa4, 0x38, 0x7d, 0x2b, 0x72, 0xa4, 0xe7, 0x2e, 0xcf, 0x83, 0x4e,
+	0x8e, 0xb9, 0xf2, 0xdd, 0x90, 0xc4, 0x3d, 0x6a, 0xcf, 0xd1, 0xaf, 0x36, 0xf4, 0x47, 0x1a, 0x99,
+	0xc1, 0x0a, 0xeb, 0x61, 0x31, 0xd9, 0x8c, 0xec, 0x53, 0x70, 0x0a, 0x9d, 0x6d, 0x84, 0x75, 0x65,
+	0xf8, 0x4f, 0x98, 0x46, 0xe0, 0xb2, 0x5c, 0x95, 0x72, 0x85, 0xd4, 0x89, 0x77, 0x0e, 0x20, 0x59,
+	0x25, 0x34, 0x19, 0x29, 0x21, 0xe9, 0xfa, 0x49, 0x9d, 0xbb, 0x7b, 0x2d, 0xee, 0xdd, 0x1a, 0xf7,
+	0xcf, 0x04, 0x6e, 0x53, 0xfc, 0x84, 0xac, 0xb8, 0x2a, 0xf8, 0x7b, 0xd0, 0xab, 0x96, 0xf2, 0xbd,
+	0xe0, 0x15, 0x7e, 0xba, 0x5d, 0x15, 0x5e, 0xf3, 0xda, 0x5c, 0x4e, 0xd3, 0x5c, 0xd1, 0x3b, 0xe8,
+	0x53, 0x34, 0xa5, 0x96, 0xff, 0xa0, 0x81, 0xe8, 0x6b, 0x1b, 0xee, 0x1e, 0x4d, 0xf9, 0x45, 0xae,
+	0xde, 0x30, 0x6d, 0x04, 0x16, 0x37, 0x3b, 0xe5, 0xe5, 0x56, 0x3b, 0xd7, 0xdb, 0xea, 0xce, 0x0d,
+	0x24, 0x70, 0xeb, 0x4a, 0x09, 0x1c, 0xfa, 0xdf, 0xe6, 0x01, 0x39, 0x9b, 0x07, 0xe4, 0xe7, 0x3c,
+	0x20, 0x5f, 0x16, 0x41, 0xeb, 0x6c, 0x11, 0xb4, 0x7e, 0x2c, 0x82, 0xd6, 0xd8, 0xb5, 0xbf, 0xbc,
+	0x27, 0xbf, 0x03, 0x00, 0x00, 0xff, 0xff, 0x5d, 0x82, 0xf0, 0xf9, 0x92, 0x05, 0x00, 0x00,
 }
 
 func (m *Escrow) Marshal() (dAtA []byte, err error) {
@@ -436,20 +479,30 @@ func (m *Escrow) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.Sender) > 0 {
+	if m.Metadata != nil {
 		dAtA[i] = 0xa
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(m.Metadata.Size()))
+		n1, err := m.Metadata.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n1
+	}
+	if len(m.Sender) > 0 {
+		dAtA[i] = 0x12
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Sender)))
 		i += copy(dAtA[i:], m.Sender)
 	}
 	if len(m.Arbiter) > 0 {
-		dAtA[i] = 0x12
+		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Arbiter)))
 		i += copy(dAtA[i:], m.Arbiter)
 	}
 	if len(m.Recipient) > 0 {
-		dAtA[i] = 0x1a
+		dAtA[i] = 0x22
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Recipient)))
 		i += copy(dAtA[i:], m.Recipient)
@@ -483,27 +536,37 @@ func (m *CreateEscrowMsg) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.Src) > 0 {
+	if m.Metadata != nil {
 		dAtA[i] = 0xa
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(m.Metadata.Size()))
+		n2, err := m.Metadata.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n2
+	}
+	if len(m.Src) > 0 {
+		dAtA[i] = 0x12
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Src)))
 		i += copy(dAtA[i:], m.Src)
 	}
 	if len(m.Arbiter) > 0 {
-		dAtA[i] = 0x12
+		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Arbiter)))
 		i += copy(dAtA[i:], m.Arbiter)
 	}
 	if len(m.Recipient) > 0 {
-		dAtA[i] = 0x1a
+		dAtA[i] = 0x22
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Recipient)))
 		i += copy(dAtA[i:], m.Recipient)
 	}
 	if len(m.Amount) > 0 {
 		for _, msg := range m.Amount {
-			dAtA[i] = 0x22
+			dAtA[i] = 0x2a
 			i++
 			i = encodeVarintCodec(dAtA, i, uint64(msg.Size()))
 			n, err := msg.MarshalTo(dAtA[i:])
@@ -514,12 +577,12 @@ func (m *CreateEscrowMsg) MarshalTo(dAtA []byte) (int, error) {
 		}
 	}
 	if m.Timeout != 0 {
-		dAtA[i] = 0x28
+		dAtA[i] = 0x30
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(m.Timeout))
 	}
 	if len(m.Memo) > 0 {
-		dAtA[i] = 0x32
+		dAtA[i] = 0x3a
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Memo)))
 		i += copy(dAtA[i:], m.Memo)
@@ -542,15 +605,25 @@ func (m *ReleaseEscrowMsg) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.EscrowId) > 0 {
+	if m.Metadata != nil {
 		dAtA[i] = 0xa
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(m.Metadata.Size()))
+		n3, err := m.Metadata.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n3
+	}
+	if len(m.EscrowId) > 0 {
+		dAtA[i] = 0x12
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.EscrowId)))
 		i += copy(dAtA[i:], m.EscrowId)
 	}
 	if len(m.Amount) > 0 {
 		for _, msg := range m.Amount {
-			dAtA[i] = 0x12
+			dAtA[i] = 0x1a
 			i++
 			i = encodeVarintCodec(dAtA, i, uint64(msg.Size()))
 			n, err := msg.MarshalTo(dAtA[i:])
@@ -578,8 +651,18 @@ func (m *ReturnEscrowMsg) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.EscrowId) > 0 {
+	if m.Metadata != nil {
 		dAtA[i] = 0xa
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(m.Metadata.Size()))
+		n4, err := m.Metadata.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n4
+	}
+	if len(m.EscrowId) > 0 {
+		dAtA[i] = 0x12
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.EscrowId)))
 		i += copy(dAtA[i:], m.EscrowId)
@@ -602,26 +685,36 @@ func (m *UpdateEscrowPartiesMsg) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.EscrowId) > 0 {
+	if m.Metadata != nil {
 		dAtA[i] = 0xa
+		i++
+		i = encodeVarintCodec(dAtA, i, uint64(m.Metadata.Size()))
+		n5, err := m.Metadata.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n5
+	}
+	if len(m.EscrowId) > 0 {
+		dAtA[i] = 0x12
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.EscrowId)))
 		i += copy(dAtA[i:], m.EscrowId)
 	}
 	if len(m.Sender) > 0 {
-		dAtA[i] = 0x12
+		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Sender)))
 		i += copy(dAtA[i:], m.Sender)
 	}
 	if len(m.Arbiter) > 0 {
-		dAtA[i] = 0x1a
+		dAtA[i] = 0x22
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Arbiter)))
 		i += copy(dAtA[i:], m.Arbiter)
 	}
 	if len(m.Recipient) > 0 {
-		dAtA[i] = 0x22
+		dAtA[i] = 0x2a
 		i++
 		i = encodeVarintCodec(dAtA, i, uint64(len(m.Recipient)))
 		i += copy(dAtA[i:], m.Recipient)
@@ -644,6 +737,10 @@ func (m *Escrow) Size() (n int) {
 	}
 	var l int
 	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.Size()
+		n += 1 + l + sovCodec(uint64(l))
+	}
 	l = len(m.Sender)
 	if l > 0 {
 		n += 1 + l + sovCodec(uint64(l))
@@ -672,6 +769,10 @@ func (m *CreateEscrowMsg) Size() (n int) {
 	}
 	var l int
 	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.Size()
+		n += 1 + l + sovCodec(uint64(l))
+	}
 	l = len(m.Src)
 	if l > 0 {
 		n += 1 + l + sovCodec(uint64(l))
@@ -706,6 +807,10 @@ func (m *ReleaseEscrowMsg) Size() (n int) {
 	}
 	var l int
 	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.Size()
+		n += 1 + l + sovCodec(uint64(l))
+	}
 	l = len(m.EscrowId)
 	if l > 0 {
 		n += 1 + l + sovCodec(uint64(l))
@@ -725,6 +830,10 @@ func (m *ReturnEscrowMsg) Size() (n int) {
 	}
 	var l int
 	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.Size()
+		n += 1 + l + sovCodec(uint64(l))
+	}
 	l = len(m.EscrowId)
 	if l > 0 {
 		n += 1 + l + sovCodec(uint64(l))
@@ -738,6 +847,10 @@ func (m *UpdateEscrowPartiesMsg) Size() (n int) {
 	}
 	var l int
 	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.Size()
+		n += 1 + l + sovCodec(uint64(l))
+	}
 	l = len(m.EscrowId)
 	if l > 0 {
 		n += 1 + l + sovCodec(uint64(l))
@@ -801,6 +914,42 @@ func (m *Escrow) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCodec
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &weave.Metadata{}
+			}
+			if err := m.Metadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Sender", wireType)
 			}
 			var byteLen int
@@ -833,7 +982,7 @@ func (m *Escrow) Unmarshal(dAtA []byte) error {
 				m.Sender = []byte{}
 			}
 			iNdEx = postIndex
-		case 2:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Arbiter", wireType)
 			}
@@ -867,7 +1016,7 @@ func (m *Escrow) Unmarshal(dAtA []byte) error {
 				m.Arbiter = []byte{}
 			}
 			iNdEx = postIndex
-		case 3:
+		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Recipient", wireType)
 			}
@@ -1007,6 +1156,42 @@ func (m *CreateEscrowMsg) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCodec
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &weave.Metadata{}
+			}
+			if err := m.Metadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Src", wireType)
 			}
 			var byteLen int
@@ -1039,7 +1224,7 @@ func (m *CreateEscrowMsg) Unmarshal(dAtA []byte) error {
 				m.Src = []byte{}
 			}
 			iNdEx = postIndex
-		case 2:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Arbiter", wireType)
 			}
@@ -1073,7 +1258,7 @@ func (m *CreateEscrowMsg) Unmarshal(dAtA []byte) error {
 				m.Arbiter = []byte{}
 			}
 			iNdEx = postIndex
-		case 3:
+		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Recipient", wireType)
 			}
@@ -1107,7 +1292,7 @@ func (m *CreateEscrowMsg) Unmarshal(dAtA []byte) error {
 				m.Recipient = []byte{}
 			}
 			iNdEx = postIndex
-		case 4:
+		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
 			}
@@ -1141,7 +1326,7 @@ func (m *CreateEscrowMsg) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 5:
+		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Timeout", wireType)
 			}
@@ -1160,7 +1345,7 @@ func (m *CreateEscrowMsg) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 6:
+		case 7:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Memo", wireType)
 			}
@@ -1247,6 +1432,42 @@ func (m *ReleaseEscrowMsg) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCodec
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &weave.Metadata{}
+			}
+			if err := m.Metadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field EscrowId", wireType)
 			}
 			var byteLen int
@@ -1279,7 +1500,7 @@ func (m *ReleaseEscrowMsg) Unmarshal(dAtA []byte) error {
 				m.EscrowId = []byte{}
 			}
 			iNdEx = postIndex
-		case 2:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
 			}
@@ -1368,6 +1589,42 @@ func (m *ReturnEscrowMsg) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCodec
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &weave.Metadata{}
+			}
+			if err := m.Metadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field EscrowId", wireType)
 			}
 			var byteLen int
@@ -1455,6 +1712,42 @@ func (m *UpdateEscrowPartiesMsg) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCodec
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCodec
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCodec
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &weave.Metadata{}
+			}
+			if err := m.Metadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field EscrowId", wireType)
 			}
 			var byteLen int
@@ -1487,7 +1780,7 @@ func (m *UpdateEscrowPartiesMsg) Unmarshal(dAtA []byte) error {
 				m.EscrowId = []byte{}
 			}
 			iNdEx = postIndex
-		case 2:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Sender", wireType)
 			}
@@ -1521,7 +1814,7 @@ func (m *UpdateEscrowPartiesMsg) Unmarshal(dAtA []byte) error {
 				m.Sender = []byte{}
 			}
 			iNdEx = postIndex
-		case 3:
+		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Arbiter", wireType)
 			}
@@ -1555,7 +1848,7 @@ func (m *UpdateEscrowPartiesMsg) Unmarshal(dAtA []byte) error {
 				m.Arbiter = []byte{}
 			}
 			iNdEx = postIndex
-		case 4:
+		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Recipient", wireType)
 			}

--- a/x/escrow/codec.proto
+++ b/x/escrow/codec.proto
@@ -2,8 +2,10 @@ syntax = "proto3";
 
 package escrow;
 
-import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "github.com/iov-one/weave/codec.proto";
 import "github.com/iov-one/weave/coin/codec.proto";
+
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 // Escrow holds some coins.
 // The arbiter or sender can release them to the recipient.
@@ -13,9 +15,11 @@ import "github.com/iov-one/weave/coin/codec.proto";
 // Note that if the arbiter is a Hashlock permission, we have
 // an HTLC ;)
 message Escrow {
-  bytes sender = 1 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
-  bytes arbiter = 2 [(gogoproto.casttype) = "github.com/iov-one/weave.Condition"];
-  bytes recipient = 3 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
+  weave.Metadata metadata = 1;
+
+  bytes sender = 2 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
+  bytes arbiter = 3 [(gogoproto.casttype) = "github.com/iov-one/weave.Condition"];
+  bytes recipient = 4 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
 
   // If unreleased before timeout, escrow will return to sender.
   // Timeout represents wall clock time as read from the block header. Timeout
@@ -34,15 +38,17 @@ message Escrow {
 // If sender is not defined, it defaults to the first signer
 // The rest must be defined
 message CreateEscrowMsg {
-  bytes src = 1 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
-  bytes arbiter = 2 [(gogoproto.casttype) = "github.com/iov-one/weave.Condition"];
-  bytes recipient = 3 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
+  weave.Metadata metadata = 1;
+
+  bytes src = 2 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
+  bytes arbiter = 3 [(gogoproto.casttype) = "github.com/iov-one/weave.Condition"];
+  bytes recipient = 4 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
   // amount may contain multiple token types
-  repeated coin.Coin amount = 4;
+  repeated coin.Coin amount = 5;
   // Timeout represents wall clock time.
-  int64 timeout = 5 [(gogoproto.casttype) = "github.com/iov-one/weave.UnixTime"];
+  int64 timeout = 6 [(gogoproto.casttype) = "github.com/iov-one/weave.UnixTime"];
   // max length 128 character
-  string memo = 6;
+  string memo = 7;
 }
 
 // ReleaseEscrowMsg releases the content to the recipient.
@@ -50,14 +56,18 @@ message CreateEscrowMsg {
 // If amount not provided, defaults to entire escrow,
 // May be a subset of the current balance.
 message ReleaseEscrowMsg {
-  bytes escrow_id = 1;
-  repeated coin.Coin amount = 2;
+  weave.Metadata metadata = 1;
+
+  bytes escrow_id = 2;
+  repeated coin.Coin amount = 3;
 }
 
 // ReturnEscrowMsg returns the content to the sender.
 // Must be authorized by the sender or an expired timeout
 message ReturnEscrowMsg {
-  bytes escrow_id = 1;
+  weave.Metadata metadata = 1;
+
+  bytes escrow_id = 2;
 }
 
 // UpdateEscrowPartiesMsg changes any of the parties of the escrow:
@@ -66,8 +76,10 @@ message ReturnEscrowMsg {
 //
 // Represents delegating responsibility
 message UpdateEscrowPartiesMsg {
-  bytes escrow_id = 1;
-  bytes sender = 2 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
-  bytes arbiter = 3 [(gogoproto.casttype) = "github.com/iov-one/weave.Condition"];
-  bytes recipient = 4 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
+  weave.Metadata metadata = 1;
+
+  bytes escrow_id = 2;
+  bytes sender = 3 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
+  bytes arbiter = 4 [(gogoproto.casttype) = "github.com/iov-one/weave.Condition"];
+  bytes recipient = 5 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
 }

--- a/x/escrow/init.go
+++ b/x/escrow/init.go
@@ -31,6 +31,7 @@ func (i *Initializer) FromGenesis(opts weave.Options, db weave.KVStore) error {
 	bucket := NewBucket()
 	for j, e := range escrows {
 		escr := Escrow{
+			Metadata:  &weave.Metadata{Schema: 1},
 			Sender:    e.Sender,
 			Arbiter:   e.Arbiter,
 			Recipient: e.Recipient,

--- a/x/escrow/init_test.go
+++ b/x/escrow/init_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/migration"
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/weavetest"
 	"github.com/iov-one/weave/x/cash"
@@ -40,6 +41,7 @@ func TestGenesisKey(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(genesis), &opts))
 
 	db := store.MemStore()
+	migration.MustInitPkg(db, "escrow", "cash")
 
 	// when
 	cashCtrl := cash.NewController(cash.NewBucket())

--- a/x/escrow/msg.go
+++ b/x/escrow/msg.go
@@ -4,7 +4,15 @@ import (
 	"github.com/iov-one/weave"
 	coin "github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/migration"
 )
+
+func init() {
+	migration.MustRegister(1, &CreateEscrowMsg{}, migration.NoModification)
+	migration.MustRegister(1, &ReleaseEscrowMsg{}, migration.NoModification)
+	migration.MustRegister(1, &ReturnEscrowMsg{}, migration.NoModification)
+	migration.MustRegister(1, &UpdateEscrowPartiesMsg{}, migration.NoModification)
+}
 
 const (
 	pathCreateEscrowMsg        = "escrow/create"
@@ -54,6 +62,7 @@ func NewCreateMsg(
 	memo string,
 ) *CreateEscrowMsg {
 	return &CreateEscrowMsg{
+		Metadata:  &weave.Metadata{Schema: 1},
 		Src:       sender,
 		Recipient: recipient,
 		Arbiter:   arbiter,
@@ -65,6 +74,9 @@ func NewCreateMsg(
 
 // Validate makes sure that this is sensible
 func (m *CreateEscrowMsg) Validate() error {
+	if err := m.Metadata.Validate(); err != nil {
+		return errors.Wrap(err, "metadata")
+	}
 	if err := m.Arbiter.Validate(); err != nil {
 		return errors.Wrap(err, "arbiter")
 	}
@@ -91,6 +103,9 @@ func (m *CreateEscrowMsg) Validate() error {
 
 // Validate makes sure that this is sensible
 func (m *ReleaseEscrowMsg) Validate() error {
+	if err := m.Metadata.Validate(); err != nil {
+		return errors.Wrap(err, "metadata")
+	}
 	err := validateEscrowID(m.EscrowId)
 	if err != nil {
 		return err
@@ -103,12 +118,18 @@ func (m *ReleaseEscrowMsg) Validate() error {
 
 // Validate always returns true for no data
 func (m *ReturnEscrowMsg) Validate() error {
+	if err := m.Metadata.Validate(); err != nil {
+		return errors.Wrap(err, "metadata")
+	}
 	return validateEscrowID(m.EscrowId)
 }
 
 // Validate makes sure any included items are valid permissions
 // and there is at least one change
 func (m *UpdateEscrowPartiesMsg) Validate() error {
+	if err := m.Metadata.Validate(); err != nil {
+		return errors.Wrap(err, "metadata")
+	}
 	err := validateEscrowID(m.EscrowId)
 	if err != nil {
 		return err

--- a/x/escrow/msg_test.go
+++ b/x/escrow/msg_test.go
@@ -48,10 +48,16 @@ func TestCreateEscrowMsg(t *testing.T) {
 		check checkErr
 	}{
 		// nothing
-		0: {new(CreateEscrowMsg), errors.ErrEmpty.Is},
+		0: {
+			&CreateEscrowMsg{
+				Metadata: &weave.Metadata{Schema: 1},
+			},
+			errors.ErrEmpty.Is,
+		},
 		// proper
 		1: {
 			&CreateEscrowMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
 				Src:       a.Address(),
 				Arbiter:   b,
 				Recipient: c.Address(),
@@ -63,6 +69,7 @@ func TestCreateEscrowMsg(t *testing.T) {
 		// missing sender okay, dups okay
 		2: {
 			&CreateEscrowMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
 				Arbiter:   c,
 				Recipient: c.Address(),
 				Amount:    plus,
@@ -74,6 +81,7 @@ func TestCreateEscrowMsg(t *testing.T) {
 		// invalid permissions
 		3: {
 			&CreateEscrowMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
 				Arbiter:   d,
 				Recipient: c.Address(),
 				Amount:    plus,
@@ -84,6 +92,7 @@ func TestCreateEscrowMsg(t *testing.T) {
 		// negative amount
 		4: {
 			&CreateEscrowMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
 				Arbiter:   b,
 				Recipient: c.Address(),
 				Amount:    minus,
@@ -94,6 +103,7 @@ func TestCreateEscrowMsg(t *testing.T) {
 		// improperly formatted amount
 		5: {
 			&CreateEscrowMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
 				Arbiter:   b,
 				Recipient: c.Address(),
 				Amount:    mixed,
@@ -104,6 +114,7 @@ func TestCreateEscrowMsg(t *testing.T) {
 		// missing amount
 		6: {
 			&CreateEscrowMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
 				Arbiter:   b,
 				Recipient: c.Address(),
 				Timeout:   timeout,
@@ -113,6 +124,7 @@ func TestCreateEscrowMsg(t *testing.T) {
 		// invalid memo
 		7: {
 			&CreateEscrowMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
 				Arbiter:   b,
 				Recipient: c.Address(),
 				Amount:    plus,
@@ -124,6 +136,7 @@ func TestCreateEscrowMsg(t *testing.T) {
 		// zero timeout
 		8: {
 			&CreateEscrowMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
 				Arbiter:   b,
 				Recipient: c.Address(),
 				Amount:    plus,
@@ -160,10 +173,16 @@ func TestReleaseEscrowMsg(t *testing.T) {
 		check checkErr
 	}{
 		// nothing
-		0: {new(ReleaseEscrowMsg), errors.ErrInvalidInput.Is},
+		0: {
+			&ReleaseEscrowMsg{
+				Metadata: &weave.Metadata{Schema: 1},
+			},
+			errors.ErrInvalidInput.Is,
+		},
 		// proper: valid amount
 		1: {
 			&ReleaseEscrowMsg{
+				Metadata: &weave.Metadata{Schema: 1},
 				EscrowId: escrow,
 				Amount:   plus,
 			},
@@ -172,6 +191,7 @@ func TestReleaseEscrowMsg(t *testing.T) {
 		// missing amount okay
 		2: {
 			&ReleaseEscrowMsg{
+				Metadata: &weave.Metadata{Schema: 1},
 				EscrowId: escrow,
 			},
 			noErr,
@@ -179,6 +199,7 @@ func TestReleaseEscrowMsg(t *testing.T) {
 		// invalid id
 		3: {
 			&ReleaseEscrowMsg{
+				Metadata: &weave.Metadata{Schema: 1},
 				EscrowId: scarecrow,
 			},
 			errors.ErrInvalidInput.Is,
@@ -186,13 +207,15 @@ func TestReleaseEscrowMsg(t *testing.T) {
 		// missing id
 		4: {
 			&ReleaseEscrowMsg{
-				Amount: plus,
+				Metadata: &weave.Metadata{Schema: 1},
+				Amount:   plus,
 			},
 			errors.ErrInvalidInput.Is,
 		},
 		// negative amount
 		5: {
 			&ReleaseEscrowMsg{
+				Metadata: &weave.Metadata{Schema: 1},
 				EscrowId: escrow,
 				Amount:   minus,
 			},
@@ -201,6 +224,7 @@ func TestReleaseEscrowMsg(t *testing.T) {
 		// improperly formatted amount
 		6: {
 			&ReleaseEscrowMsg{
+				Metadata: &weave.Metadata{Schema: 1},
 				EscrowId: escrow,
 				Amount:   mixed,
 			},
@@ -228,10 +252,16 @@ func TestReturnEscrowMsg(t *testing.T) {
 		check checkErr
 	}{
 		// missing id
-		0: {new(ReturnEscrowMsg), errors.ErrInvalidInput.Is},
+		0: {
+			&ReturnEscrowMsg{
+				Metadata: &weave.Metadata{Schema: 1},
+			},
+			errors.ErrInvalidInput.Is,
+		},
 		// proper: valid id
 		1: {
 			&ReturnEscrowMsg{
+				Metadata: &weave.Metadata{Schema: 1},
 				EscrowId: escrow,
 			},
 			noErr,
@@ -239,6 +269,7 @@ func TestReturnEscrowMsg(t *testing.T) {
 		// invalid id
 		2: {
 			&ReturnEscrowMsg{
+				Metadata: &weave.Metadata{Schema: 1},
 				EscrowId: scarecrow,
 			},
 			errors.ErrInvalidInput.Is,
@@ -272,10 +303,16 @@ func TestUpdateEscrowMsg(t *testing.T) {
 		check checkErr
 	}{
 		// nothing
-		0: {new(UpdateEscrowPartiesMsg), errors.ErrInvalidInput.Is},
+		0: {
+			&UpdateEscrowPartiesMsg{
+				Metadata: &weave.Metadata{Schema: 1},
+			},
+			errors.ErrInvalidInput.Is,
+		},
 		// proper: valid id, one valid permission
 		1: {
 			&UpdateEscrowPartiesMsg{
+				Metadata: &weave.Metadata{Schema: 1},
 				EscrowId: escrow,
 				Sender:   a.Address(),
 			},
@@ -284,6 +321,7 @@ func TestUpdateEscrowMsg(t *testing.T) {
 		// valid escrow, no permissions
 		2: {
 			&UpdateEscrowPartiesMsg{
+				Metadata: &weave.Metadata{Schema: 1},
 				EscrowId: escrow,
 			},
 			errors.ErrEmpty.Is,
@@ -291,6 +329,7 @@ func TestUpdateEscrowMsg(t *testing.T) {
 		// invalid escrow, proper permissions
 		3: {
 			&UpdateEscrowPartiesMsg{
+				Metadata: &weave.Metadata{Schema: 1},
 				EscrowId: scarecrow,
 				Sender:   a.Address(),
 			},
@@ -299,6 +338,7 @@ func TestUpdateEscrowMsg(t *testing.T) {
 		// allow multiple permissions
 		4: {
 			&UpdateEscrowPartiesMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
 				EscrowId:  escrow,
 				Recipient: b.Address(),
 				Arbiter:   c,
@@ -308,6 +348,7 @@ func TestUpdateEscrowMsg(t *testing.T) {
 		// check for valid permissions
 		5: {
 			&UpdateEscrowPartiesMsg{
+				Metadata: &weave.Metadata{Schema: 1},
 				EscrowId: escrow,
 				Arbiter:  d,
 			},

--- a/x/paychan/handler_test.go
+++ b/x/paychan/handler_test.go
@@ -496,7 +496,7 @@ func TestPaymentChannelHandlers(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			db := store.MemStore()
 
-			migration.MustInitPkg(db, "paychan")
+			migration.MustInitPkg(db, "paychan", "cash")
 
 			// Create a sender account with coins.
 			wallet, err := cash.WalletWith(src.Address(), dogeCoin(11, 22))


### PR DESCRIPTION
x/cash, x/escrow x/distribution: use schema versioning 

This is a big change that breaks the extensions. Add integration with
the migration package to allow schema versioning for models and
messages.

This is clubbed all together because all those packages tightly require
x/cash to provide their functionality.

Small adjustments to the migration package to make error messages
better.

part of #564