### PR TITLE
migration: introduce a handler router based on message schema version

### DIFF
--- a/migration/handler.go
+++ b/migration/handler.go
@@ -179,20 +179,10 @@ func (h SchemaRoutingHandler) selectHandler(tx weave.Tx) (weave.Handler, error) 
 	}
 	meta := m.GetMetadata()
 
-	var handler weave.Handler
-	for ver := uint32(1); ver < uint32(len(h)); ver++ {
-		// It is allowed to leave gaps between handler version mappings
-		// so it. If this is the case, the previously available version
-		// must be used.
-		if next := h[ver]; next != nil {
-			handler = next
-		}
-		if ver >= meta.Schema {
-			break
+	for ver := meta.Schema; ver > 0; ver-- {
+		if h[ver] != nil {
+			return h[ver], nil
 		}
 	}
-	if handler == nil {
-		return nil, errors.Wrapf(errors.ErrSchema, "no matching handler for schema version %d", meta.Schema)
-	}
-	return handler, nil
+	return nil, errors.Wrapf(errors.ErrSchema, "no matching handler for schema version %d", meta.Schema)
 }


### PR DESCRIPTION
A new handler implementation is introduced.
`SchemaRoutingHandler` is a container that clubs toghether message
handlers for a single type message but different schema formats. Each
handler is registered together with the lowest schema version that it
supports. For example:

    handler := SchemaRoutingHandler{
      1: &MyHandlerVersionAlpha{},
      7: &MyHandlerVersionBeta{},
    }

In the above setup, messages with schema version 1 to 6 will be handled
by the alpha handler. Messages with schema version 7 and above are
passed to the beta handler.

It is not allowed to use an empty SchemaRoutingHandler instance. It is
not allowed to register a handler for schema version zero.
All messages processed by this handler must implement Migratable
interface.


Please note that it does not make sense to use `SchemaRoutingHandler` together with [`SchemaMigratingHandler`](https://github.com/iov-one/weave/blob/master/migration/handler.go#L9-L15).
This is implementing an idea mentioned in https://github.com/iov-one/weave/pull/591#issuecomment-490211578