### PR TITLE
x/sigs: when incrementing a sequence, check for overflow

### DIFF
--- a/x/sigs/model.go
+++ b/x/sigs/model.go
@@ -64,7 +64,7 @@ func (u *UserData) CheckAndIncrementSequence(expected int64) error {
 	// client code.
 	const maxSequenceValue = (1 << 53) - 1
 	if next <= 0 || next > maxSequenceValue {
-		return errors.Wrapf(errors.ErrOverflow, "value exceeded: %v > %v", next, maxSequenceValue)
+		return errors.Wrap(errors.ErrOverflow, "sequence out of range")
 	}
 	u.Sequence = next
 	return nil


### PR DESCRIPTION
When incremeting a user sequence, ensure that the value does not exceed
the max value supported by the client (2^53 - 1).

resolve #511