### PR TITLE
orm: proposal of ModelBucket implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## HEAD
 
+- A new bucket implementation `orm.ModelBucket` was added that provides an
+  easier to use interface when dealing with a single entity type.
+- `migration` package was updated to provide `orm.ModelBucket` wrapper for
+  transparent schema version migrations
+
 
 ## 0.15.0
 

--- a/migration/orm.go
+++ b/migration/orm.go
@@ -151,6 +151,10 @@ func (m *ModelBucket) Delete(db weave.KVStore, key []byte) error {
 	return m.b.Delete(db, key)
 }
 
+func (m *ModelBucket) Has(db weave.KVStore, key []byte) error {
+	return m.b.Has(db, key)
+}
+
 // useRegister will update this bucket to use a custom register instance
 // instead of the global one. This is a private method meant to be used for
 // tests only.

--- a/migration/orm.go
+++ b/migration/orm.go
@@ -112,9 +112,10 @@ func (m *ModelBucket) One(db weave.ReadOnlyKVStore, key []byte, dest orm.Model) 
 	return nil
 }
 
-func (m *ModelBucket) ByIndex(db weave.ReadOnlyKVStore, indexName string, key []byte, dest orm.ModelSlicePtr) error {
-	if err := m.b.ByIndex(db, indexName, key, dest); err != nil {
-		return err
+func (m *ModelBucket) ByIndex(db weave.ReadOnlyKVStore, indexName string, key []byte, dest orm.ModelSlicePtr) ([][]byte, error) {
+	keys, err := m.b.ByIndex(db, indexName, key, dest)
+	if err != nil {
+		return nil, err
 	}
 
 	// The correct type of the dest was already validated by the
@@ -134,10 +135,10 @@ func (m *ModelBucket) ByIndex(db weave.ReadOnlyKVStore, indexName string, key []
 		}
 
 		if err := m.migrate(db, model); err != nil {
-			return errors.Wrapf(err, "migrade %d element", i)
+			return nil, errors.Wrapf(err, "migrade %d element", i)
 		}
 	}
-	return nil
+	return keys, nil
 }
 
 func (m *ModelBucket) Put(db weave.KVStore, key []byte, model orm.Model) ([]byte, error) {

--- a/migration/orm.go
+++ b/migration/orm.go
@@ -98,6 +98,10 @@ func NewModelBucket(packageName string, b orm.ModelBucket) *ModelBucket {
 	}
 }
 
+func (m *ModelBucket) Register(name string, r weave.QueryRouter) {
+	m.b.Register(name, r)
+}
+
 func (m *ModelBucket) One(db weave.ReadOnlyKVStore, key []byte, dest orm.Model) error {
 	if err := m.b.One(db, key, dest); err != nil {
 		return err

--- a/migration/orm.go
+++ b/migration/orm.go
@@ -1,6 +1,8 @@
 package migration
 
 import (
+	"reflect"
+
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/orm"
@@ -63,13 +65,113 @@ func (svb Bucket) Save(db weave.KVStore, obj orm.Object) error {
 }
 
 func (svb Bucket) migrate(db weave.ReadOnlyKVStore, obj orm.Object) error {
-	m, ok := obj.Value().(Migratable)
+	return migrate(svb.migrations, svb.schema, svb.packageName, db, obj.Value())
+}
+
+func (svb Bucket) WithIndex(name string, indexer orm.Indexer, unique bool) orm.Bucket {
+	svb.Bucket = svb.Bucket.WithIndex(name, indexer, unique)
+	return svb
+}
+
+func (svb Bucket) WithMultiKeyIndex(name string, indexer orm.MultiKeyIndexer, unique bool) orm.Bucket {
+	svb.Bucket = svb.Bucket.WithMultiKeyIndex(name, indexer, unique)
+	return svb
+}
+
+// ModelBucket implementes the orm.ModelBucket interface and provides the same
+// functionality with additional model schema migration.
+type ModelBucket struct {
+	b           orm.ModelBucket
+	packageName string
+	schema      *SchemaBucket
+	migrations  *register
+}
+
+var _ orm.ModelBucket = (*ModelBucket)(nil)
+
+func NewModelBucket(packageName string, b orm.ModelBucket) *ModelBucket {
+	return &ModelBucket{
+		b:           b,
+		packageName: packageName,
+		schema:      NewSchemaBucket(),
+		migrations:  reg,
+	}
+}
+
+func (m *ModelBucket) One(db weave.ReadOnlyKVStore, key []byte, dest orm.Model) error {
+	if err := m.b.One(db, key, dest); err != nil {
+		return err
+	}
+	if err := m.migrate(db, dest); err != nil {
+		return errors.Wrap(err, "migrate")
+	}
+	return nil
+}
+
+func (m *ModelBucket) ByIndex(db weave.ReadOnlyKVStore, indexName string, key []byte, dest orm.ModelSlicePtr) error {
+	if err := m.b.ByIndex(db, indexName, key, dest); err != nil {
+		return err
+	}
+
+	// The correct type of the dest was already validated by the
+	// ModelBucket when getting data by index. We can safely skip checks -
+	// dest is a slice of models.
+	slice := reflect.ValueOf(dest).Elem()
+	for i := 0; i < slice.Len(); i++ {
+		item := slice.Index(i)
+
+		// Slice can be both of values and pointer to values. This
+		// method must support both notations.
+		var model orm.Model
+		if m, ok := item.Interface().(orm.Model); ok {
+			model = m
+		} else {
+			model = item.Addr().Interface().(orm.Model)
+		}
+
+		if err := m.migrate(db, model); err != nil {
+			return errors.Wrapf(err, "migrade %d element", i)
+		}
+	}
+	return nil
+}
+
+func (m *ModelBucket) Put(db weave.KVStore, key []byte, model orm.Model) ([]byte, error) {
+	if err := m.migrate(db, model); err != nil {
+		return nil, errors.Wrap(err, "migrate")
+	}
+	return m.b.Put(db, key, model)
+}
+
+func (m *ModelBucket) Delete(db weave.KVStore, key []byte) error {
+	return m.b.Delete(db, key)
+}
+
+// useRegister will update this bucket to use a custom register instance
+// instead of the global one. This is a private method meant to be used for
+// tests only.
+func (m *ModelBucket) useRegister(r *register) {
+	m.migrations = r
+}
+
+func (m *ModelBucket) migrate(db weave.ReadOnlyKVStore, model orm.Model) error {
+	return migrate(m.migrations, m.schema, m.packageName, db, model)
+}
+
+func migrate(
+	migrations *register,
+	schema *SchemaBucket,
+	packageName string,
+	db weave.ReadOnlyKVStore,
+	value interface{},
+) error {
+	m, ok := value.(Migratable)
 	if !ok {
 		return errors.Wrap(errors.ErrModel, "model cannot be migrated")
 	}
-	currSchemaVer, err := svb.schema.CurrentSchema(db, svb.packageName)
+	currSchemaVer, err := schema.CurrentSchema(db, packageName)
 	if err != nil {
-		return errors.Wrapf(err, "current schema version of package %q", svb.packageName)
+		return errors.Wrapf(err, "current schema version of package %q", packageName)
 	}
 
 	meta := m.GetMetadata()
@@ -90,18 +192,8 @@ func (svb Bucket) migrate(db weave.ReadOnlyKVStore, obj orm.Object) error {
 	}
 
 	// Migration is applied in place, directly modyfying the instance.
-	if err := svb.migrations.Apply(db, m, currSchemaVer); err != nil {
+	if err := migrations.Apply(db, m, currSchemaVer); err != nil {
 		return errors.Wrap(err, "schema migration")
 	}
 	return nil
-}
-
-func (svb Bucket) WithIndex(name string, indexer orm.Indexer, unique bool) orm.Bucket {
-	svb.Bucket = svb.Bucket.WithIndex(name, indexer, unique)
-	return svb
-}
-
-func (svb Bucket) WithMultiKeyIndex(name string, indexer orm.MultiKeyIndexer, unique bool) orm.Bucket {
-	svb.Bucket = svb.Bucket.WithMultiKeyIndex(name, indexer, unique)
-	return svb
 }

--- a/migration/orm.go
+++ b/migration/orm.go
@@ -135,7 +135,7 @@ func (m *ModelBucket) ByIndex(db weave.ReadOnlyKVStore, indexName string, key []
 		}
 
 		if err := m.migrate(db, model); err != nil {
-			return nil, errors.Wrapf(err, "migrade %d element", i)
+			return nil, errors.Wrapf(err, "migrate %d element", i)
 		}
 	}
 	return keys, nil

--- a/migration/orm_test.go
+++ b/migration/orm_test.go
@@ -163,10 +163,8 @@ func TestSchemaVersionedModelBucket(t *testing.T) {
 
 	b := NewModelBucket(
 		thisPkgName,
-		orm.NewModelBucket(
-			orm.NewBucket("mymodel", orm.NewSimpleObj(nil, &MyModel{})).
-				// Regardless the object, club all together.
-				WithIndex("const", func(orm.Object) ([]byte, error) { return []byte("all"), nil }, false),
+		orm.NewModelBucket("mymodel", &MyModel{},
+			orm.WithIndex("const", func(orm.Object) ([]byte, error) { return []byte("all"), nil }, false),
 		),
 	)
 

--- a/migration/orm_test.go
+++ b/migration/orm_test.go
@@ -209,7 +209,7 @@ func TestSchemaVersionedModelBucket(t *testing.T) {
 
 	// ByIndex must support destination being slice of values.
 	var setp []*MyModel
-	if err := b.ByIndex(db, "const", []byte("all"), &setp); err != nil {
+	if _, err := b.ByIndex(db, "const", []byte("all"), &setp); err != nil {
 		t.Fatalf("cannot query by index: %s", err)
 	}
 	wantp := []*MyModel{
@@ -220,7 +220,7 @@ func TestSchemaVersionedModelBucket(t *testing.T) {
 
 	// ByIndex must support destination being slice of pointers.
 	var setv []MyModel
-	if err := b.ByIndex(db, "const", []byte("all"), &setv); err != nil {
+	if _, err := b.ByIndex(db, "const", []byte("all"), &setv); err != nil {
 		t.Fatalf("cannot query by index: %s", err)
 	}
 	wantv := []MyModel{

--- a/orm/model_bucket.go
+++ b/orm/model_bucket.go
@@ -59,6 +59,10 @@ type ModelBucket interface {
 	// Delete removes an entity with given primary key from the database.
 	// It returns ErrNotFound if an entity with given key does not exist.
 	Delete(db weave.KVStore, key []byte) error
+
+	// Register registers this buckets content to be accessable via query
+	// requests under the given name.
+	Register(name string, r weave.QueryRouter)
 }
 
 // NewModelBucket returns a ModelBucket instance. This implementation relies on
@@ -74,6 +78,10 @@ func NewModelBucket(b Bucket) ModelBucket {
 type modelBucket struct {
 	b     Bucket
 	idSeq Sequence
+}
+
+func (mb *modelBucket) Register(name string, r weave.QueryRouter) {
+	mb.b.Register(name, r)
 }
 
 func (mb *modelBucket) One(db weave.ReadOnlyKVStore, key []byte, dest Model) error {

--- a/orm/model_bucket.go
+++ b/orm/model_bucket.go
@@ -38,7 +38,7 @@ type ModelBucket interface {
 	// is returned.
 	One(db weave.ReadOnlyKVStore, key []byte, dest Model) error
 
-	// ByIndex returns all objects that secondary index with given name is
+	// ByIndex returns all objects that secondary index with given name and
 	// given key. Main index is always unique but secondary indexes can
 	// return more than one value for the same key.
 	// All matching entities are appended to given destination slice. If no

--- a/orm/model_bucket.go
+++ b/orm/model_bucket.go
@@ -1,0 +1,98 @@
+package orm
+
+import (
+	"reflect"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/errors"
+)
+
+// TODO
+// - migrations
+// - do not use Bucket but directly access KVStore
+// - register for queries
+
+// Model is impelemented by any entity that can be stored using ModelBucket.
+//
+// This is the same interface as CloneableData. Using the right type names
+// provides an easier to read API.
+type Model interface {
+	weave.Persistent
+	Validate() error
+	Copy() CloneableData
+}
+
+// ModelBucket is implemented by buckets that operates on Models rather than
+// Objects.
+type ModelBucket interface {
+	// One query the database for a single model instance. Lookup is done
+	// by the primary index key. Result is loaded into given destination
+	// model.
+	// This method returns ErrNotFound if the entity does not exist in the
+	// database.
+	// If given model type cannot be used to contain stored entity, ErrType
+	// is returned.
+	One(db weave.ReadOnlyKVStore, key []byte, dest Model) error
+
+	// Put saves given model in the database.
+	Put(db weave.KVStore, key []byte, m Model) error
+
+	// Delete removes an entity with given primary key from the database.
+	// It returns ErrNotFound if an entity with given key does not exist.
+	Delete(db weave.KVStore, key []byte) error
+}
+
+// NewModelBucket returns a ModelBucket instance. This implementation relies on
+// a bucket instance. Final implementation should operate directly on the
+// KVStore instead.
+func NewModelBucket(b Bucket) ModelBucket {
+	return &modelBucket{
+		b: b,
+	}
+}
+
+type modelBucket struct {
+	b Bucket
+}
+
+func (mb *modelBucket) One(db weave.ReadOnlyKVStore, key []byte, dest Model) error {
+	obj, err := mb.b.Get(db, key)
+	if err != nil {
+		return err
+	}
+	if obj == nil || obj.Value() == nil {
+		return errors.Wrapf(errors.ErrNotFound, "%T not in the store", dest)
+	}
+	res := obj.Value()
+
+	if !reflect.TypeOf(res).AssignableTo(reflect.TypeOf(dest)) {
+		return errors.Wrapf(errors.ErrType, "%T cannot be represented as %T", res, dest)
+	}
+
+	reflect.ValueOf(dest).Elem().Set(reflect.ValueOf(res).Elem())
+	return nil
+}
+
+func (mb *modelBucket) Put(db weave.KVStore, key []byte, m Model) error {
+	if err := m.Validate(); err != nil {
+		return errors.Wrap(err, "invalid model")
+	}
+	obj := NewSimpleObj(key, m)
+	if err := mb.b.Save(db, obj); err != nil {
+		return errors.Wrap(err, "cannot store in the database")
+	}
+	return nil
+}
+
+func (mb *modelBucket) Delete(db weave.KVStore, key []byte) error {
+	obj, err := mb.b.Get(db, key)
+	if err != nil {
+		return err
+	}
+	if obj == nil || obj.Value() == nil {
+		return errors.ErrNotFound
+	}
+	return mb.b.Delete(db, key)
+}
+
+var _ ModelBucket = (*modelBucket)(nil)

--- a/orm/model_bucket_test.go
+++ b/orm/model_bucket_test.go
@@ -222,3 +222,24 @@ func TestModelBucketByIndexWrongModelType(t *testing.T) {
 		t.Fatalf("unexpected error when trying to find wrong model type value: %s: %v", err, refs)
 	}
 }
+
+func TestModelBucketHas(t *testing.T) {
+	db := store.MemStore()
+	b := NewModelBucket("cnts", &Counter{})
+
+	if _, err := b.Put(db, []byte("counter"), &Counter{Count: 1}); err != nil {
+		t.Fatalf("cannot save counter instance: %s", err)
+	}
+
+	if err := b.Has(db, []byte("counter")); err != nil {
+		t.Fatalf("an existing entity must return no error: %s", err)
+	}
+
+	if err := b.Has(db, nil); !errors.ErrNotFound.Is(err) {
+		t.Fatalf("a nil key must return ErrNotFound: %s", err)
+	}
+
+	if err := b.Has(db, []byte("does-not-exist")); !errors.ErrNotFound.Is(err) {
+		t.Fatalf("a non exists entity must return ErrNotFound: %s", err)
+	}
+}

--- a/orm/model_bucket_test.go
+++ b/orm/model_bucket_test.go
@@ -1,6 +1,7 @@
 package orm
 
 import (
+	"bytes"
 	"strconv"
 	"testing"
 
@@ -50,8 +51,12 @@ func TestModelBucketPutSequence(t *testing.T) {
 	b := NewModelBucket(objBucket)
 
 	// Using a nil key should cause the sequence ID to be used.
-	if _, err := b.Put(db, nil, &Counter{Count: 111}); err != nil {
+	key, err := b.Put(db, nil, &Counter{Count: 111})
+	if err != nil {
 		t.Fatalf("cannot save counter instance: %s", err)
+	}
+	if !bytes.Equal(key, weavetest.SequenceID(1)) {
+		t.Fatalf("first sequence key should be 1, instead got %d", key)
 	}
 
 	// Inserting an entity with a key provided must not modify the ID
@@ -60,8 +65,12 @@ func TestModelBucketPutSequence(t *testing.T) {
 		t.Fatalf("cannot save counter instance: %s", err)
 	}
 
-	if _, err := b.Put(db, nil, &Counter{Count: 222}); err != nil {
+	key, err = b.Put(db, nil, &Counter{Count: 222})
+	if err != nil {
 		t.Fatalf("cannot save counter instance: %s", err)
+	}
+	if !bytes.Equal(key, weavetest.SequenceID(2)) {
+		t.Fatalf("second sequence key should be 2, instead got %d", key)
 	}
 
 	var c1 Counter

--- a/orm/model_bucket_test.go
+++ b/orm/model_bucket_test.go
@@ -85,7 +85,7 @@ func TestModelBucketByIndex(t *testing.T) {
 	cases := map[string]struct {
 		IndexName  string
 		QueryKey   string
-		DestFn     func() ModelSlice
+		DestFn     func() ModelSlicePtr
 		WantErr    *errors.Error
 		WantResPtr []*Counter
 		WantRes    []Counter

--- a/orm/model_bucket_test.go
+++ b/orm/model_bucket_test.go
@@ -1,10 +1,12 @@
 package orm
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/store"
+	"github.com/iov-one/weave/weavetest/assert"
 )
 
 func TestModelBucket(t *testing.T) {
@@ -35,5 +37,108 @@ func TestModelBucket(t *testing.T) {
 	}
 	if err := b.One(db, []byte("c1"), &c1); !errors.ErrNotFound.Is(err) {
 		t.Fatalf("unexpected error for an unknown model get: %s", err)
+	}
+}
+
+func TestModelBucketMany(t *testing.T) {
+	cases := map[string]struct {
+		IndexName string
+		QueryKey  string
+		Dest      []Model
+		WantErr   *errors.Error
+		WantRes   []Model
+	}{
+		"find none": {
+			IndexName: "value",
+			QueryKey:  "124089710947120",
+			Dest:      nil,
+			WantErr:   nil,
+			WantRes:   nil,
+		},
+		"find one": {
+			IndexName: "value",
+			QueryKey:  "1111",
+			Dest:      nil,
+			WantErr:   nil,
+			WantRes: []Model{
+				&Counter{Count: 1111},
+			},
+		},
+		"find two with nil destination": {
+			IndexName: "value",
+			QueryKey:  "4444",
+			Dest:      []Model{},
+			WantErr:   nil,
+			WantRes: []Model{
+				&Counter{Count: 4444},
+				&Counter{Count: 4444},
+			},
+		},
+		"find two with allocated destination": {
+			IndexName: "value",
+			QueryKey:  "4444",
+			Dest:      make([]Model, 0, 10),
+			WantErr:   nil,
+			WantRes: []Model{
+				&Counter{Count: 4444},
+				&Counter{Count: 4444},
+			},
+		},
+		"find two with non empty destination": {
+			IndexName: "value",
+			QueryKey:  "4444",
+			Dest: []Model{
+				&Counter{Count: 007},
+			},
+			WantErr: nil,
+			WantRes: []Model{
+				// Destination is always appended to.
+				&Counter{Count: 007},
+
+				&Counter{Count: 4444},
+				&Counter{Count: 4444},
+			},
+		},
+		"non existing index name": {
+			IndexName: "xyz",
+			WantErr:   ErrInvalidIndex,
+		},
+	}
+
+	for testName, tc := range cases {
+		t.Run(testName, func(t *testing.T) {
+			db := store.MemStore()
+
+			indexByValue := func(obj Object) ([]byte, error) {
+				c, ok := obj.Value().(*Counter)
+				if !ok {
+					return nil, errors.Wrapf(errors.ErrType, "%T", obj.Value())
+				}
+				raw := strconv.FormatInt(c.Count, 10)
+				return []byte(raw), nil
+			}
+			objBucket := NewBucket("cnts", NewSimpleObj(nil, &Counter{})).
+				WithIndex("value", indexByValue, false)
+			b := NewModelBucket(objBucket)
+
+			if err := b.Put(db, []byte("c1"), &Counter{Count: 4444}); err != nil {
+				t.Fatalf("cannot save counter instance: %s", err)
+			}
+			if err := b.Put(db, []byte("c2"), &Counter{Count: 4444}); err != nil {
+				t.Fatalf("cannot save counter instance: %s", err)
+			}
+			if err := b.Put(db, []byte("c3"), &Counter{Count: 1111}); err != nil {
+				t.Fatalf("cannot save counter instance: %s", err)
+			}
+			if err := b.Put(db, []byte("c4"), &Counter{Count: 99999}); err != nil {
+				t.Fatalf("cannot save counter instance: %s", err)
+			}
+
+			err := b.Many(db, tc.IndexName, []byte(tc.QueryKey), &tc.Dest)
+			if !tc.WantErr.Is(err) {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			assert.Equal(t, tc.WantRes, tc.Dest)
+		})
 	}
 }

--- a/orm/model_bucket_test.go
+++ b/orm/model_bucket_test.go
@@ -1,0 +1,39 @@
+package orm
+
+import (
+	"testing"
+
+	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/store"
+)
+
+func TestModelBucket(t *testing.T) {
+	db := store.MemStore()
+
+	obj := NewSimpleObj(nil, &Counter{})
+	objBucket := NewBucket("cnts", obj)
+
+	b := NewModelBucket(objBucket)
+
+	if err := b.Put(db, []byte("c1"), &Counter{Count: 1}); err != nil {
+		t.Fatalf("cannot save counter instance: %s", err)
+	}
+
+	var c1 Counter
+	if err := b.One(db, []byte("c1"), &c1); err != nil {
+		t.Fatalf("cannot get c1 counter: %s", err)
+	}
+	if c1.Count != 1 {
+		t.Fatalf("unexpected counter state: %d", c1)
+	}
+
+	if err := b.Delete(db, []byte("c1")); err != nil {
+		t.Fatalf("cannot delete c1 counter: %s", err)
+	}
+	if err := b.Delete(db, []byte("unknown")); !errors.ErrNotFound.Is(err) {
+		t.Fatalf("unexpected error when deleting unexisting instance: %s", err)
+	}
+	if err := b.One(db, []byte("c1"), &c1); !errors.ErrNotFound.Is(err) {
+		t.Fatalf("unexpected error for an unknown model get: %s", err)
+	}
+}

--- a/orm/model_bucket_test.go
+++ b/orm/model_bucket_test.go
@@ -14,10 +14,7 @@ import (
 func TestModelBucket(t *testing.T) {
 	db := store.MemStore()
 
-	obj := NewSimpleObj(nil, &Counter{})
-	objBucket := NewBucket("cnts", obj)
-
-	b := NewModelBucket(objBucket)
+	b := NewModelBucket("cnts", &Counter{})
 
 	if _, err := b.Put(db, []byte("c1"), &Counter{Count: 1}); err != nil {
 		t.Fatalf("cannot save counter instance: %s", err)
@@ -45,10 +42,7 @@ func TestModelBucket(t *testing.T) {
 func TestModelBucketPutSequence(t *testing.T) {
 	db := store.MemStore()
 
-	obj := NewSimpleObj(nil, &Counter{})
-	objBucket := NewBucket("cnts", obj)
-
-	b := NewModelBucket(objBucket)
+	b := NewModelBucket("cnts", &Counter{})
 
 	// Using a nil key should cause the sequence ID to be used.
 	key, err := b.Put(db, nil, &Counter{Count: 111})
@@ -149,9 +143,7 @@ func TestModelBucketByIndex(t *testing.T) {
 				raw := strconv.FormatInt(c.Count/1000, 10)
 				return []byte(raw), nil
 			}
-			objBucket := NewBucket("cnts", NewSimpleObj(nil, &Counter{})).
-				WithIndex("value", indexByBigValue, false)
-			b := NewModelBucket(objBucket)
+			b := NewModelBucket("cnts", &Counter{}, WithIndex("value", indexByBigValue, false))
 
 			if _, err := b.Put(db, nil, &Counter{Count: 4001}); err != nil {
 				t.Fatalf("cannot save counter instance: %s", err)
@@ -185,9 +177,7 @@ func TestModelBucketByIndex(t *testing.T) {
 
 func TestModelBucketPutWrongModelType(t *testing.T) {
 	db := store.MemStore()
-	obj := NewSimpleObj(nil, &Counter{})
-	objBucket := NewBucket("cnts", obj)
-	b := NewModelBucket(objBucket)
+	b := NewModelBucket("cnts", &Counter{})
 
 	if _, err := b.Put(db, nil, &MultiRef{Refs: [][]byte{[]byte("foo")}}); !errors.ErrType.Is(err) {
 		t.Fatalf("unexpected error when trying to store wrong model type value: %s", err)
@@ -196,9 +186,7 @@ func TestModelBucketPutWrongModelType(t *testing.T) {
 
 func TestModelBucketOneWrongModelType(t *testing.T) {
 	db := store.MemStore()
-	obj := NewSimpleObj(nil, &Counter{})
-	objBucket := NewBucket("cnts", obj)
-	b := NewModelBucket(objBucket)
+	b := NewModelBucket("cnts", &Counter{})
 
 	if _, err := b.Put(db, []byte("counter"), &Counter{Count: 1}); err != nil {
 		t.Fatalf("cannot save counter instance: %s", err)
@@ -212,10 +200,8 @@ func TestModelBucketOneWrongModelType(t *testing.T) {
 
 func TestModelBucketByIndexWrongModelType(t *testing.T) {
 	db := store.MemStore()
-	obj := NewSimpleObj(nil, &Counter{})
-	objBucket := NewBucket("cnts", obj).
-		WithIndex("x", func(o Object) ([]byte, error) { return []byte("x"), nil }, false)
-	b := NewModelBucket(objBucket)
+	b := NewModelBucket("cnts", &Counter{},
+		WithIndex("x", func(o Object) ([]byte, error) { return []byte("x"), nil }, false))
 
 	if _, err := b.Put(db, []byte("counter"), &Counter{Count: 1}); err != nil {
 		t.Fatalf("cannot save counter instance: %s", err)

--- a/weavetest/assert/assert.go
+++ b/weavetest/assert/assert.go
@@ -37,7 +37,7 @@ func isNil(value interface{}) (isnil bool) {
 func Equal(t testing.TB, want, got interface{}) {
 	t.Helper()
 	if !reflect.DeepEqual(want, got) {
-		t.Fatalf("values not equal \nwant %v\n got %v", want, got)
+		t.Fatalf("values not equal \nwant %T %v\n got %T %v", want, want, got, got)
 	}
 }
 

--- a/x/paychan/handler_test.go
+++ b/x/paychan/handler_test.go
@@ -27,7 +27,7 @@ var (
 func TestPaymentChannelHandlers(t *testing.T) {
 	cashBucket := cash.NewBucket()
 	bankCtrl := cash.NewController(cashBucket)
-	payChanBucket := NewPaymentChannelBucket()
+	payChanBucket := newPaymentChannelObjectBucket()
 	auth := &weavetest.CtxAuth{Key: "auth"}
 
 	rt := app.NewRouter()
@@ -66,7 +66,7 @@ func TestPaymentChannelHandlers(t *testing.T) {
 				{
 					path:   "/paychans",
 					data:   weavetest.SequenceID(1),
-					bucket: payChanBucket.Bucket,
+					bucket: payChanBucket,
 					wantRes: []orm.Object{
 						orm.NewSimpleObj(weavetest.SequenceID(1), &PaymentChannel{
 							Metadata:     &weave.Metadata{Schema: 1},
@@ -136,7 +136,7 @@ func TestPaymentChannelHandlers(t *testing.T) {
 				{
 					path:    "/paychans",
 					data:    weavetest.SequenceID(1),
-					bucket:  payChanBucket.Bucket,
+					bucket:  payChanBucket,
 					wantRes: nil,
 				},
 				// Query senders wallet to ensure money was
@@ -259,7 +259,7 @@ func TestPaymentChannelHandlers(t *testing.T) {
 				{
 					path:    "/paychans",
 					data:    weavetest.SequenceID(1),
-					bucket:  payChanBucket.Bucket,
+					bucket:  payChanBucket,
 					wantRes: nil,
 				},
 				// Query senders wallet to ensure that the

--- a/x/paychan/model.go
+++ b/x/paychan/model.go
@@ -63,8 +63,8 @@ func (pc PaymentChannel) Copy() orm.CloneableData {
 
 // NewPaymentChannelBucket returns a bucket for storing PaymentChannel state.
 func NewPaymentChannelBucket() orm.ModelBucket {
-	b := newPaymentChannelObjectBucket()
-	return migration.NewModelBucket("paychan", orm.NewModelBucket(b))
+	b := orm.NewModelBucket("paychan", &PaymentChannel{})
+	return migration.NewModelBucket("paychan", b)
 }
 
 func newPaymentChannelObjectBucket() orm.Bucket {

--- a/x/paychan/model.go
+++ b/x/paychan/model.go
@@ -1,7 +1,6 @@
 package paychan
 
 import (
-	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
 	"github.com/iov-one/weave/orm"
@@ -62,54 +61,13 @@ func (pc PaymentChannel) Copy() orm.CloneableData {
 	}
 }
 
-// PaymentChannelBucket is a wrapper over orm.Bucket that ensures that only
-// PaymentChannel entities can be persisted.
-type PaymentChannelBucket struct {
-	migration.Bucket
-	idSeq orm.Sequence
-}
-
 // NewPaymentChannelBucket returns a bucket for storing PaymentChannel state.
-func NewPaymentChannelBucket() PaymentChannelBucket {
-	b := migration.NewBucket("paychan", "paychan", orm.NewSimpleObj(nil, &PaymentChannel{}))
-	return PaymentChannelBucket{
-		Bucket: b,
-		idSeq:  b.Sequence("id"),
-	}
+func NewPaymentChannelBucket() orm.ModelBucket {
+	b := newPaymentChannelObjectBucket()
+	return migration.NewModelBucket("paychan", orm.NewModelBucket(b))
 }
 
-// Create adds given payment store entity to the store and returns the ID of
-// the newly inserted entity.
-func (b *PaymentChannelBucket) Create(db weave.KVStore, pc *PaymentChannel) (orm.Object, error) {
-	key, err := b.idSeq.NextVal(db)
-	if err != nil {
-		return nil, err
-	}
-	obj := orm.NewSimpleObj(key, pc)
-	return obj, b.Bucket.Save(db, obj)
-}
-
-// Save updates the state of given PaymentChannel entity in the store.
-func (b *PaymentChannelBucket) Save(db weave.KVStore, obj orm.Object) error {
-	if _, ok := obj.Value().(*PaymentChannel); !ok {
-		return errors.WithType(errors.ErrModel, obj.Value())
-	}
-	return b.Bucket.Save(db, obj)
-}
-
-// GetPaymentChannel returns a payment channel instance with given ID or
-// returns an error.
-func (b *PaymentChannelBucket) GetPaymentChannel(db weave.KVStore, paymentChannelID []byte) (*PaymentChannel, error) {
-	obj, err := b.Get(db, paymentChannelID)
-	if err != nil {
-		return nil, err
-	}
-	if obj == nil || obj.Value() == nil {
-		return nil, errors.Wrap(errors.ErrNotFound, "payment channel not found")
-	}
-	pc, ok := obj.Value().(*PaymentChannel)
-	if !ok {
-		return nil, errors.Wrap(errors.ErrNotFound, "payment channel not found")
-	}
-	return pc, nil
+func newPaymentChannelObjectBucket() orm.Bucket {
+	obj := orm.NewSimpleObj(nil, &PaymentChannel{})
+	return orm.NewBucket("paychan", obj)
 }


### PR DESCRIPTION
This is a proposal and a proof-of-concept implementation of a bucket
that operates directly on the model rather than Object instances.

This implementation relies on the Bucket to access the database. Final
implementation must not use Bucket but directly use KVStore instance.

Methods used (`One`, `Put`) are to be refined. I want to use something
very different than `Get` and `Save` of the existing bucket
implementation to avoid confusion and conflicts.

There are some more topics that are to be addressed before this
implementation is finished:

- [x] integration with the `migration` package
- [ ] do not use Bucket but directly access KVStore
- [x] register for queries
- [x] implement `Many` method for getting a list of models
- [x] implement `Has` method for checking if an entity exist without
      deserialization
- [x] integrate in at least one extension to learn if the new interface
      looks good and is easy to use

resolve #536