### PR TITLE
errors: initial mutierr

### DIFF
--- a/errors/abci.go
+++ b/errors/abci.go
@@ -14,7 +14,7 @@ const (
 	// All unclassified errors that do not provide an ABCI code are clubbed
 	// under an internal error code and a generic message instead of
 	// detailed error string.
-	internalABCICode = 1
+	internalABCICode uint32 =  1
 	internalABCILog  = "internal error"
 )
 
@@ -51,16 +51,16 @@ func ABCIInfo(err error, debug bool) (uint32, string) {
 	return internalABCICode, internalABCILog
 }
 
+type coder interface {
+	ABCICode() uint32
+}
+
 // abciCode test if given error contains an ABCI code and returns the value of
 // it if available. This function is testing for the causer interface as well
 // and unwraps the error.
 func abciCode(err error) uint32 {
 	if errIsNil(err) {
 		return SuccessABCICode
-	}
-
-	type coder interface {
-		ABCICode() uint32
 	}
 
 	for {

--- a/errors/abci.go
+++ b/errors/abci.go
@@ -14,8 +14,8 @@ const (
 	// All unclassified errors that do not provide an ABCI code are clubbed
 	// under an internal error code and a generic message instead of
 	// detailed error string.
-	internalABCICode uint32 =  1
-	internalABCILog  = "internal error"
+	internalABCICode uint32 = 1
+	internalABCILog         = "internal error"
 )
 
 // ABCIInfo returns the ABCI error information as consumed by the tenderemint

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -167,10 +167,7 @@ func (kind *Error) Is(err error) bool {
 	// For multiErr, "Is" is used recursively, so there is no need
 	// to proceed with causer logic after this block.
 	if mErr, ok := err.(*multiErr); ok {
-		if mErr.is(kind.Is) {
-			return true
-		}
-		return false
+		return mErr.is(kind.Is)
 	}
 
 	for {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -164,6 +164,15 @@ func (kind *Error) Is(err error) bool {
 		return reflect.ValueOf(err).IsNil()
 	}
 
+	// For multiErr, "Is" is used recursively, so there is no need
+	// to proceed with causer logic after this block.
+	if mErr, ok := err.(*multiErr); ok {
+		if mErr.is(kind.Is) {
+			return true
+		}
+		return false
+	}
+
 	for {
 		if err == kind {
 			return true

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -21,7 +21,7 @@ func TestMultiErr(t *testing.T) {
 			name := "Test"
 			err := MultiAdd()
 			assert.Equal(t, err.IsEmpty(), true)
-			err.AddNamed(name, nil)
+			_ = err.AddNamed(name, nil)
 			assert.Equal(t, err.IsEmpty(), true)
 		},
 		"Named errors accumulate": func(t *testing.T) {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -17,6 +17,13 @@ func TestMultiErr(t *testing.T) {
 			assert.Equal(t, err.Named(name), ErrEmpty)
 			assert.Equal(t, err.Named("random"), nil)
 		},
+		"IsEmpty": func(t *testing.T) {
+			name := "Test"
+			err := MultiAdd()
+			assert.Equal(t, err.IsEmpty(), true)
+			err.AddNamed(name, nil)
+			assert.Equal(t, err.IsEmpty(), true)
+		},
 		"Named error override": func(t *testing.T) {
 			name := "Test"
 			err := MultiAddNamed(name, ErrEmpty)

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -26,13 +26,17 @@ func TestMultiErr(t *testing.T) {
 		},
 		"Named error override": func(t *testing.T) {
 			name := "Test"
-			err := MultiAddNamed(name, ErrEmpty)
-			err.AddNamed(name, ErrState)
+			err := MultiAddNamed(name, ErrEmpty).AddNamed(name, ErrState)
 			assert.Equal(t, err.Named(name), ErrState)
 		},
 		"ABCICode is consistent with that of a normal error": func(t *testing.T) {
 			err := MultiAdd(ErrEmpty)
 			assert.Equal(t, err.(coder).ABCICode(), ErrEmpty.ABCICode())
+		},
+		"Tests wraps work properly": func(t *testing.T) {
+			multiErr := MultiAdd(ErrEmpty)
+			err := Wrap(Wrap(MultiAdd(Wrap(multiErr, "descr")), "descr"), "descr")
+			assert.Equal(t, ErrEmpty.Is(err), true)
 		},
 		"Error() works as expected": func(t *testing.T) {
 			err := MultiAdd()

--- a/errors/multi.go
+++ b/errors/multi.go
@@ -1,0 +1,104 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Multi interface {
+	Add(err error)
+	AddNamed(name string, err error)
+	Named(name string) error
+	Is(err error) bool
+}
+
+// multiErr is a default implementation of errors.Multi.
+// It does not support flattening in order to maintain consistent
+// behaviour of named errors
+type multiErr struct {
+	errors []error
+	errorNames map[string]int
+}
+
+func (me *multiErr) isEmpty() bool {
+	return len(me.errors) == 0
+}
+
+// Add adds an error to this multiErr
+func (me *multiErr) Add(err error) {
+	me.errors = append(me.errors, err)
+}
+
+// AddNamed adds an error that could later be retrieved by name
+func (me *multiErr) AddNamed(name string, err error) {
+	me.errors = append(me.errors, err)
+	me.errorNames[name] = len(me.errors) - 1
+}
+
+// Named returns a named error or nil
+func (me *multiErr) Named(name string) error {
+	index, ok := me.errorNames[name]
+	if ok {
+		return me.errors[index]
+	}
+	return nil
+}
+
+func(me *multiErr) Error() string {
+	if len(me.errors) == 1 {
+		return fmt.Sprintf("1 error occurred:\n\t* %s\n\n", me.errors[0])
+	}
+
+	points := make([]string, len(me.errors))
+	for i, err := range me.errors {
+		points[i] = fmt.Sprintf("* %s", err)
+	}
+
+	return fmt.Sprintf(
+		"%d errors occurred:\n\t%s\n\n",
+		len(me.errors), strings.Join(points, "\n\t"))
+}
+
+func (me *multiErr) Is(err error) error {
+	if merr, ok := err.(multiErr); ok {
+
+	}
+}
+
+var _ coder = (*multiErr)(nil)
+var _ causer = (*multiErr)(nil)
+var _ Multi = (*multiErr)(nil)
+var _ error = (*multiErr)(nil)
+
+
+
+// ABCICode returns the error code of a first error consistent with fail-fast approach or falls back to
+// internalError code if the error does not satisfy the coder interface.
+// Returns success code if the multiErr is empty
+func (me *multiErr) ABCICode() uint32 {
+	if me.isEmpty() {
+		return SuccessABCICode
+	}
+
+	c, ok := me.errors[0].(coder)
+	if ok {
+		return c.ABCICode()
+	}
+	return internalABCICode
+}
+
+// Cause returns the cause of a first error consistent with ABCICode
+// if the interface is not satisfied - it returns errInternal
+// in case multiErr is empty - we return a nil
+func (me *multiErr) Cause() error {
+	if me.isEmpty() {
+		return nil
+	}
+	c, ok := me.errors[0].(causer)
+	if ok {
+		return c.Cause()
+	}
+	return errInternal
+}
+
+

--- a/errors/multi.go
+++ b/errors/multi.go
@@ -44,6 +44,9 @@ func (me *multiErr) Add(err error) {
 	me.errors = append(me.errors, err)
 }
 
+// This AddNamed implementation would overwrite a pointer to
+// a named error if the same name is used twice, while keeping
+// the original error in the container for matching.
 func (me *multiErr) AddNamed(name string, err error) {
 	me.errors = append(me.errors, err)
 	me.errorNames[name] = len(me.errors) - 1

--- a/errors/multi.go
+++ b/errors/multi.go
@@ -108,3 +108,17 @@ func (me *multiErr) Cause() error {
 	}
 	return errInternal
 }
+
+// MultiAdd allows to create a multiErr from an error
+func MultiAdd(err error) Multi {
+	mErr := &multiErr{}
+	mErr.Add(err)
+	return mErr
+}
+
+// MultiAddNamed creates a multiErr from a named error
+func MultiAddNamed(name string, err error) Multi {
+	mErr := &multiErr{}
+	mErr.AddNamed(name, err)
+	return mErr
+}

--- a/errors/multi.go
+++ b/errors/multi.go
@@ -23,7 +23,7 @@ type Multi interface {
 
 // multiErr is a default implementation of errors.Multi.
 // It does not support flattening in order to maintain consistent
-// behaviour of named errors
+// behaviour of named errors. The implementation is not thread-safe
 type multiErr struct {
 	errors     []error
 	errorNames map[string]int

--- a/errors/multi.go
+++ b/errors/multi.go
@@ -58,18 +58,22 @@ func (me *multiErr) Named(name string) error {
 }
 
 func (me *multiErr) Error() string {
-	if len(me.errors) == 1 {
-		return fmt.Sprintf("1 error occurred:\n\t* %s\n\n", me.errors[0])
+	if me.isEmpty() {
+		return ""
 	}
 
-	points := make([]string, len(me.errors))
+	if len(me.errors) == 1 {
+		return me.first().Error()
+	}
+
+	errs := make([]string, len(me.errors))
 	for i, err := range me.errors {
-		points[i] = fmt.Sprintf("* %s", err)
+		errs[i] = fmt.Sprintf("* %s", err)
 	}
 
 	return fmt.Sprintf(
 		"%d errors occurred:\n\t%s\n\n",
-		len(me.errors), strings.Join(points, "\n\t"))
+		len(me.errors), strings.Join(errs, "\n\t"))
 }
 
 // is provides a helper for Error.Is to work with multiErr

--- a/errors/multi.go
+++ b/errors/multi.go
@@ -13,9 +13,9 @@ var _ Multi = (*multiErr)(nil)
 // to the rest of the app.
 type Multi interface {
 	// Add adds an error to this multiErr
-	Add(err error)
+	Add(err error) Multi
 	// AddNamed adds an error that could later be retrieved by name
-	AddNamed(name string, err error)
+	AddNamed(name string, err error) Multi
 	// Named returns a named error or nil
 	Named(name string) error
 	// IsEmpty returns true if there are no actual errors registered,
@@ -43,22 +43,24 @@ func (me *multiErr) first() error {
 	return me.errors[0]
 }
 
-func (me *multiErr) Add(err error) {
+func (me *multiErr) Add(err error) Multi {
 	if err == nil {
-		return
+		return me
 	}
 	me.errors = append(me.errors, err)
+	return me
 }
 
 // This AddNamed implementation would overwrite a pointer to
 // a named error if the same name is used twice, while keeping
 // the original error in the container for matching.
-func (me *multiErr) AddNamed(name string, err error) {
+func (me *multiErr) AddNamed(name string, err error) Multi {
 	if err == nil {
-		return
+		return me
 	}
 	me.errors = append(me.errors, err)
 	me.errorNames[name] = len(me.errors) - 1
+	return me
 }
 
 func (me *multiErr) Named(name string) error {

--- a/errors/multi.go
+++ b/errors/multi.go
@@ -143,3 +143,17 @@ func MultiAddNamed(name string, err error) Multi {
 	mErr.AddNamed(name, err)
 	return mErr
 }
+
+// AsMulti is a nil-safe cast for working with multiErr
+// in tests
+func AsMulti(err error) Multi {
+	if err == nil {
+		return newMulti()
+	}
+
+	if v, ok := err.(Multi); ok {
+		return v
+	}
+
+	return MultiAdd(err)
+}

--- a/errors/multi.go
+++ b/errors/multi.go
@@ -113,11 +113,15 @@ func (me *multiErr) Cause() error {
 	return me.first()
 }
 
-// MultiAdd allows to create a multiErr with an optional list of errors
-func MultiAdd(errs ...error) Multi {
-	mErr := &multiErr{
+func newMulti() *multiErr {
+	return &multiErr{
 		errorNames: make(map[string]int, 0),
 	}
+}
+
+// MultiAdd allows to create a multiErr with an optional list of errors
+func MultiAdd(errs ...error) Multi {
+	mErr := newMulti()
 	for _, err := range errs {
 		mErr.Add(err)
 	}
@@ -126,9 +130,7 @@ func MultiAdd(errs ...error) Multi {
 
 // MultiAddNamed creates a multiErr from a named error
 func MultiAddNamed(name string, err error) Multi {
-	mErr := &multiErr{
-		errorNames: make(map[string]int, 0),
-	}
+	mErr := newMulti()
 	mErr.AddNamed(name, err)
 	return mErr
 }

--- a/x/batch/msg.go
+++ b/x/batch/msg.go
@@ -16,13 +16,17 @@ type Msg interface {
 
 func Validate(msg Msg) error {
 	l, err := msg.MsgList()
-	if err != nil {
-		return errors.Wrap(err, "cannot retrieve batch message")
-	}
+	multiErr := errors.MultiAddNamed("Message", errors.Wrap(err, "cannot retrieve batch message"))
 
 	msgNum := len(l)
 	if msgNum > MaxBatchMessages {
-		return errors.Wrapf(errors.ErrInput, "transaction is too large, max: %d vs current: %d", MaxBatchMessages, msgNum)
+		multiErr.AddNamed("Size", errors.Wrapf(errors.ErrInput,
+			"transaction is too large, max: %d vs current: %d", MaxBatchMessages, msgNum))
 	}
-	return nil
+
+	if multiErr.IsEmpty() {
+		return nil
+	}
+
+	return multiErr
 }

--- a/x/batch/msg_test.go
+++ b/x/batch/msg_test.go
@@ -1,10 +1,11 @@
 package batch_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/weavetest/assert"
 	"github.com/iov-one/weave/x/batch"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/mock"
@@ -19,17 +20,14 @@ func TestMsg(t *testing.T) {
 			msg.AssertExpectations(t)
 		})
 
-		Convey("Test list too long", func() {
-			msg.On("MsgList").Return(make([]weave.Msg, 11), nil)
-			So(batch.Validate(msg), ShouldNotBeNil)
+		Convey("Test validation errors", func() {
+			msg.On("MsgList").Return(make([]weave.Msg, 11), errors.ErrEmpty)
+			err := batch.Validate(msg).(errors.Multi)
+			assert.Equal(t, errors.ErrEmpty.Is(err.Named("Message")), true)
+			assert.Equal(t, errors.ErrInput.Is(err.Named("Size")), true)
 			msg.AssertExpectations(t)
 		})
 
-		Convey("Test error", func() {
-			msg.On("MsgList").Return(make([]weave.Msg, 10), errors.New("whatever"))
-			So(batch.Validate(msg), ShouldNotBeNil)
-			msg.AssertExpectations(t)
-		})
 	})
 }
 

--- a/x/batch/msg_test.go
+++ b/x/batch/msg_test.go
@@ -22,7 +22,7 @@ func TestMsg(t *testing.T) {
 
 		Convey("Test validation errors", func() {
 			msg.On("MsgList").Return(make([]weave.Msg, 11), errors.ErrEmpty)
-			err := batch.Validate(msg).(errors.Multi)
+			err := errors.AsMulti(batch.Validate(msg))
 			assert.Equal(t, errors.ErrEmpty.Is(err.Named("Message")), true)
 			assert.Equal(t, errors.ErrInput.Is(err.Named("Size")), true)
 			msg.AssertExpectations(t)


### PR DESCRIPTION
Fixes #529 

This is missing tests.

I didn't really like the `ValidationError` idea as I'm not sure how we can benefit from having a generic ABCICode for the whole multiErr instance. Instead, I've taken another approach and made it generic by taking the first error as root cause. 

I'm not entirely satisfied by helper names `MultiAdd` and `MultiAddNamed`, so if anybody has a better idea - I'd be glad to hear it.

TODO: Please implement @alpe 's [request](https://github.com/iov-one/weave/pull/628#issuecomment-496465408)
- [ ] Dedicated multierr response code
- [ ] No nested muliterr with multierr -> they should be flattened when added to a multierr (inside multierr)
- [ ] No support of errorNames until we have a strategy how this is used by any client
- [ ] Impl serialization of errors inside multierr to preseve code + content

Also "the api should be a pleasure to work with": 
- [ ] port `x/cash` and `coins` to show how it will look
- [ ] adjust API as needed to be nice