### PR TITLE
CHANGELOG cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 - Added support for go 1.12
 - Bumped minimum required version of go to 1.11.4+ as otherwise some commands
   fail because of go mod constraints
-- Governance changes
 
 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `x/cash` is using the new `gconf` package for configuration. New genesis path
   is used. To update genesis file, replace `"gconf": { "cash:xyz": "foo" }` with
   `"conf": { "cash": { "xyz": "foo" } }`
-- Removed support for Go 1.10. Minimal required version is not 1.11.4.
+- Removed support for Go 1.10. Minimal required version is now 1.11.4.
 - Added support for Go 1.12
 
 Breaking changes
@@ -33,6 +33,9 @@ Breaking changes
   `x/sigs` extension
 - New `migration` package. Schema versioning for models and messages can be
   implemented by relying on functionality provided by this package.
+- When considering expiration in `x/escrow` extension, expiration time is now
+  inclusive
+- A new validator subjective anti-spam fee was added
 
 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added support for go 1.12
 - Bumped minimum required version of go to 1.11.4+ as otherwise some commands
   fail because of go mod constraints
+- Governance changes
 
 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,48 +2,45 @@
 
 ## HEAD
 
+
 ## 0.15.0
-- Upgrade to tendermint version 0.31.5, minor interface changes for subscriptions and commands
-- Added `aswap` package. Atomic swap implementation is now separate from `escrow`.
-- Added `migration` package. Schema versioning can be implemented by relying on
-  functionality provided by this package.
-- `gconf` package was reimplemented from scratch
-- `x/cash` is using new `gconf` package for configuration. New genesis path is
-  used. To update genesis file, replace "gconf": { "cash:xyz": "foo" }
-  with "conf": { "cash": { "xyz": "foo" } }
-- Introducing go modules instead of dep
-- Removed support for go 1.10
-- Added support for go 1.12
-- Bumped minimum required version of go to 1.11.4+ as otherwise some commands
-  fail because of go mod constraints
+
+- Tendermint is upgraded to version 0.31.5
+- New `x/aswap` extension implementing atomic swap functionality. Atomic swap
+  implementation is separated from `x/escrow`
+- `x/cash` is using the new `gconf` package for configuration. New genesis path
+  is used. To update genesis file, replace `"gconf": { "cash:xyz": "foo" }` with
+  `"conf": { "cash": { "xyz": "foo" } }`
+- Removed support for Go 1.10. Minimal required version is not 1.11.4.
+- Added support for Go 1.12
 
 Breaking changes
 
-- x/paychan is using a wall clock timeout instead of block height
-- x/cash is using schema versioned model and messages
-- x/paychan is using schema versioned model and messages
-- x/escrow is using schema versioned model and messages
-- x/distribution is using schema versioned model and messages
-- x/namecoin is using schema versioned model and messages
-- x/sigs is using schema versioned model and messages
-- x/multisig is using schema versioned model and messages
-- x/msgfee is using schema versioned model and messages
-- x/currency is using schema versioned model and messages
-- x/nft is using schema versioned model and messages
-- x/validators is using schema versioned model and messages
+- Dependency management was migrated to Go modules. `dep` is no longer used or
+  supported.
+- `x/paychan` extension is using a wall clock for the timeout functionality
+  instead of relying on the block height
+- `gconf` package was reimplemented from scratch. Configuration can be changed
+  during the runtime using messages.
+
 
 ## 0.14.0
-- Tests were cleaned up and no use testify or convey packages. A new package
-  `weavetest/assert` contains test helpers
-- Simplify transaction message unpacking with weave.LoadMsg
-- Initial version of governance model
-- Crypto package improvements #495
-- Reduce timeout resolution in client/backend interface #447
-- Move timeout point to expired state (for atomic swaps) #446
-- Simplify validation logic in Handlers #437
-- Charge gas in x/sigs #429
-- New bump sequence Tx #388
-- Anti-spam fee changes    
+
+- Simplify transaction message unpacking with `weave.LoadMsg`
+- Initial version of the governance extension (`x/gov`)
+- Signature verification in `x/sigs` extension costs gas now
+- A new message `BumpSequenceMsg` for incrementing a user sequence value in
+  `x/sigs` extension
+- New `migration` package. Schema versioning for models and messages can be
+  implemented by relying on functionality provided by this package.
+
+Breaking changes
+
+- Many extensions where updated to provide `weave.Metadata` and support schema
+  versioning as implemeneted by `migrations` package. Updated extensions are:
+  x/cash`, `x/currency`, `x/distribution`, `x/escrow`, `x/msgfee`,
+  `x/multisig`, `x/namecoin`, `x/nft`, `x/paychan`, `x/sigs`, `x/validators`
+
 
 ## 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@
 - `x/cash` is using new `gconf` package for configuration. New genesis path is
   used. To update genesis file, replace "gconf": { "cash:xyz": "foo" }
   with "conf": { "cash": { "xyz": "foo" } }
-- Tests were cleaned up and no use testify or convey packages. A new package
-  `weavetest/assert` contains test helpers
-- Simplify transaction message unpacking with `weave.LoadMsg`
-- Initial version of governance model
 - Introducing go modules instead of dep
 - Removed support for go 1.10
 - Added support for go 1.12
@@ -35,6 +31,24 @@ Breaking changes
 - x/currency is using schema versioned model and messages
 - x/nft is using schema versioned model and messages
 - x/validators is using schema versioned model and messages
+
+## 0.14.0
+- Tests were cleaned up and no use testify or convey packages. A new package
+  `weavetest/assert` contains test helpers
+- Simplify transaction message unpacking with weave.LoadMsg
+- Initial version of governance model
+- crypto package improvements #495
+- Weave documentation : References to IOV-CORE examples need removing #464
+- Reduce timeout resolution in client/backend interface #447
+- Move timeout point to expired state (for atomic swaps) #446
+- Simplify validation logic in Handlers #437
+- Charge gas in x/sigs #429
+- New bump sequence Tx #388
+- Anti-spam fee changes    
+  
+Breaking changes  
+  
+- Move Memo and ChainID to top level Tx codec #435
 
 
 ## 0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-
 ## HEAD
+
+## 0.15.0
 - Upgrade to tendermint version 0.31.5, minor interface changes for subscriptions and commands
 - Added `aswap` package. Atomic swap implementation is now separate from `escrow`.
 - Added `migration` package. Schema versioning can be implemented by relying on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   `"conf": { "cash": { "xyz": "foo" } }`
 - Removed support for Go 1.10. Minimal required version is now 1.11.4.
 - Added support for Go 1.12
+- New `migration` package. Schema versioning for models and messages can be
+  implemented by relying on functionality provided by this package.
 
 Breaking changes
 
@@ -22,6 +24,12 @@ Breaking changes
   instead of relying on the block height
 - `gconf` package was reimplemented from scratch. Configuration can be changed
   during the runtime using messages.
+- Many extensions where updated to provide `weave.Metadata` and support schema
+  versioning as implemented by `migrations` package. Protobuf messages are
+  using new schema and are not binary compatible with old ones. Updated
+  extensions are: x/cash`, `x/currency`, `x/distribution`, `x/escrow`,
+  `x/msgfee`, `x/multisig`, `x/namecoin`,
+  `x/nft`, `x/paychan`, `x/sigs`, `x/validators`
 
 
 ## 0.14.0
@@ -31,18 +39,9 @@ Breaking changes
 - Signature verification in `x/sigs` extension costs gas now
 - A new message `BumpSequenceMsg` for incrementing a user sequence value in
   `x/sigs` extension
-- New `migration` package. Schema versioning for models and messages can be
-  implemented by relying on functionality provided by this package.
 - When considering expiration in `x/escrow` extension, expiration time is now
   inclusive
 - A new validator subjective anti-spam fee was added
-
-Breaking changes
-
-- Many extensions where updated to provide `weave.Metadata` and support schema
-  versioning as implemeneted by `migrations` package. Updated extensions are:
-  x/cash`, `x/currency`, `x/distribution`, `x/escrow`, `x/msgfee`,
-  `x/multisig`, `x/namecoin`, `x/nft`, `x/paychan`, `x/sigs`, `x/validators`
 
 
 ## 0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,19 +38,13 @@ Breaking changes
   `weavetest/assert` contains test helpers
 - Simplify transaction message unpacking with weave.LoadMsg
 - Initial version of governance model
-- crypto package improvements #495
-- Weave documentation : References to IOV-CORE examples need removing #464
+- Crypto package improvements #495
 - Reduce timeout resolution in client/backend interface #447
 - Move timeout point to expired state (for atomic swaps) #446
 - Simplify validation logic in Handlers #437
 - Charge gas in x/sigs #429
 - New bump sequence Tx #388
 - Anti-spam fee changes    
-  
-Breaking changes  
-  
-- Move Memo and ChainID to top level Tx codec #435
-
 
 ## 0.13.0
 


### PR DESCRIPTION
I have manually edited and rewritten latest entries in the CHANGELOG
file. I have removed all points that were implementation specific (ie
tests) and are not important for the users.
I was trying to keep only information that is improtatnt for our users,
without going too much into implementation details.