### PR TITLE
migration: provide schema migrating registry decorator

### DIFF
--- a/x/aswap/handler.go
+++ b/x/aswap/handler.go
@@ -25,11 +25,12 @@ const (
 // RegisterRoutes will instantiate and register
 // all handlers in this package
 func RegisterRoutes(r weave.Registry, auth x.Authenticator, cashctrl cash.Controller) {
+	r = migration.SchemaMigratingRegistry("aswap", r)
 	bucket := NewBucket()
 
-	r.Handle(pathCreateSwap, migration.SchemaMigratingHandler("aswap", CreateSwapHandler{auth, bucket, cashctrl}))
-	r.Handle(pathReleaseSwap, migration.SchemaMigratingHandler("aswap", ReleaseSwapHandler{auth, bucket, cashctrl}))
-	r.Handle(pathReturnReturn, migration.SchemaMigratingHandler("aswap", ReturnSwapHandler{auth, bucket, cashctrl}))
+	r.Handle(pathCreateSwap, CreateSwapHandler{auth, bucket, cashctrl})
+	r.Handle(pathReleaseSwap, ReleaseSwapHandler{auth, bucket, cashctrl})
+	r.Handle(pathReturnReturn, ReturnSwapHandler{auth, bucket, cashctrl})
 }
 
 // RegisterQuery will register this bucket as "/aswaps"

--- a/x/cash/handler.go
+++ b/x/cash/handler.go
@@ -11,10 +11,10 @@ import (
 // RegisterRoutes will instantiate and register
 // all handlers in this package
 func RegisterRoutes(r weave.Registry, auth x.Authenticator, control Controller) {
-	r.Handle(pathSendMsg, migration.SchemaMigratingHandler("cash",
-		NewSendHandler(auth, control)))
-	r.Handle(pathConfigurationUpdateMsg, migration.SchemaMigratingHandler("cash",
-		NewConfigHandler(auth)))
+	r = migration.SchemaMigratingRegistry("cash", r)
+
+	r.Handle(pathSendMsg, NewSendHandler(auth, control))
+	r.Handle(pathConfigurationUpdateMsg, NewConfigHandler(auth))
 }
 
 // RegisterQuery will register this bucket as "/wallets"

--- a/x/currency/handler.go
+++ b/x/currency/handler.go
@@ -14,7 +14,9 @@ func RegisterQuery(qr weave.QueryRouter) {
 }
 
 func RegisterRoutes(r weave.Registry, auth x.Authenticator, issuer weave.Address) {
-	r.Handle(NewTokenInfoMsg{}.Path(), migration.SchemaMigratingHandler("currency", NewTokenInfoHandler(auth, issuer)))
+	r = migration.SchemaMigratingRegistry("currency", r)
+
+	r.Handle(NewTokenInfoMsg{}.Path(), NewTokenInfoHandler(auth, issuer))
 }
 
 func NewTokenInfoHandler(auth x.Authenticator, issuer weave.Address) weave.Handler {

--- a/x/distribution/handler.go
+++ b/x/distribution/handler.go
@@ -30,25 +30,23 @@ type CashController interface {
 
 // RegisterRoutes registers handlers for feedlist message processing.
 func RegisterRoutes(r weave.Registry, auth x.Authenticator, ctrl CashController) {
+	r = migration.SchemaMigratingRegistry("distribution", r)
 	bucket := NewRevenueBucket()
-	r.Handle(pathNewRevenueMsg, migration.SchemaMigratingHandler("distribution",
-		&newRevenueHandler{
-			auth:   auth,
-			bucket: bucket,
-			ctrl:   ctrl,
-		}))
-	r.Handle(pathDistributeMsg, migration.SchemaMigratingHandler("distribution",
-		&distributeHandler{
-			auth:   auth,
-			bucket: bucket,
-			ctrl:   ctrl,
-		}))
-	r.Handle(pathResetRevenueMsg, migration.SchemaMigratingHandler("distribution",
-		&resetRevenueHandler{
-			auth:   auth,
-			bucket: bucket,
-			ctrl:   ctrl,
-		}))
+	r.Handle(pathNewRevenueMsg, &newRevenueHandler{
+		auth:   auth,
+		bucket: bucket,
+		ctrl:   ctrl,
+	})
+	r.Handle(pathDistributeMsg, &distributeHandler{
+		auth:   auth,
+		bucket: bucket,
+		ctrl:   ctrl,
+	})
+	r.Handle(pathResetRevenueMsg, &resetRevenueHandler{
+		auth:   auth,
+		bucket: bucket,
+		ctrl:   ctrl,
+	})
 }
 
 type newRevenueHandler struct {

--- a/x/escrow/handler.go
+++ b/x/escrow/handler.go
@@ -21,12 +21,13 @@ const (
 // RegisterRoutes will instantiate and register
 // all handlers in this package
 func RegisterRoutes(r weave.Registry, auth x.Authenticator, cashctrl cash.Controller) {
+	r = migration.SchemaMigratingRegistry("escrow", r)
 	bucket := NewBucket()
 
-	r.Handle(pathCreateEscrowMsg, migration.SchemaMigratingHandler("escrow", CreateEscrowHandler{auth, bucket, cashctrl}))
-	r.Handle(pathReleaseEscrowMsg, migration.SchemaMigratingHandler("escrow", ReleaseEscrowHandler{auth, bucket, cashctrl}))
-	r.Handle(pathReturnEscrowMsg, migration.SchemaMigratingHandler("escrow", ReturnEscrowHandler{auth, bucket, cashctrl}))
-	r.Handle(pathUpdateEscrowPartiesMsg, migration.SchemaMigratingHandler("escrow", UpdateEscrowHandler{auth, bucket}))
+	r.Handle(pathCreateEscrowMsg, CreateEscrowHandler{auth, bucket, cashctrl})
+	r.Handle(pathReleaseEscrowMsg, ReleaseEscrowHandler{auth, bucket, cashctrl})
+	r.Handle(pathReturnEscrowMsg, ReturnEscrowHandler{auth, bucket, cashctrl})
+	r.Handle(pathUpdateEscrowPartiesMsg, UpdateEscrowHandler{auth, bucket})
 }
 
 // RegisterQuery will register this bucket as "/escrows"

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -33,40 +33,41 @@ func RegisterQuery(qr weave.QueryRouter) {
 func RegisterRoutes(r weave.Registry, auth x.Authenticator) {
 	propBucket := NewProposalBucket()
 	elecBucket := NewElectorateBucket()
-	r.Handle(pathVoteMsg, migration.SchemaMigratingHandler(packageName, &VoteHandler{
+
+	r = migration.SchemaMigratingRegistry(packageName, r)
+	r.Handle(pathVoteMsg, &VoteHandler{
 		auth:       auth,
 		propBucket: propBucket,
 		elecBucket: elecBucket,
 		voteBucket: NewVoteBucket(),
-	}))
-	r.Handle(pathTallyMsg, migration.SchemaMigratingHandler(packageName,
-		NewTallyHandler(auth, propBucket, elecBucket)))
-	r.Handle(pathCreateTextProposalMsg, migration.SchemaMigratingHandler(packageName, &TextProposalHandler{
+	})
+	r.Handle(pathTallyMsg, NewTallyHandler(auth, propBucket, elecBucket))
+	r.Handle(pathCreateTextProposalMsg, &TextProposalHandler{
 		auth:        auth,
 		propBucket:  propBucket,
 		elecBucket:  elecBucket,
 		rulesBucket: NewElectionRulesBucket(),
-	}))
+	})
 	r.Handle(pathCreateElectorateUpdateProposalMsg, &ElectorateUpdateProposalHandler{
 		auth:        auth,
 		propBucket:  propBucket,
 		elecBucket:  elecBucket,
 		rulesBucket: NewElectionRulesBucket(),
 	})
-	r.Handle(pathDeleteTextProposalMsg, migration.SchemaMigratingHandler(packageName, &DeleteTextProposalHandler{
+	r.Handle(pathDeleteTextProposalMsg, &DeleteTextProposalHandler{
 		auth:       auth,
 		propBucket: propBucket,
-	}))
-	r.Handle(pathUpdateElectorateMsg, migration.SchemaMigratingHandler(packageName, &UpdateElectorateHandler{
+	})
+	r.Handle(pathUpdateElectorateMsg, &UpdateElectorateHandler{
 		auth:       auth,
 		propBucket: propBucket,
 		elecBucket: elecBucket,
-	}))
-	r.Handle(pathUpdateElectionRulesMsg, migration.SchemaMigratingHandler(packageName, &UpdateElectionRuleHandler{
+	})
+	r.Handle(pathUpdateElectionRulesMsg, &UpdateElectionRuleHandler{
 		auth:       auth,
 		propBucket: propBucket,
 		ruleBucket: NewElectionRulesBucket(),
-	}))
+	})
 }
 
 type VoteHandler struct {

--- a/x/multisig/handlers.go
+++ b/x/multisig/handlers.go
@@ -11,9 +11,10 @@ import (
 // RegisterRoutes will instantiate and register
 // all handlers in this package
 func RegisterRoutes(r weave.Registry, auth x.Authenticator) {
+	r = migration.SchemaMigratingRegistry("multisig", r)
 	bucket := NewContractBucket()
-	r.Handle(pathCreateContractMsg, migration.SchemaMigratingHandler("multisig", CreateContractMsgHandler{auth, bucket}))
-	r.Handle(pathUpdateContractMsg, migration.SchemaMigratingHandler("multisig", UpdateContractMsgHandler{auth, bucket}))
+	r.Handle(pathCreateContractMsg, CreateContractMsgHandler{auth, bucket})
+	r.Handle(pathUpdateContractMsg, UpdateContractMsgHandler{auth, bucket})
 }
 
 // RegisterQuery register queries from buckets in this package

--- a/x/namecoin/handler.go
+++ b/x/namecoin/handler.go
@@ -44,10 +44,11 @@ func NewSetNameHandler(auth x.Authenticator, bucket NamedBucket) weave.Handler {
 // RegisterRoutes will instantiate and register
 // all handlers in this package.
 func RegisterRoutes(r weave.Registry, auth x.Authenticator, issuer weave.Address) {
+	r = migration.SchemaMigratingRegistry("namecoin", r)
 	pathSend := cash.SendMsg{}.Path()
-	r.Handle(pathSend, migration.SchemaMigratingHandler("namecoin", NewSendHandler(auth)))
-	r.Handle(pathNewTokenMsg, migration.SchemaMigratingHandler("namecoin", NewTokenHandler(auth, issuer)))
-	r.Handle(pathSetNameMsg, migration.SchemaMigratingHandler("namecoin", NewSetNameHandler(auth, NewWalletBucket())))
+	r.Handle(pathSend, NewSendHandler(auth))
+	r.Handle(pathNewTokenMsg, NewTokenHandler(auth, issuer))
+	r.Handle(pathSetNameMsg, NewSetNameHandler(auth, NewWalletBucket()))
 }
 
 // RegisterQuery will register wallets as "/wallets"

--- a/x/paychan/handler.go
+++ b/x/paychan/handler.go
@@ -22,13 +22,15 @@ func RegisterQuery(qr weave.QueryRouter) {
 
 // RegisterRouters registers payment channel message handelers in given registry.
 func RegisterRoutes(r weave.Registry, auth x.Authenticator, cash cash.Controller) {
+	r = migration.SchemaMigratingRegistry("paychan", r)
+
 	bucket := NewPaymentChannelBucket()
-	r.Handle(pathCreatePaymentChannelMsg, migration.SchemaMigratingHandler(
-		"paychan", &createPaymentChannelHandler{auth: auth, bucket: bucket, cash: cash}))
-	r.Handle(pathTransferPaymentChannelMsg, migration.SchemaMigratingHandler(
-		"paychan", &transferPaymentChannelHandler{auth: auth, bucket: bucket, cash: cash}))
-	r.Handle(pathClosePaymentChannelMsg, migration.SchemaMigratingHandler(
-		"paychan", &closePaymentChannelHandler{auth: auth, bucket: bucket, cash: cash}))
+	r.Handle(pathCreatePaymentChannelMsg,
+		&createPaymentChannelHandler{auth: auth, bucket: bucket, cash: cash})
+	r.Handle(pathTransferPaymentChannelMsg,
+		&transferPaymentChannelHandler{auth: auth, bucket: bucket, cash: cash})
+	r.Handle(pathClosePaymentChannelMsg,
+		&closePaymentChannelHandler{auth: auth, bucket: bucket, cash: cash})
 }
 
 type createPaymentChannelHandler struct {


### PR DESCRIPTION
It is common to decorate with `SchemaMigratingHandler` all handlers before
registering. This requires quite some typing and passing everywhere the
same package argument. To simplify this process a new decorator is
introduced: `SchemaMigratingRegistry`.

The old way of registering a schema migration for a handler is:

	var r weave.Registry
	r.Handle("a", SchemaMigratingHandler("mypkg", myHandlerA)
	r.Handle("b", SchemaMigratingHandler("mypkg", myHandlerB)

The above is equivalent to the below code enabled by this change:

	r = SchemaMigratingRegistry("mypkg", r)
	r.Handle("a", myHandlerA)
	r.Handle("b", myHandlerB)