### PR TITLE
cmd/collectproto: a new tool for collecting protobuf

### DIFF
--- a/cmd/collectproto/README.md
+++ b/cmd/collectproto/README.md
@@ -1,0 +1,17 @@
+# `collectproto`
+
+Collect, combine and produce a single protobuf file with all declarations.
+
+This program reads provided protobuf declarations and:
+- removes all non standard plugin information (ie gogoproto)
+- removes all package declaration
+- removes all but one syntax declaration
+- removes all import declarations, inlines all weave protobuf imports
+
+Combined result is written to stdout.
+
+Example usage:
+```
+$ go run cmd/collectproto/collectproto.go cmd/bnsd/app/codec.proto | wc -l
+930
+```

--- a/cmd/collectproto/collectproto.go
+++ b/cmd/collectproto/collectproto.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func main() {
+	// Keep track of those file paths that were already processed to avoid
+	// including the same declaration more than once.
+	processed := make(map[string]struct{})
+
+	var out bytes.Buffer
+
+	// Syntax declaration is never rewritten. Initialize combined file with
+	// one as it is required.
+	fmt.Fprintln(&out, "syntax proto3;")
+
+	// Stack of all files that are to be processed.
+	protofiles := append([]string{}, os.Args[1:]...)
+
+	for len(protofiles) != 0 {
+		// Pop one.
+		path := protofiles[0]
+		protofiles = protofiles[1:]
+		if strings.HasPrefix(path, "github.com") {
+			if strings.HasPrefix(path, iovGitHubPrefix) {
+				path = path[len(iovGitHubPrefix):]
+			} else {
+				// Ignore all github imports that are not IOV.
+				// This is for example a gogoproto import.
+				continue
+			}
+		}
+		if _, ok := processed[path]; ok {
+			continue
+		}
+
+		fd, err := os.Open(path)
+		if err != nil {
+			fail(2, "cannot open file: %s", err)
+		}
+
+		fmt.Fprintf(&out, "\n\n// definitions from %s\n", iovGitHubPrefix+path)
+
+		imports, err := collect(fd, &out)
+		fd.Close()
+		if err != nil {
+			fail(2, "format: %s", err.Error())
+		}
+
+		for _, i := range imports {
+			if _, ok := processed[i]; !ok {
+				protofiles = append(protofiles, i)
+			}
+		}
+	}
+
+	out.WriteTo(os.Stdout)
+}
+
+const iovGitHubPrefix = "github.com/iov-one/weave/"
+
+func fail(code int, tmpl string, args ...interface{}) {
+	if !strings.HasSuffix(tmpl, "\n") {
+		tmpl += "\n"
+	}
+	fmt.Fprintf(os.Stderr, tmpl, args...)
+	os.Exit(code)
+
+}
+
+func collect(in io.Reader, out io.Writer) ([]string, error) {
+	rd := bufio.NewReader(in)
+	wr := bufio.NewWriter(out)
+	defer wr.Flush()
+
+	var imports []string
+
+	// Track the scope.
+	var (
+		// inPluginDecl is set to true if reading content between two
+		// [] brackets that defines a plugin content.
+		inPluginDecl bool
+
+		// inComment is set to true if reading content of that is a
+		// comment.
+		inComment bool
+	)
+
+	shouldWriteChar := func() bool {
+		return inComment || !inPluginDecl
+	}
+
+	// Pretend the first character read was a new line for easier parsing.
+	c := byte('\n')
+	for {
+		switch c {
+		case '\n':
+			// Comments are always single line.
+			inComment = false
+
+			// Package declarations are not rewritten.
+			if next, err := rd.Peek(8); err == nil && bytes.Equal(next, []byte("package ")) {
+				rd.ReadString('\n')
+				continue
+			}
+			// Syntax declaration are not rewritten as it should be provided only once.
+			if next, err := rd.Peek(7); err == nil && bytes.Equal(next, []byte("syntax ")) {
+				rd.ReadString('\n')
+				continue
+			}
+
+			// Import declarations are not rewritten but parsed and returned from this function.
+			if next, err := rd.Peek(7); err == nil && bytes.Equal(next, []byte("import ")) {
+				line, err := rd.ReadString(';')
+				if err != nil {
+					return nil, fmt.Errorf("cannot read import line: %s", err)
+				}
+
+				// Discard new line character to avoid empty lines.
+				if next, err := rd.Peek(1); err == nil && next[0] == '\n' {
+					_, _ = rd.ReadByte()
+				}
+
+				// Thim space, remove "import" and ";"
+				line = strings.TrimSpace(line[6 : len(line)-1])
+				if line[0] != '"' || line[len(line)-1] != '"' {
+					return nil, fmt.Errorf("unexpected import declaration line: %q", line)
+				}
+				path := line[1 : len(line)-1]
+				imports = append(imports, path)
+				continue
+			}
+
+			if shouldWriteChar() {
+				if next, err := rd.Peek(2); err == nil && next[0] == '\n' && next[1] == '\n' {
+					// Avoid double empty lines.
+				} else {
+					_ = wr.WriteByte(c)
+				}
+			}
+		case '\\':
+			if next, err := rd.Peek(1); err == nil && next[0] == '\\' {
+				// The rest of the line is a comment.
+				inComment = true
+			}
+			if shouldWriteChar() {
+				_ = wr.WriteByte(c)
+			}
+		case '[', ']':
+			if inComment {
+				_ = wr.WriteByte(c)
+			} else {
+				inPluginDecl = c == '['
+			}
+		default:
+			if shouldWriteChar() {
+				_ = wr.WriteByte(c)
+			}
+		}
+
+		var err error
+		c, err = rd.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				return imports, nil
+			}
+			return imports, fmt.Errorf("cannot read: %s", err)
+		}
+	}
+}

--- a/cmd/collectproto/collectproto.go
+++ b/cmd/collectproto/collectproto.go
@@ -18,7 +18,7 @@ func main() {
 
 	// Syntax declaration is never rewritten. Initialize combined file with
 	// one as it is required.
-	fmt.Fprintln(&out, "syntax proto3;")
+	fmt.Fprintln(&out, "syntax = proto3;")
 
 	// Stack of all files that are to be processed.
 	protofiles := append([]string{}, os.Args[1:]...)
@@ -111,6 +111,12 @@ func collect(in io.Reader, out io.Writer) ([]string, error) {
 			}
 			// Syntax declaration are not rewritten as it should be provided only once.
 			if next, err := rd.Peek(7); err == nil && bytes.Equal(next, []byte("syntax ")) {
+				rd.ReadString('\n')
+				continue
+			}
+
+			// Any options declared on the message are ignored.
+			if next, err := rd.Peek(12); err == nil && bytes.HasPrefix(bytes.TrimLeft(next, " \t"), []byte("option")) {
 				rd.ReadString('\n')
 				continue
 			}

--- a/cmd/collectproto/collectproto.go
+++ b/cmd/collectproto/collectproto.go
@@ -18,7 +18,7 @@ func main() {
 
 	// Syntax declaration is never rewritten. Initialize combined file with
 	// one as it is required.
-	fmt.Fprintln(&out, "syntax = proto3;")
+	fmt.Fprintln(&out, `syntax = "proto3";`)
 
 	// Stack of all files that are to be processed.
 	protofiles := append([]string{}, os.Args[1:]...)

--- a/cmd/collectproto/collectproto_test.go
+++ b/cmd/collectproto/collectproto_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFormat(t *testing.T) {
+	const proto = `
+// This is an example protobuf file.
+package foobar;
+
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "github.com/iov-one/weave/cmd/bnsd/x/nft/username/codec.proto";
+import "github.com/iov-one/weave/migration/codec.proto";
+import "github.com/iov-one/weave/x/cash/codec.proto";
+
+// SendMsg is a request to move these coins from the given
+// source to the given destination address.
+// memo is an optional human-readable message
+// ref is optional binary data, that can refer to another
+// eg. tx hash
+message SendMsg {
+  weave.Metadata metadata = 1;
+  bytes src = 2 [
+  	(gogoproto.casttype) = "github.com/iov-one/weave.Address"
+  	(gogoproto.customname) = "Source"
+  ];
+  bytes dest = 3 [
+     (gogoproto.casttype)
+
+     =
+
+     "github.com/iov-one/weave.Address"];
+  coin.Coin amount = 4;
+  // max length 128 character
+  string memo = 5;
+  // max length 64 bytes
+  bytes ref = 6;
+}
+	`
+	var out bytes.Buffer
+	imports, err := collect(strings.NewReader(proto), &out)
+	if err != nil {
+		t.Fatalf("format failed: %s", err)
+	}
+
+	const wantDecl = `
+// This is an example protobuf file.
+
+
+// SendMsg is a request to move these coins from the given
+// source to the given destination address.
+// memo is an optional human-readable message
+// ref is optional binary data, that can refer to another
+// eg. tx hash
+message SendMsg {
+  weave.Metadata metadata = 1;
+  bytes src = 2 ;
+  bytes dest = 3 ;
+  coin.Coin amount = 4;
+  // max length 128 character
+  string memo = 5;
+  // max length 64 bytes
+  bytes ref = 6;
+}
+	`
+	if gotDecl := out.String(); gotDecl != wantDecl {
+		t.Logf("want: \n%s", wantDecl)
+		t.Logf("got: \n%s", gotDecl)
+		t.Errorf("unexpected declaration resultresult")
+	}
+
+	wantImports := []string{
+		"github.com/gogo/protobuf/gogoproto/gogo.proto",
+		"github.com/iov-one/weave/cmd/bnsd/x/nft/username/codec.proto",
+		"github.com/iov-one/weave/migration/codec.proto",
+		"github.com/iov-one/weave/x/cash/codec.proto",
+	}
+	if !reflect.DeepEqual(imports, wantImports) {
+		t.Errorf("got imports: %q", imports)
+	}
+
+}

--- a/cmd/collectproto/collectproto_test.go
+++ b/cmd/collectproto/collectproto_test.go
@@ -48,6 +48,7 @@ message SendMsg {
 	}
 
 	const wantDecl = `
+
 // This is an example protobuf file.
 
 


### PR DESCRIPTION
A new command line tool for collecting all protobuf declarations was
added.

fix https://github.com/iov-one/weave/issues/618

---

From the `README.md`:

Collect, combine and produce a single protobuf file with all declarations.

This program reads provided protobuf declarations and:
- removes all non standard plugin information (ie gogoproto)
- removes all package declaration
- removes all but one syntax declaration
- removes all import declarations, inlines all weave protobuf imports

The combined result is written to stdout.

Example usage:
```
$ go run cmd/collectproto/collectproto.go cmd/bnsd/app/codec.proto | wc -l
930
```

Please let me know if the output is as expected.