### PR TITLE
cmd/cleanproto: a new tool for cleaning protobuf

### DIFF
--- a/cmd/cleanproto/.gitignore
+++ b/cmd/cleanproto/.gitignore
@@ -1,0 +1,1 @@
+cleanproto

--- a/cmd/cleanproto/Makefile
+++ b/cmd/cleanproto/Makefile
@@ -1,6 +1,6 @@
-build: cleanproto
+.PHONY: build test
 
-cleanproto:
+build:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o cleanproto .
 
 test:

--- a/cmd/cleanproto/Makefile
+++ b/cmd/cleanproto/Makefile
@@ -1,0 +1,8 @@
+build: cleanproto
+
+cleanproto:
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o cleanproto .
+
+test:
+	go test . -v -race
+	./tests/test.sh

--- a/cmd/cleanproto/README.md
+++ b/cmd/cleanproto/README.md
@@ -1,0 +1,13 @@
+# `cleanproto`
+
+Clean a protobuf file from all non standard declarations, for example
+[gogoproto options](https://godoc.org/github.com/gogo/protobuf/gogoproto).
+
+
+Protobuf declaration is read from `stdin`. Result is written to `stdout`.
+
+Example usage:
+```
+$ go run cmd/cleanproto/cleanproto.go < cmd/bnsd/app/codec.proto | wc -l
+930
+```

--- a/cmd/cleanproto/cleanproto.go
+++ b/cmd/cleanproto/cleanproto.go
@@ -64,7 +64,7 @@ func cleanup(in io.Reader, out io.Writer) error {
 			// Comments are always single line.
 			inComment = false
 
-			if inComment || !inPluginDecl {
+			if !inPluginDecl {
 				if next, err := rd.Peek(2); err == nil && next[0] == '\n' && next[1] == '\n' {
 					// Avoid double empty lines.
 				} else {

--- a/cmd/cleanproto/cleanproto.go
+++ b/cmd/cleanproto/cleanproto.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), `Remove non standard declarations from a protobuf file. Usage:
+	%s < MYFILE.proto > CLEAN.proto
+Where MYFILE is the original protobuf file that should be cleaned.
+`, os.Args[0])
+	}
+	flag.Parse()
+	var out bytes.Buffer
+	if err := cleanup(os.Stdin, &out); err != nil {
+		fail(1, err.Error())
+	}
+	out.WriteTo(os.Stdout)
+}
+
+func fail(code int, tmpl string, args ...interface{}) {
+	if !strings.HasSuffix(tmpl, "\n") {
+		tmpl += "\n"
+	}
+	fmt.Fprintf(os.Stderr, tmpl, args...)
+	os.Exit(code)
+
+}
+
+func cleanup(in io.Reader, out io.Writer) error {
+	rd := bufio.NewReader(in)
+	wr := bufio.NewWriter(out)
+	defer wr.Flush()
+
+	// Track the scope.
+	var (
+		// inPluginDecl is set to true if reading content between two
+		// [] brackets that defines a plugin content.
+		inPluginDecl bool
+
+		// inComment is set to true if reading content of that is a
+		// comment.
+		inComment bool
+	)
+
+	for {
+		c, err := rd.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("cannot read: %s", err)
+		}
+
+		switch c {
+		case '\n':
+			// Comments are always single line.
+			inComment = false
+
+			// Any options declared on the message are ignored.
+			if next, err := rd.Peek(12); err == nil && bytes.HasPrefix(bytes.TrimLeft(next, " \t"), []byte("option")) {
+				rd.ReadString(';')
+				continue
+			}
+
+			if inComment || !inPluginDecl {
+				if next, err := rd.Peek(2); err == nil && next[0] == '\n' && next[1] == '\n' {
+					// Avoid double empty lines.
+				} else {
+					_ = wr.WriteByte(c)
+				}
+			}
+		case '\\':
+			if next, err := rd.Peek(1); err == nil && next[0] == '\\' {
+				// The rest of the line is a comment.
+				inComment = true
+			}
+			if inComment || !inPluginDecl {
+				_ = wr.WriteByte(c)
+			}
+		case '[', ']':
+			if inComment {
+				_ = wr.WriteByte(c)
+			} else {
+				inPluginDecl = c == '['
+			}
+		default:
+			if inComment || !inPluginDecl {
+				_ = wr.WriteByte(c)
+			}
+		}
+	}
+}

--- a/cmd/cleanproto/cleanproto_test.go
+++ b/cmd/cleanproto/cleanproto_test.go
@@ -11,8 +11,11 @@ func TestFormat(t *testing.T) {
 // This is an example protobuf file.
 package foobar;
 
+import "github.com/iov-one/weave/x/paychan/codec.proto";
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 import "github.com/iov-one/weave/cmd/bnsd/x/nft/username/codec.proto";
+
+option go_package = "foobar";
 
 // SendMsg is a request to move these coins from the given
 // source to the given destination address.
@@ -49,7 +52,7 @@ message SendMsg {
 // This is an example protobuf file.
 package foobar;
 
-import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "github.com/iov-one/weave/x/paychan/codec.proto";
 import "github.com/iov-one/weave/cmd/bnsd/x/nft/username/codec.proto";
 
 // SendMsg is a request to move these coins from the given

--- a/cmd/cleanproto/cleanproto_test.go
+++ b/cmd/cleanproto/cleanproto_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestFormat(t *testing.T) {
+	const proto = `
+// This is an example protobuf file.
+package foobar;
+
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "github.com/iov-one/weave/cmd/bnsd/x/nft/username/codec.proto";
+
+// SendMsg is a request to move these coins from the given
+// source to the given destination address.
+// memo is an optional human-readable message
+// ref is optional binary data, that can refer to another
+// eg. tx hash
+message SendMsg {
+  option (gogoproto.goproto_stringer) = false;
+  weave.Metadata metadata = 1;
+  bytes src = 2 [
+  	(gogoproto.casttype) = "github.com/iov-one/weave.Address"
+  	(gogoproto.customname) = "Source"
+  ];
+  bytes dest = 3 [
+     (gogoproto.casttype)
+
+     =
+
+     "github.com/iov-one/weave.Address"];
+  coin.Coin amount = 4;
+  // max length 128 character
+  string memo = 5;
+  // max length 64 bytes
+  bytes ref = 6;
+}
+	`
+	var out bytes.Buffer
+	err := cleanup(strings.NewReader(proto), &out)
+	if err != nil {
+		t.Fatalf("cleanup failed: %s", err)
+	}
+
+	const wantDecl = `
+// This is an example protobuf file.
+package foobar;
+
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "github.com/iov-one/weave/cmd/bnsd/x/nft/username/codec.proto";
+
+// SendMsg is a request to move these coins from the given
+// source to the given destination address.
+// memo is an optional human-readable message
+// ref is optional binary data, that can refer to another
+// eg. tx hash
+message SendMsg {
+  weave.Metadata metadata = 1;
+  bytes src = 2 ;
+  bytes dest = 3 ;
+  coin.Coin amount = 4;
+  // max length 128 character
+  string memo = 5;
+  // max length 64 bytes
+  bytes ref = 6;
+}
+	`
+	if gotDecl := out.String(); gotDecl != wantDecl {
+		t.Logf("want: \n%s", wantDecl)
+		t.Logf("got: \n%s", gotDecl)
+		t.Errorf("unexpected declaration resultresult")
+	}
+}

--- a/cmd/cleanproto/tests/codec.proto
+++ b/cmd/cleanproto/tests/codec.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package coin;
+
+import "github.com/iov-one/weave/codec.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+
+// Coin can hold any amount between -1 billion and +1 billion
+// at steps of 10^-9. It is a fixed-point decimal
+// representation and uses integers to avoid rounding
+// associated with floats.
+//
+// Every code has a denomination, which is just a
+//
+// If you want anything more complex, you should write your
+// own type, possibly borrowing from this code.
+message Coin {
+  option (gogoproto.goproto_stringer) = false;
+  // Whole coins, -10^15 < integer < 10^15
+  int64 whole = 1;
+  // Billionth of coins. 0 <= abs(fractional) < 10^9
+  // If fractional != 0, must have same sign as integer
+  int64 fractional = 2;
+  // Ticker is 3-4 upper-case letters and
+  // all Coins of the same currency can be combined
+  string ticker = 3;
+}
+
+// SendMsg is a request to move these coins from the given
+// source to the given destination address.
+// memo is an optional human-readable message
+// ref is optional binary data, that can refer to another
+// eg. tx hash
+message SendMsg {
+  weave.Metadata metadata = 1;
+  bytes src = 2 [
+	  (gogoproto.casttype) = "github.com/iov-one/weave.Address"
+	  (gogoproto.customname) = "Source"
+  ];
+  bytes dest = 3 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
+  coin.Coin amount = 4;
+  // max length 128 character
+  string memo = 5;
+  // max length 64 bytes
+  bytes ref = 6;
+}

--- a/cmd/cleanproto/tests/codec.proto
+++ b/cmd/cleanproto/tests/codec.proto
@@ -34,7 +34,7 @@ message Coin {
 message SendMsg {
   weave.Metadata metadata = 1;
   bytes src = 2 [
-	  (gogoproto.casttype) = "github.com/iov-one/weave.Address"
+	  (gogoproto.casttype) = "github.com/iov-one/weave.Address",
 	  (gogoproto.customname) = "Source"
   ];
   bytes dest = 3 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];

--- a/cmd/cleanproto/tests/codec.proto
+++ b/cmd/cleanproto/tests/codec.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package coin;
 
-import "github.com/iov-one/weave/codec.proto";
-import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "codec.proto";
+import "gogoproto/gogo.proto";
 
 // Coin can hold any amount between -1 billion and +1 billion
 // at steps of 10^-9. It is a fixed-point decimal

--- a/cmd/cleanproto/tests/codec.proto.gold
+++ b/cmd/cleanproto/tests/codec.proto.gold
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package coin;
 
-import "github.com/iov-one/weave/codec.proto";
+import "codec.proto";
 
 // Coin can hold any amount between -1 billion and +1 billion
 // at steps of 10^-9. It is a fixed-point decimal

--- a/cmd/cleanproto/tests/codec.proto.gold
+++ b/cmd/cleanproto/tests/codec.proto.gold
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package coin;
+
+import "github.com/iov-one/weave/codec.proto";
+
+// Coin can hold any amount between -1 billion and +1 billion
+// at steps of 10^-9. It is a fixed-point decimal
+// representation and uses integers to avoid rounding
+// associated with floats.
+//
+// Every code has a denomination, which is just a
+//
+// If you want anything more complex, you should write your
+// own type, possibly borrowing from this code.
+message Coin {
+  // Whole coins, -10^15 < integer < 10^15
+  int64 whole = 1;
+  // Billionth of coins. 0 <= abs(fractional) < 10^9
+  // If fractional != 0, must have same sign as integer
+  int64 fractional = 2;
+  // Ticker is 3-4 upper-case letters and
+  // all Coins of the same currency can be combined
+  string ticker = 3;
+}
+
+// SendMsg is a request to move these coins from the given
+// source to the given destination address.
+// memo is an optional human-readable message
+// ref is optional binary data, that can refer to another
+// eg. tx hash
+message SendMsg {
+  weave.Metadata metadata = 1;
+  bytes src = 2 ;
+  bytes dest = 3 ;
+  coin.Coin amount = 4;
+  // max length 128 character
+  string memo = 5;
+  // max length 64 bytes
+  bytes ref = 6;
+}

--- a/cmd/cleanproto/tests/test.sh
+++ b/cmd/cleanproto/tests/test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+cd $(dirname $(dirname "$0"))
+
+make build
+dest=`tempfile`
+./cleanproto < tests/codec.proto > $dest
+result=`diff tests/codec.proto.gold $dest`
+exit $result


### PR DESCRIPTION
A new command line tool for coleaning a protobuf file from a non
standard declarations, for example [gogoproto
options](https://godoc.org/github.com/gogo/protobuf/gogoproto).

Protobuf declaration is read from `stdin`. Result is written to `stdout`.

Example usage:
```
$ go run cmd/cleanproto/cleanproto.go < cmd/bnsd/app/codec.proto | wc -l
930
```

This is successor of https://github.com/iov-one/weave/pull/659 

fix #618


- [x] remove all plugin options declared for an attribute (content between `[..]`)
- [x] remove all plugin options declared per message
- [x] remove `go_module` option
- [x] remove gogo/protobuf import lines