### PR TITLE
weave: add InThePast and InTheFuture functions

### DIFF
--- a/app/store.go
+++ b/app/store.go
@@ -333,10 +333,13 @@ func (s *StoreApp) BeginBlock(req abci.RequestBeginBlock) (res abci.ResponseBegi
 	// set the begin block context
 	ctx := weave.WithHeader(s.baseContext, req.Header)
 	ctx = weave.WithHeight(ctx, req.Header.GetHeight())
-	ctx = weave.WithBlockTime(ctx, req.Header.GetTime())
+	now := req.Header.GetTime()
+	if now.IsZero() {
+		panic("current time not found in the block header")
+	}
+	ctx = weave.WithBlockTime(ctx, now)
 	s.blockContext = ctx
-
-	return
+	return res
 }
 
 // EndBlock - ABCI

--- a/cmd/bnsd/app/app_test.go
+++ b/cmd/bnsd/app/app_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/iov-one/weave"
 	weaveApp "github.com/iov-one/weave/app"
@@ -334,7 +335,10 @@ func signAndCommit(
 	require.NotEmpty(t, txBytes)
 
 	// Submit to the chain
-	header := abci.Header{Height: height}
+	header := abci.Header{
+		Height: height,
+		Time:   time.Now(),
+	}
 	app.BeginBlock(abci.RequestBeginBlock{Header: header})
 	// check and deliver must pass
 	chres := app.CheckTx(txBytes)

--- a/cmd/bnsd/app/testdata/fixtures/app.go
+++ b/cmd/bnsd/app/testdata/fixtures/app.go
@@ -53,7 +53,10 @@ func (f AppFixture) Build() abci.Application {
 		AppStateBytes: appStateGenesis(f.GenesisKeyAddress),
 		ChainId:       f.ChainID,
 	})
-	header := abci.Header{Height: 1}
+	header := abci.Header{
+		Height: 1,
+		Time:   time.Now(),
+	}
 	myApp.BeginBlock(abci.RequestBeginBlock{Header: header})
 	myApp.EndBlock(abci.RequestEndBlock{})
 	cres := myApp.Commit()

--- a/examples/mycoind/app/app_test.go
+++ b/examples/mycoind/app/app_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/app"
@@ -90,7 +91,10 @@ func fromHex(t testing.TB, s string) weave.Address {
 // testCommit will commit at height h and return new hash
 func testCommit(t *testing.T, myApp app.BaseApp, h int64) []byte {
 	// Commit first block, make sure non-nil hash
-	header := abci.Header{Height: h}
+	header := abci.Header{
+		Height: h,
+		Time:   time.Now(),
+	}
 	myApp.BeginBlock(abci.RequestBeginBlock{Header: header})
 	myApp.EndBlock(abci.RequestEndBlock{})
 	cres := myApp.Commit()
@@ -144,7 +148,10 @@ func testSendTx(t *testing.T, myApp app.BaseApp, h int64,
 	require.NotEmpty(t, txBytes)
 
 	// Submit to the chain
-	header := abci.Header{Height: h}
+	header := abci.Header{
+		Height: h,
+		Time:   time.Now(),
+	}
 	myApp.BeginBlock(abci.RequestBeginBlock{Header: header})
 	// check and deliver must pass
 	chres := myApp.CheckTx(txBytes)

--- a/time.go
+++ b/time.go
@@ -1,6 +1,7 @@
 package weave
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -101,11 +102,43 @@ func (t UnixTime) String() string {
 // must never happen. The panic is here to prevent from broken setup to be
 // processing data incorrectly.
 func IsExpired(ctx Context, t UnixTime) bool {
-	blockNow, ok := BlockTime(ctx)
-	if !ok {
-		panic("block time is not present")
+	blockNow, err := BlockTime(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("%+v", err))
 	}
 	return t <= AsUnixTime(blockNow)
+}
+
+// InThePast returns true if given time is in the past compared to the current
+// time as declared in the context. Context "now" should come from the block
+// header.
+// Keep in mind that this function is not inclusive of current time. It given
+// time is equal to "now" then this function returns false.
+// This function panic if the block time is not provided in the context. This
+// must never happen. The panic is here to prevent from broken setup to be
+// processing data incorrectly.
+func InThePast(ctx context.Context, t time.Time) bool {
+	now, err := BlockTime(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("%+v", err))
+	}
+	return t.Before(now)
+}
+
+// InTheFuture returns true if given time is in the future compared to the
+// current time as declared in the context. Context "now" should come from the
+// block header.
+// Keep in mind that this function is not inclusive of current time. It given
+// time is equal to "now" then this function returns false.
+// This function panic if the block time is not provided in the context. This
+// must never happen. The panic is here to prevent from broken setup to be
+// processing data incorrectly.
+func InTheFuture(ctx context.Context, t time.Time) bool {
+	now, err := BlockTime(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("%+v", err))
+	}
+	return t.After(now)
 }
 
 // UnixDuration represents a time duration with granularity of a second. This

--- a/time_test.go
+++ b/time_test.go
@@ -200,3 +200,37 @@ func TestUnixDurationJSONUnmarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestInThePast(t *testing.T) {
+	now := time.Now()
+	ctx := WithBlockTime(context.Background(), now)
+
+	assert.Equal(t, false, InThePast(ctx, now))
+	assert.Equal(t, false, InThePast(ctx, now.Add(time.Second)))
+	assert.Equal(t, true, InThePast(ctx, now.Add(-time.Second)))
+}
+
+func TestInThePastRequiresBlockTime(t *testing.T) {
+	assert.Panics(t, func() {
+		// Calling isExpected with a context without a block height
+		// attached is expected to panic.
+		InThePast(context.Background(), time.Now())
+	})
+}
+
+func TestInTheFuture(t *testing.T) {
+	now := time.Now()
+	ctx := WithBlockTime(context.Background(), now)
+
+	assert.Equal(t, false, InTheFuture(ctx, now))
+	assert.Equal(t, true, InTheFuture(ctx, now.Add(time.Second)))
+	assert.Equal(t, false, InTheFuture(ctx, now.Add(-time.Second)))
+}
+
+func TestInTheFutureRequiresBlockTime(t *testing.T) {
+	assert.Panics(t, func() {
+		// Calling isExpected with a context without a block height
+		// attached is expected to panic.
+		InTheFuture(context.Background(), time.Now())
+	})
+}


### PR DESCRIPTION
Add two new functions for comparing given time to "now" from the
context.

Use `weave.InThePast` and `weave.InTheFuture` instead of manually
comparing time with the result of `weave.BlockTime`.

`weave.BlockTime` notation was changed to return `error` instead of
`bool` as a second argument. This should signal that the second argument
must not be ignored.
`BlockTime` function use was almost completely replaced with two new
functions.


This is not implemented as described in #582 I think this solution is better as I often have time with comparing dates and using `After` and `Before` methods especially when combined with a time delta. I think having `InTheFuture` and `InThePast` makes it a bit easier to use.

#trivial

resolve #582