### PR TITLE
x/gov: restrict who can create a proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+- Creation of a new proposal in `x/gov` extension is now restricted to only
+  members of the electorate that this proposal is created for.
 - Cleanup escrow: removed the support for atomic swap
 - A new bucket implementation `orm.ModelBucket` was added that provides an
   easier to use interface when dealing with a single entity type.

--- a/x/gov/codec.proto
+++ b/x/gov/codec.proto
@@ -34,11 +34,11 @@ message Elector {
 // Election Rule defines how an election is run. A proposal must be voted upon via a pre-defined ruleset.
 message ElectionRule {
   weave.Metadata metadata = 1;
-  // Document version
+  // Document version.
   uint32 version = 2;
-  // Admin is the address that is allowed ot modify an existing election rule.
+  // Admin is the address that is allowed to modify an existing election rule.
   bytes admin = 3 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
-  // ElectorateID references the electorate using this rule (without version, as changing electorate changes the rule)
+  // ElectorateID references the electorate using this rule (without version, as changing electorate changes the rule).
   bytes electorate_id = 4 [(gogoproto.customname) = "ElectorateID"];
   // Human readable title.
   string title = 5;

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -363,6 +363,20 @@ func (h CreateProposalHandler) validate(ctx weave.Context, db weave.KVStore, tx 
 		return nil, nil, nil, errors.Wrap(err, "electorate")
 	}
 
+	// A proposal can be created only by a person that belongs to the
+	// electorats group. At least one signature must be present in order to
+	// be authorized to create a new proposal.
+	authorized := false
+	for _, e := range elect.Electors {
+		if h.auth.HasAddress(ctx, e.Address) {
+			authorized = true
+			break
+		}
+	}
+	if !authorized {
+		return nil, nil, nil, errors.Wrap(errors.ErrUnauthorized, "proposal creation must be signed by at least one of the electors")
+	}
+
 	author := base.Author
 	if author != nil {
 		if !h.auth.HasAddress(ctx, author) {

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -363,8 +363,8 @@ func (h CreateProposalHandler) validate(ctx weave.Context, db weave.KVStore, tx 
 		return nil, nil, nil, errors.Wrap(err, "electorate")
 	}
 
-	// A proposal can be created only by a person that belongs to the
-	// electorats group. At least one signature must be present in order to
+	// A proposal can be created only by an entity that belongs to the
+	// electorate group. At least one signature must be present in order to
 	// be authorized to create a new proposal.
 	authorized := false
 	for _, e := range elect.Electors {


### PR DESCRIPTION
An electorate creation message must be signed by at least one of the
electorate members that this proposal is created for. In other words,
only those who are allowed to vote can approve a proposal creation.

I did not introduce `proposers_id` as I think this is exactly what `electorate_id` is.

resolve #670