### PR TITLE
Rework abci error serialization with multiErr

### DIFF
--- a/abci.go
+++ b/abci.go
@@ -120,7 +120,6 @@ type TickResult struct {
 // as much info as possible.
 // When in debug mode always the full error information is returned.
 func DeliverTxError(err error, debug bool) abci.ResponseDeliverTx {
-	err = errors.Redact(err, debug)
 	code, log := errors.ABCIInfo(err, debug)
 	if code != errors.SuccessABCICode {
 		log = fmt.Sprintf("cannot deliver tx: %s", log)
@@ -135,7 +134,6 @@ func DeliverTxError(err error, debug bool) abci.ResponseDeliverTx {
 // much info as possible.
 // When in debug mode always the full error information is returned.
 func CheckTxError(err error, debug bool) abci.ResponseCheckTx {
-	err = errors.Redact(err, debug)
 	code, log := errors.ABCIInfo(err, debug)
 	if code != errors.SuccessABCICode {
 		log = fmt.Sprintf("cannot check tx: %s", log)

--- a/errors/abci.go
+++ b/errors/abci.go
@@ -50,7 +50,7 @@ func debugErrEncoder(err error) string {
 	return fmt.Sprintf("%+v", err)
 }
 
-// The debugErrEncoder applies Redact on the error before encoding it with its internal error message.
+// The defaultErrEncoder applies Redact on the error before encoding it with its internal error message.
 func defaultErrEncoder(err error) string {
 	return Redact(err).Error()
 }

--- a/errors/abci.go
+++ b/errors/abci.go
@@ -30,25 +30,40 @@ func ABCIInfo(err error, debug bool) (uint32, string) {
 		return SuccessABCICode, ""
 	}
 
-	// Only non-internal errors information can be exposed. Any error that
-	// does not explicitly expose its state by providing and ABCI error
-	// code must be silenced.
-	if code := abciCode(err); code != internalABCICode {
-		if debug {
-			// Try to trigger full information formatting. This
-			// might produce a stacktrace.
-			return code, fmt.Sprintf("%+v", err)
-		}
-		return code, err.Error()
-	}
-
+	encode := defaultErrEncoder
 	if debug {
-		return internalABCICode, fmt.Sprintf("%+v", err)
+		encode = debugErrEncoder
+	}
+	code := abciCode(err)
+	if code == multiErrCode {
+		encode = multiErrEncoder(encode)
 	}
 
-	// For internal errors hide the original error message and return
-	// generic data.
-	return internalABCICode, internalABCILog
+	return code, encode(err)
+}
+
+// The errEncoder converts an error into a string string representation
+type errEncoder func(error) string
+
+// The debugErrEncoder encodes the error with a stacktrace.
+func debugErrEncoder(err error) string {
+	return fmt.Sprintf("%+v", err)
+}
+
+// The debugErrEncoder applies Redact on the error before encoding it with its internal error message.
+func defaultErrEncoder(err error) string {
+	return Redact(err).Error()
+}
+
+// The multiErrEncoder wraps an encoder with support for multiErr type
+func multiErrEncoder(enc errEncoder) errEncoder {
+	return func(err error) string {
+		mErr, ok := err.(multiErr)
+		if !ok {
+			return enc(err)
+		}
+		return serializeMultiErr(mErr, enc)
+	}
 }
 
 type coder interface {
@@ -95,12 +110,7 @@ func errIsNil(err error) bool {
 // generic internal error instance. This function is supposed to hide
 // implementation details errors and leave only those that weave framework
 // originates.
-//
-// This is a no-operation function when running in debug mode.
-func Redact(err error, debug bool) error {
-	if debug {
-		return err
-	}
+func Redact(err error) error {
 	if ErrPanic.Is(err) {
 		return errors.New(internalABCILog)
 	}

--- a/errors/abci_test.go
+++ b/errors/abci_test.go
@@ -1,10 +1,13 @@
 package errors
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestABCInfo(t *testing.T) {
@@ -156,34 +159,79 @@ func TestABCIInfoHidesStacktrace(t *testing.T) {
 }
 
 func TestRedact(t *testing.T) {
-	if err := Redact(ErrPanic, false); ErrPanic.Is(err) {
-		t.Error("in non-debug mode, redact must not pass through panic error")
+	if err := Redact(ErrPanic); ErrPanic.Is(err) {
+		t.Error("reduct must not pass through panic error")
 	}
-	if err := Redact(ErrPanic, true); !ErrPanic.Is(err) {
-		t.Error("in debug mode, redact should pass through panic error")
-	}
-
-	if err := Redact(ErrNotFound, true); !ErrNotFound.Is(err) {
-		t.Error("in debug mode, redact should pass through weave error")
-	}
-	if err := Redact(ErrNotFound, false); !ErrNotFound.Is(err) {
-		t.Error("in non-debug mode, redact should pass through weave error")
+	if err := Redact(ErrNotFound); !ErrNotFound.Is(err) {
+		t.Error("reduct should pass through weave error")
 	}
 
 	var cerr customErr
-	if err := Redact(cerr, true); err != cerr {
-		t.Error("in debug mode, redact should pass through ABCI code error")
-	}
-	if err := Redact(cerr, false); err != cerr {
-		t.Error("in non-debug mode, redact should pass through ABCI code error")
+	if err := Redact(cerr); err != cerr {
+		t.Error("reduct should pass through ABCI code error")
 	}
 
 	serr := fmt.Errorf("stdlib error")
-	if err := Redact(serr, false); err == serr {
-		t.Error("in non-debug mode, redact must not pass through a stdlib error")
+	if err := Redact(serr); err == serr {
+		t.Error("reduct must not pass through a stdlib error")
 	}
-	if err := Redact(serr, true); err != serr {
-		t.Error("in debug mode, redact should pass through a stdlib error")
+}
+
+func TestABCIInfoSerializeErr(t *testing.T) {
+	var (
+		// create errors with stacktrace for equal comparision
+		myErrState          = errors.WithStack(ErrState)
+		myErrMsg            = errors.WithStack(ErrMsg)
+		myPanic             = errors.WithStack(ErrPanic)
+		myErrStateSTJson, _ = json.Marshal(fmt.Sprintf("%+v", myErrState))
+		myErrMsgSTJson, _   = json.Marshal(fmt.Sprintf("%+v", myErrMsg))
+	)
+
+	specs := map[string]struct {
+		src   error
+		debug bool
+		exp   string
+	}{
+		"single error": {
+			src:   myErrMsg,
+			debug: false,
+			exp:   "invalid message",
+		},
+		"single error with debug": {
+			src:   myErrMsg,
+			debug: true,
+			exp:   fmt.Sprintf("%+v", myErrMsg),
+		},
+		"multiErr default encoder": {
+			src: Append(myErrMsg, myErrState),
+			exp: `{"data":[{"code":4,"log":"invalid message"},{"code":10,"log":"invalid state"}]}`,
+		},
+		"multiErr default with internal": {
+			src: Append(myErrMsg, myPanic),
+			exp: `{"data":[{"code":4,"log":"invalid message"},{"code":111222,"log":"internal error"}]}`,
+		},
+		"multiErr debug": {
+			src:   Append(myErrMsg, myErrState),
+			debug: true,
+			exp:   fmt.Sprintf(`{"data":[{"code":4,"log":%s},{"code":10,"log":%s}]}`, string(myErrMsgSTJson), string(myErrStateSTJson)),
+		},
+		"redact in default encoder": {
+			src: myPanic,
+			exp: internalABCILog,
+		},
+		"do not redact in debug encoder": {
+			src:   myPanic,
+			debug: true,
+			exp:   fmt.Sprintf("%+v", myPanic),
+		},
+	}
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			_, log := ABCIInfo(spec.src, spec.debug)
+			if exp, got := spec.exp, log; exp != got {
+				t.Errorf("expected %v but got %v", exp, got)
+			}
+		})
 	}
 }
 

--- a/errors/abci_test.go
+++ b/errors/abci_test.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"strings"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 func TestABCInfo(t *testing.T) {
@@ -180,9 +178,9 @@ func TestRedact(t *testing.T) {
 func TestABCIInfoSerializeErr(t *testing.T) {
 	var (
 		// create errors with stacktrace for equal comparision
-		myErrState          = errors.WithStack(ErrState)
-		myErrMsg            = errors.WithStack(ErrMsg)
-		myPanic             = errors.WithStack(ErrPanic)
+		myErrState          = Wrap(ErrState, "test")
+		myErrMsg            = Wrap(ErrMsg, "test")
+		myPanic             = ErrPanic
 		myErrStateSTJson, _ = json.Marshal(fmt.Sprintf("%+v", myErrState))
 		myErrMsgSTJson, _   = json.Marshal(fmt.Sprintf("%+v", myErrMsg))
 	)
@@ -195,7 +193,7 @@ func TestABCIInfoSerializeErr(t *testing.T) {
 		"single error": {
 			src:   myErrMsg,
 			debug: false,
-			exp:   "invalid message",
+			exp:   "test: invalid message",
 		},
 		"single error with debug": {
 			src:   myErrMsg,
@@ -204,11 +202,11 @@ func TestABCIInfoSerializeErr(t *testing.T) {
 		},
 		"multiErr default encoder": {
 			src: Append(myErrMsg, myErrState),
-			exp: `{"data":[{"code":4,"log":"invalid message"},{"code":10,"log":"invalid state"}]}`,
+			exp: `{"data":[{"code":4,"log":"test: invalid message"},{"code":10,"log":"test: invalid state"}]}`,
 		},
 		"multiErr default with internal": {
 			src: Append(myErrMsg, myPanic),
-			exp: `{"data":[{"code":4,"log":"invalid message"},{"code":111222,"log":"internal error"}]}`,
+			exp: `{"data":[{"code":4,"log":"test: invalid message"},{"code":111222,"log":"internal error"}]}`,
 		},
 		"multiErr debug": {
 			src:   Append(myErrMsg, myErrState),

--- a/errors/multi_test.go
+++ b/errors/multi_test.go
@@ -5,15 +5,14 @@ import (
 	"testing"
 
 	"github.com/iov-one/weave/weavetest/assert"
-	"github.com/pkg/errors"
 )
 
 func TestAddToMultiErr(t *testing.T) {
 	var (
 		// create errors with stacktrace for equal comparision
-		myErrNotFound = errors.WithStack(ErrNotFound)
-		myErrState    = errors.WithStack(ErrState)
-		myErrMsg      = errors.WithStack(ErrMsg)
+		myErrNotFound = Wrap(ErrNotFound, "test")
+		myErrState    = Wrap(ErrState, "test")
+		myErrMsg      = Wrap(ErrMsg, "test")
 	)
 	specs := map[string]struct {
 		src error


### PR DESCRIPTION
Features:
* Serialize mulitErr into json structure
* Move error Redact code into serialization step of `ABCIInfo(err error, debug bool) (uint32, string)`

Example:
```json
{
  "data": [
    {
      "code": 4,
      "log": "invalid message"
    },
    {
      "code": 10,
      "log": "invalid state"
    }
  ]
}

```

See:
* #693 
* #529 

Reviewer notes:
- Errors on the json serialization are silently ignored and an empty json struct returned

#trivial