### PR TITLE
cmd/bnscli: add command to create a distribution reset transaction

### DIFF
--- a/cmd/bnscli/cmd_cash.go
+++ b/cmd/bnscli/cmd_cash.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/cmd/bnsd/app"
+	"github.com/iov-one/weave/x/cash"
+)
+
+func cmdSendTokens(input io.Reader, output io.Writer, args []string) error {
+	fl := flag.NewFlagSet("", flag.ExitOnError)
+	fl.Usage = func() {
+		fmt.Fprintln(flag.CommandLine.Output(), `
+Create a transaction for transfering funds from the source account to the
+destination account.
+		`)
+		fl.PrintDefaults()
+	}
+	var (
+		srcFl    = flAddress(fl, "src", "", "A source account address that the founds are send from.")
+		dstFl    = flAddress(fl, "dst", "", "A destination account address that the founds are send to.")
+		amountFl = flCoin(fl, "amount", "1 IOV", "An amount that is to be transferred between the source to the destination accounts.")
+		memoFl   = fl.String("memo", "", "A short message attached to the transfer operation.")
+	)
+	fl.Parse(args)
+
+	tx := &app.Tx{
+		Sum: &app.Tx_SendMsg{
+			SendMsg: &cash.SendMsg{
+				Metadata: &weave.Metadata{Schema: 1},
+				Src:      *srcFl,
+				Dest:     *dstFl,
+				Amount:   amountFl,
+				Memo:     *memoFl,
+				Ref:      nil,
+			},
+		},
+	}
+	raw, err := tx.Marshal()
+	if err != nil {
+		return fmt.Errorf("cannot serialize transaction: %s", err)
+	}
+	_, err = output.Write(raw)
+	return err
+}

--- a/cmd/bnscli/cmd_cash_test.go
+++ b/cmd/bnscli/cmd_cash_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/iov-one/weave/cmd/bnsd/app"
+	"github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/weavetest/assert"
+	"github.com/iov-one/weave/x/cash"
+)
+
+func TestCmdSendTokensHappyPath(t *testing.T) {
+	var output bytes.Buffer
+	args := []string{
+		"-src", "b1ca7e78f74423ae01da3b51e676934d9105f282",
+		"-dst", "E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0",
+		"-amount", "5 DOGE",
+		"-memo", "a memo",
+	}
+	if err := cmdSendTokens(nil, &output, args); err != nil {
+		t.Fatalf("cannot create a new token transfer transaction: %s", err)
+	}
+
+	var tx app.Tx
+	if err := tx.Unmarshal(output.Bytes()); err != nil {
+		t.Fatalf("cannot unmarshal created transaction: %s", err)
+	}
+
+	txmsg, err := tx.GetMsg()
+	if err != nil {
+		t.Fatalf("cannot get transaction message: %s", err)
+	}
+	msg := txmsg.(*cash.SendMsg)
+
+	assert.Equal(t, fromHex(t, "b1ca7e78f74423ae01da3b51e676934d9105f282"), []byte(msg.Src))
+	assert.Equal(t, fromHex(t, "E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0"), []byte(msg.Dest))
+	assert.Equal(t, "a memo", msg.Memo)
+	assert.Equal(t, coin.NewCoinp(5, 0, "DOGE"), msg.Amount)
+}

--- a/cmd/bnscli/cmd_distribution.go
+++ b/cmd/bnscli/cmd_distribution.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/cmd/bnsd/app"
+	"github.com/iov-one/weave/x/distribution"
+)
+
+func cmdResetRevenue(input io.Reader, output io.Writer, args []string) error {
+	fl := flag.NewFlagSet("", flag.ExitOnError)
+	fl.Usage = func() {
+		fmt.Fprintln(flag.CommandLine.Output(), `
+Create a transaction for reseting a revenue stream with a new configuration.
+		`)
+		fl.PrintDefaults()
+	}
+	revenueFl := flHex(fl, "revenue", "", "A hex encoded ID of a revenue that is to be altered.")
+	recipientsFl := fl.String("recipients", "", "A path to a CSV file with recipients configuration. File should be a list of pairs (address, weight).")
+	fl.Parse(args)
+
+	recipients, err := readRecipients(*recipientsFl)
+	if err != nil {
+		return fmt.Errorf("cannot read %q recipients file: %s", *recipientsFl, err)
+	}
+
+	tx := &app.Tx{
+		Sum: &app.Tx_ResetRevenueMsg{
+			ResetRevenueMsg: &distribution.ResetRevenueMsg{
+				RevenueID:  *revenueFl,
+				Recipients: recipients,
+			},
+		},
+	}
+	raw, err := tx.Marshal()
+	if err != nil {
+		return fmt.Errorf("cannot serialize transaction: %s", err)
+	}
+	_, err = output.Write(raw)
+	return err
+}
+
+func readRecipients(csvpath string) ([]*distribution.Recipient, error) {
+	fd, err := os.Open(csvpath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open file: %s", err)
+	}
+	defer fd.Close()
+
+	var recipients []*distribution.Recipient
+
+	rd := csv.NewReader(fd)
+	for lineNo := 1; ; lineNo++ {
+		row, err := rd.Read()
+		if err != nil {
+			if err == io.EOF {
+				return recipients, nil
+			}
+			return recipients, err
+		}
+
+		if len(row) != 2 {
+			return recipients, fmt.Errorf("invalid line %d: expected 2 columns, got %d", lineNo, len(row))
+		}
+		address, err := weave.ParseAddress(row[0])
+		if err != nil {
+			return recipients, fmt.Errorf("invalid line %d: invalid address %q: %s", lineNo, row[0], err)
+		}
+		weight, err := strconv.ParseUint(row[1], 10, 32)
+		if err != nil {
+			return recipients, fmt.Errorf("invalid line %d: invalid weight (q-factor) %q: %s", lineNo, row[1], err)
+		}
+		recipients = append(recipients, &distribution.Recipient{
+			Address: address,
+			Weight:  int32(weight),
+		})
+	}
+}

--- a/cmd/bnscli/cmd_distribution_test.go
+++ b/cmd/bnscli/cmd_distribution_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/iov-one/weave/cmd/bnsd/app"
+	"github.com/iov-one/weave/weavetest/assert"
+	"github.com/iov-one/weave/x/distribution"
+)
+
+func TestCmdResetRevenue(t *testing.T) {
+	recipientsPath := mustCreateFile(t, strings.NewReader(`seq:foo/bar/1,3
+seq:foo/bar/2,1
+seq:foo/bar/3,20`))
+
+	var output bytes.Buffer
+	args := []string{
+		"-revenue", "b1ca7e78f74423ae01da3b51e676934d9105f282",
+		"-recipients", recipientsPath,
+	}
+	if err := cmdResetRevenue(nil, &output, args); err != nil {
+		t.Fatalf("cannot create a transaction: %s", err)
+	}
+
+	var tx app.Tx
+	if err := tx.Unmarshal(output.Bytes()); err != nil {
+		t.Fatalf("cannot unmarshal created transaction: %s", err)
+	}
+
+	txmsg, err := tx.GetMsg()
+	if err != nil {
+		t.Fatalf("cannot get transaction message: %s", err)
+	}
+	msg := txmsg.(*distribution.ResetRevenueMsg)
+
+	assert.Equal(t, msg.RevenueID, fromHex(t, "b1ca7e78f74423ae01da3b51e676934d9105f282"))
+	assert.Equal(t, len(msg.Recipients), 3)
+	assert.Equal(t, msg.Recipients[0].Weight, int32(3))
+	assert.Equal(t, msg.Recipients[1].Weight, int32(1))
+	assert.Equal(t, msg.Recipients[2].Weight, int32(20))
+}

--- a/cmd/bnscli/cmd_escrow.go
+++ b/cmd/bnscli/cmd_escrow.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/cmd/bnsd/app"
+	"github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/x/escrow"
+)
+
+func cmdReleaseEscrow(input io.Reader, output io.Writer, args []string) error {
+	fl := flag.NewFlagSet("", flag.ExitOnError)
+	fl.Usage = func() {
+		fmt.Fprintln(flag.CommandLine.Output(), `
+Create a transaction for releasing funds from given escrow.
+		`)
+		fl.PrintDefaults()
+	}
+	var (
+		escrowFl = flHex(fl, "escrow", "", "A hex encoded ID of an escrow that is to be released.")
+		amountFl = flCoin(fl, "amount", "", "Optional amount that is to be transferred from the escrow. The whole escrow hold amount is used if no value is provided.")
+	)
+	fl.Parse(args)
+
+	var amount []*coin.Coin
+	if !coin.IsEmpty(amountFl) {
+		amount = append(amount, amountFl)
+	}
+	tx := &app.Tx{
+		Sum: &app.Tx_ReleaseEscrowMsg{
+			ReleaseEscrowMsg: &escrow.ReleaseEscrowMsg{
+				Metadata: &weave.Metadata{Schema: 1},
+				EscrowId: *escrowFl,
+				Amount:   amount,
+			},
+		},
+	}
+	raw, err := tx.Marshal()
+	if err != nil {
+		return fmt.Errorf("cannot serialize transaction: %s", err)
+	}
+	_, err = output.Write(raw)
+	return err
+}

--- a/cmd/bnscli/cmd_escrow_test.go
+++ b/cmd/bnscli/cmd_escrow_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/iov-one/weave/cmd/bnsd/app"
+	"github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/weavetest/assert"
+	"github.com/iov-one/weave/x/escrow"
+)
+
+func TestCmdReleaseEscrowHappyPath(t *testing.T) {
+	var output bytes.Buffer
+	args := []string{
+		"-escrow", "E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0",
+		"-amount", "49 DOGE",
+	}
+	if err := cmdReleaseEscrow(nil, &output, args); err != nil {
+		t.Fatalf("cannot create a new release escrow transaction: %s", err)
+	}
+
+	var tx app.Tx
+	if err := tx.Unmarshal(output.Bytes()); err != nil {
+		t.Fatalf("cannot unmarshal created transaction: %s", err)
+	}
+
+	txmsg, err := tx.GetMsg()
+	if err != nil {
+		t.Fatalf("cannot get transaction message: %s", err)
+	}
+	msg := txmsg.(*escrow.ReleaseEscrowMsg)
+
+	assert.Equal(t, fromHex(t, "E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0"), []byte(msg.EscrowId))
+	assert.Equal(t, []*coin.Coin{coin.NewCoinp(49, 0, "DOGE")}, msg.Amount)
+}

--- a/cmd/bnscli/cmd_gov_test.go
+++ b/cmd/bnscli/cmd_gov_test.go
@@ -4,25 +4,41 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/cmd/bnsd/app"
 	"github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/weavetest/assert"
+	"github.com/iov-one/weave/x/cash"
 	"github.com/iov-one/weave/x/gov"
 )
 
-func TestCmdNewTransferProposalHappyPath(t *testing.T) {
+func TestCmdAsProposalHappyPath(t *testing.T) {
+	// Prepare a transaction that will be used as an input for the proposal
+	// creation function.
+	sendTx := &app.Tx{
+		Sum: &app.Tx_SendMsg{
+			SendMsg: &cash.SendMsg{
+				Metadata: &weave.Metadata{Schema: 1},
+				Src:      fromHex(t, "b1ca7e78f74423ae01da3b51e676934d9105f282"),
+				Dest:     fromHex(t, "E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0"),
+				Amount:   coin.NewCoinp(5, 0, "DOGE"),
+				Memo:     "a memo",
+			},
+		},
+	}
+	rawTx, err := sendTx.Marshal()
+	if err != nil {
+		t.Fatalf("cannot serialize transaction: %s", err)
+	}
+
 	var output bytes.Buffer
 	args := []string{
-		"-src", "b1ca7e78f74423ae01da3b51e676934d9105f282",
-		"-dst", "E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0",
-		"-amount", "5 DOGE",
-		"-memo", "a memo",
 		"-title", "a title",
 		"-description", "a description",
 		"-electionrule", "1",
 	}
-	if err := cmdNewTransferProposal(nil, &output, args); err != nil {
-		t.Fatalf("cannot create a new transfer proposal: %s", err)
+	if err := cmdAsProposal(bytes.NewReader(rawTx), &output, args); err != nil {
+		t.Fatalf("cannot create a new proposal transaction: %s", err)
 	}
 
 	var tx app.Tx
@@ -49,41 +65,4 @@ func TestCmdNewTransferProposalHappyPath(t *testing.T) {
 	assert.Equal(t, fromHex(t, "E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0"), []byte(submsg.Dest))
 	assert.Equal(t, "a memo", submsg.Memo)
 	assert.Equal(t, coin.NewCoinp(5, 0, "DOGE"), submsg.Amount)
-}
-
-func TestCmdNewEscrowProposalHappyPath(t *testing.T) {
-	var output bytes.Buffer
-	args := []string{
-		"-escrow", "E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0",
-		"-amount", "49 DOGE",
-		"-title", "a title",
-		"-description", "a description",
-		"-electionrule", "1",
-	}
-	if err := cmdNewEscrowProposal(nil, &output, args); err != nil {
-		t.Fatalf("cannot create a new transfer proposal: %s", err)
-	}
-
-	var tx app.Tx
-	if err := tx.Unmarshal(output.Bytes()); err != nil {
-		t.Fatalf("cannot unmarshal created transaction: %s", err)
-	}
-
-	txmsg, err := tx.GetMsg()
-	if err != nil {
-		t.Fatalf("cannot get transaction message: %s", err)
-	}
-	msg := txmsg.(*gov.CreateProposalMsg)
-
-	assert.Equal(t, msg.Base.Title, "a title")
-	assert.Equal(t, msg.Base.Description, "a description")
-	assert.Equal(t, msg.Base.ElectionRuleID, sequenceID(1))
-
-	var options app.ProposalOptions
-	if err := options.Unmarshal(msg.RawOption); err != nil {
-		t.Fatalf("cannot unmarshal submessage: %s", err)
-	}
-	submsg := options.GetReleaseEscrowMsg()
-	assert.Equal(t, fromHex(t, "E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0"), []byte(submsg.EscrowId))
-	assert.Equal(t, []*coin.Coin{coin.NewCoinp(49, 0, "DOGE")}, submsg.Amount)
 }

--- a/cmd/bnscli/common.go
+++ b/cmd/bnscli/common.go
@@ -1,0 +1,11 @@
+package main
+
+import "encoding/binary"
+
+// sequenceID returns a sequence value encoded as implemented in the orm
+// package.
+func sequenceID(n uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, n)
+	return b
+}

--- a/cmd/bnscli/main.go
+++ b/cmd/bnscli/main.go
@@ -32,12 +32,13 @@ import (
 //   $ bnscli escrow-proposal -escrow 1 | bnscli sign | bnscli submit
 //
 var commands = map[string]func(input io.Reader, output io.Writer, args []string) error{
-	"transfer-proposal": cmdNewTransferProposal,
 	"escrow-proposal":   cmdNewEscrowProposal,
+	"reset-revenue":     cmdResetRevenue,
 	"sign":              cmdSignTransaction,
 	"submit":            cmdSubmitTransaction,
-	"view":              cmdTransactionView,
+	"transfer-proposal": cmdNewTransferProposal,
 	"version":           cmdVersion,
+	"view":              cmdTransactionView,
 }
 
 func main() {

--- a/cmd/bnscli/main.go
+++ b/cmd/bnscli/main.go
@@ -29,16 +29,20 @@ import (
 // transaction, signing and submitting. They can be combined into a single
 // pipeline line:
 //
-//   $ bnscli escrow-proposal -escrow 1 | bnscli sign | bnscli submit
+//   $ bnscli release-escrow -escrow 1 \
+//       | bnscli as-proposal \
+//       | bnscli sign \
+//       | bnscli submit
 //
 var commands = map[string]func(input io.Reader, output io.Writer, args []string) error{
-	"escrow-proposal":   cmdNewEscrowProposal,
-	"reset-revenue":     cmdResetRevenue,
-	"sign":              cmdSignTransaction,
-	"submit":            cmdSubmitTransaction,
-	"transfer-proposal": cmdNewTransferProposal,
-	"version":           cmdVersion,
-	"view":              cmdTransactionView,
+	"as-proposal":    cmdAsProposal,
+	"release-escrow": cmdReleaseEscrow,
+	"reset-revenue":  cmdResetRevenue,
+	"send-tokens":    cmdSendTokens,
+	"sign":           cmdSignTransaction,
+	"submit":         cmdSubmitTransaction,
+	"version":        cmdVersion,
+	"view":           cmdTransactionView,
 }
 
 func main() {


### PR DESCRIPTION
A new `cmd/bnscli` command `reset-revenue` was added. It allows to
create a transaction that reset (alters) an existing revenue entity.

```
weave $ cat /tmp/testdata.csv 
seq:foo/bar/1,3
seq:foo/bar/2,1
seq:foo/bar/3,20
weave $ bnscli reset-revenue -revenue aa -recipients /tmp/testdata.csv | bnscli view
{
        "Sum": {
                "ResetRevenueMsg": {
                        "revenue_id": "qg==",
                        "recipients": [
                                {
                                        "address": "60AAA3D972FDA7AF6B7E6A9D5369BA40E5AD8071",
                                        "weight": 3
                                },
                                {
                                        "address": "ED6D7D79C5F147577AEF5F97E47C183377392D56",
                                        "weight": 1
                                },
                                {
                                        "address": "C684701657740CA240D9B28B3566E585A76905CD",
                                        "weight": 20
                                }
                        ]
                }
        }
}
```

#trivial