### PR TITLE
Limit chain ids in bns usernames to 32, not 128 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Breaking changes
   Condition
 - `Metadata` attribute was removed from transaction attributes. This affects
   two entities `x/cash.FeeInfo` and `x/sigs.StdSignature`
+- Max length of blockchain ids used in username NFTs is now 32 (previously 128)
 
 
 

--- a/cmd/bnsd/x/nft/username/model.go
+++ b/cmd/bnsd/x/nft/username/model.go
@@ -14,7 +14,7 @@ import (
 // It can be used by the nft/base extension to register a handler.
 const ModelName = "username"
 
-var validBlockchainID = regexp.MustCompile(`^[a-zA-Z0-9_.-]{4,128}$`).Match
+var validBlockchainID = regexp.MustCompile(`^[a-zA-Z0-9_.-]{4,32}$`).Match
 
 type Token interface {
 	nft.BaseNFT


### PR DESCRIPTION
Closes #720 