### PR TITLE
Add -mod=readonly to all build commands and code run by CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,25 +26,25 @@ install:
 	for ex in $(TOOLS); do cd $$ex && make install && cd -; done
 
 test:
-	go vet ./...
-	go test -race ./...
+	go vet -mod=readonly  ./...
+	go test -mod=readonly -race ./...
 
 # Test fast
 tf:
 	go test -short ./...
 
 cover:
-	@ go test -covermode=$(MODE) -coverprofile=coverage/allpackages.out ./...
+	@ go test -mod=readonly -covermode=$(MODE) -coverprofile=coverage/allpackages.out ./...
 	@ # most of the tests in the app package are in examples/mycoind/app...
-	@ go test -covermode=$(MODE) \
+	@ go test -mod=readonly -covermode=$(MODE) \
 	 	-coverpkg=github.com/iov-one/weave/app,github.com/iov-one/weave/examples/mycoind/app \
 		-coverprofile=coverage/weave_examples_mycoind_app.out \
 		github.com/iov-one/weave/examples/mycoind/app
-	@ go test -covermode=$(MODE) \
+	@ go test -mod=readonly -covermode=$(MODE) \
 	 	-coverpkg=github.com/iov-one/weave/commands/server \
 		-coverprofile=coverage/weave_commands_server.out \
 		github.com/iov-one/weave/examples/mycoind/commands
-	@ go test -covermode=$(MODE) \
+	@ go test -mod=readonly -covermode=$(MODE) \
 		-coverpkg=github.com/iov-one/weave/cmd/bnsd/app,github.com/iov-one/weave/cmd/bnsd/client,github.com/iov-one/weave/app \
 		-coverprofile=coverage/bnsd_app.out \
 		github.com/iov-one/weave/cmd/bnsd/scenarios

--- a/cmd/bcpd/Makefile
+++ b/cmd/bcpd/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all build test image tf protoc clean dist
 
 BUILD_VERSION ?= manual
-BUILD_FLAGS := -ldflags "-X github.com/iov-one/weave.Version=${BUILD_VERSION}"
+BUILD_FLAGS := -mod=readonly -ldflags "-X github.com/iov-one/weave.Version=${BUILD_VERSION}"
 DOCKER_BUILD_FLAGS := -a -installsuffix cgo
 BUILDOUT ?= bcpd
 IMAGE_NAME = "iov1/bcpd:${BUILD_VERSION}"
@@ -20,7 +20,7 @@ image:
 	docker build --pull -t $(IMAGE_NAME) .
 
 test:
-	go test -race ./...
+	go test -mod=readonly -race ./...
 
 install:
 	go install $(BUILD_FLAGS) .
@@ -28,6 +28,3 @@ install:
 # Test fast
 tf:
 	go test -short ./...
-
-protoc:
-	protoc --gogofaster_out=. -I=. -I=../../vendor -I=$(GOPATH)/src app/*.proto

--- a/cmd/bnscli/Makefile
+++ b/cmd/bnscli/Makefile
@@ -1,7 +1,7 @@
 all: install
 
 build:
-	go build -ldflags "-X main.gitHash=$(shell git rev-list -1 HEAD)" .
+	go build -mod=readonly -ldflags "-X main.gitHash=$(shell git rev-list -1 HEAD)" .
 
 
 clean:
@@ -9,7 +9,7 @@ clean:
 
 
 install:
-	go install -ldflags "-X main.gitHash=$(shell git rev-list -1 HEAD)" .
+	go install -mod=readonly -ldflags "-X main.gitHash=$(shell git rev-list -1 HEAD)" .
 
 
 .PHONY: all build clean install

--- a/cmd/bnsd/Makefile
+++ b/cmd/bnsd/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all build test image tf protoc clean dist
 
 BUILD_VERSION ?= manual
-BUILD_FLAGS := -ldflags "-X github.com/iov-one/weave.Version=${BUILD_VERSION}"
+BUILD_FLAGS := -mod=readonly -ldflags "-X github.com/iov-one/weave.Version=${BUILD_VERSION}"
 DOCKER_BUILD_FLAGS := -a -installsuffix cgo
 BUILDOUT ?= bnsd
 IMAGE_NAME = "iov1/bnsd:${BUILD_VERSION}"
@@ -20,7 +20,7 @@ image:
 	docker build --pull -t $(IMAGE_NAME) .
 
 test:
-	go test -race ./...
+	go test -mod=readonly -race ./...
 
 install:
 	go install $(BUILD_FLAGS) .
@@ -28,6 +28,3 @@ install:
 # Test fast
 tf:
 	go test -short ./...
-
-protoc:
-	protoc --gogofaster_out=. -I=. -I=../../vendor -I=$(GOPATH)/src app/*.proto

--- a/cmd/cleanproto/Makefile
+++ b/cmd/cleanproto/Makefile
@@ -1,8 +1,8 @@
 .PHONY: build test
 
 build:
-	CGO_ENABLED=0 go build -o cleanproto .
+	CGO_ENABLED=0 go build -mod=readonly -o cleanproto .
 
 test:
-	go test . -v -race
+	go test -mod=readonly . -v -race
 	./tests/test.sh


### PR DESCRIPTION
`make tf` will still update go.mod (for local updates),
as will a manual `go build ...`, `go install ...`.

This ensures the official use of the Makefile and the CI run exactly what is in go.sum, and don't auto-update it.