### PR TITLE
cmd/bnscli: print the embebed content of a proposal

### DIFF
--- a/cmd/bnscli/cmd_view.go
+++ b/cmd/bnscli/cmd_view.go
@@ -62,19 +62,15 @@ func printProposalMsg(output io.Writer, tx app.Tx) error {
 		return nil
 	}
 
-	var propTx app.Tx
-	if err := propTx.Unmarshal(proposalMsg.RawOption); err != nil {
+	var options app.ProposalOptions
+	if err := options.Unmarshal(proposalMsg.RawOption); err != nil {
 		return fmt.Errorf("cannot unmarshal raw options: %s", err)
 	}
-	propMsg, err := propTx.GetMsg()
-	if err != nil {
-		return fmt.Errorf("cannot extract message from the proposal transaction")
-	}
-	propPretty, err := json.MarshalIndent(propMsg, "", "\t")
+	propPretty, err := json.MarshalIndent(options.Option, "", "\t")
 	if err != nil {
 		return fmt.Errorf("cannot JSON serialize proposal message: %s", err)
 	}
-	fmt.Fprintf(output, "\n\nThe above transaction is a proposal for executing the following %T message:\n", propMsg)
+	fmt.Fprint(output, "\n\nThe above transaction is a proposal for executing the following messages:\n")
 	_, _ = output.Write(propPretty)
 	return nil
 }


### PR DESCRIPTION
When `view`ing a proposal transaction the embeded message is base64
encoded binary representation of the content. Detect such case and print
the JSON representation of embeded message as well.

Example output:

    $ bnscli release-escrow -amount "4 ABC" | bnscli as-proposal | bnscli view
    {
            "Sum": {
                    "CreateProposalMsg": {
                            "metadata": {
                                    "schema": 1
                            },
                            "base": {
                                    "title": "Transfer funds to distribution account",
                                    "description": "Transfer funds to distribution account",
                                    "election_rule_id": "AAAAAAAAAAA=",
                                    "start_time": 1559737457
                            },
                            "raw_option": "qgMNCgIIARoHCAQaA0FCQw=="
                    }
            }
    }
    The above transaction is a proposal for executing the following *escrow.ReleaseEscrowMsg message:
    {
            "metadata": {
                    "schema": 1
            },
            "amount": [
                    {
                            "whole": 4,
                            "ticker": "ABC"
                    }
            ]
    }

#trivial