### PR TITLE
Danger doesn't cause travis CI to return error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,6 @@ script:
      make cover;
      ./coverage/upload.sh;
    fi;
-- printenv | grep -Ev "PATH|path|GEM" > env.list
-- docker run -it --rm --env-file env.list -v "$(pwd):/usr/src/app" iov1ops/danger:latest > danger.out; cat danger.out
-# this is done, because docker exits with 0 even if there are errors
-- if grep -q 'Errors' danger.out; then exit 1; fi
 - if [[ "$TRAVIS_GO_VERSION" == "$MAIN_GO_VERSION" && "$TRAVIS_OS_NAME" == "linux" ]]; then
     release_latest=$( [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_TAG" == "" && "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]] && echo "yes" || echo "no" );
     release_tag=$( [[ "$TRAVIS_TAG" != "" ]] && echo "yes" || echo "no" );

--- a/doc.go
+++ b/doc.go
@@ -4,7 +4,6 @@ Package weave defines interfaces used throughout the app, such as: storage, tran
 It also contains helpers to work with errors, context, authentication and abci.
 Look into this package to get an brief overview of design decisions made around interfaces and extension
 building blocks.
-
 */
 
 package weave


### PR DESCRIPTION
Danger is nice and I am happy to see the red flag there warning me.
However, it is annoying to see the travis flag red as well, when all tests pass.

Now that danger runs as a separate CI process, I remove it from .travis.yml
I may get a :heavy_check_mark: from travis and a :x: from danger and that is very clear feedback.