### PR TITLE
cmd/bnscli: build as a static binary

### DIFF
--- a/cmd/bnscli/Makefile
+++ b/cmd/bnscli/Makefile
@@ -1,7 +1,7 @@
 all: install
 
 build:
-	go build -mod=readonly -ldflags "-X main.gitHash=$(shell git rev-list -1 HEAD)" .
+	CGO_ENABLED=0 go build -mod=readonly -ldflags "-X main.gitHash=$(shell git rev-list -1 HEAD) -extldflags \"-static\"" .
 
 
 clean:
@@ -9,7 +9,7 @@ clean:
 
 
 install:
-	go install -mod=readonly -ldflags "-X main.gitHash=$(shell git rev-list -1 HEAD)" .
+	CGO_ENABLED=0 go install -mod=readonly -ldflags "-X main.gitHash=$(shell git rev-list -1 HEAD) -extldflags \"-static\"" .
 
 
 .PHONY: all build clean install


### PR DESCRIPTION
Remove all dynamic linking when building `bnscli` binary.

#trivial


```sh
$ ldd ~/go/bin/bnscli 
        not a dynamic executable
```
:tada: 