### PR TITLE
cmd/bnsd: allow many nft usernames for a single address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 Breaking changes
 
+- cmd/bnsd: `nft/username` allows now for any number of aliases/names for a
+  single address.
 - messages produced by `cmd/bnscli` have a new binary format incompatible with
   the previous version.
 - `x/gov` added indexes to proposals and electorate to enable better client-side UX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 Breaking changes
 
 - cmd/bnsd: `nft/username` allows now for any number of aliases/names for a
-  single address.
+  single address. Lookup of the username by an address is no longer available.
 - messages produced by `cmd/bnscli` have a new binary format incompatible with
   the previous version.
 - `x/gov` added indexes to proposals and electorate to enable better client-side UX

--- a/cmd/bnsd/app/app_nft_test.go
+++ b/cmd/bnsd/app/app_nft_test.go
@@ -4,13 +4,11 @@ import (
 	"testing"
 
 	"github.com/iov-one/weave"
-	weave_app "github.com/iov-one/weave/app"
 	"github.com/iov-one/weave/cmd/bnsd/app"
 	"github.com/iov-one/weave/cmd/bnsd/app/testdata/fixtures"
 	"github.com/iov-one/weave/cmd/bnsd/x/nft/username"
 	"github.com/iov-one/weave/coin"
 	"github.com/stretchr/testify/require"
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 func TestIssueNfts(t *testing.T) {
@@ -38,12 +36,4 @@ func TestIssueNfts(t *testing.T) {
 	tx.Fee(issuerAddr, coin.NewCoin(5, 0, "FRNK"))
 	res := signAndCommit(t, myApp, tx, []Signer{{issuerPrivKey, 0}}, appFixture.ChainID, 3)
 	require.EqualValues(t, 0, res.Code)
-
-	query := abci.RequestQuery{Path: "/nft/usernames/chainaddr", Data: []byte("myChainAddress;myblockchain")}
-	qRes := myApp.Query(query)
-	require.EqualValues(t, 0, qRes.Code, qRes.Log)
-	var actual username.UsernameToken
-	err := weave_app.UnmarshalOneResult(qRes.Value, &actual)
-	require.NoError(t, err)
-	require.Equal(t, []byte("anybody@example.com"), actual.GetBase().GetID())
 }

--- a/cmd/bnsd/x/nft/username/bucket.go
+++ b/cmd/bnsd/x/nft/username/bucket.go
@@ -7,19 +7,15 @@ import (
 	"github.com/iov-one/weave/x/nft"
 )
 
-const (
-	bucketName            = "usrnft"
-	chainAddressSeparator = ";"
-)
-
 type Bucket struct {
 	orm.Bucket
 }
 
 func NewBucket() Bucket {
-	b := NewUsernameToken(nil, nil, nil)
+	t := NewUsernameToken(nil, nil, nil)
+	b := orm.NewBucket("usrnft", t)
 	return Bucket{
-		Bucket: nft.WithOwnerIndex(orm.NewBucket(bucketName, b)),
+		Bucket: nft.WithOwnerIndex(b),
 	}
 }
 

--- a/cmd/bnsd/x/nft/username/handler_test.go
+++ b/cmd/bnsd/x/nft/username/handler_test.go
@@ -24,9 +24,11 @@ func TestHandleIssueTokenMsg(t *testing.T) {
 	db := store.MemStore()
 	bucket := username.NewBucket()
 
-	o, _ := bucket.Create(db, bob.Address(), []byte("existing@example.com"), nil, []username.ChainAddress{
-		{BlockchainID: []byte("myNet"), Address: "bobsChainAddress"},
-	})
+	bobsAddress := username.ChainAddress{
+		BlockchainID: []byte("myNet"),
+		Address:      "bobsChainAddress",
+	}
+	o, _ := bucket.Create(db, bob.Address(), []byte("existing@example.com"), nil, []username.ChainAddress{bobsAddress})
 	bucket.Save(db, o)
 
 	handler := username.NewIssueHandler(
@@ -89,10 +91,7 @@ func TestHandleIssueTokenMsg(t *testing.T) {
 			id:    []byte("any@example.com"),
 			details: username.TokenDetails{
 				Addresses: []username.ChainAddress{
-					{
-						BlockchainID: []byte("myNet"),
-						Address:      "bobsChainAddress",
-					},
+					bobsAddress,
 				},
 			},
 			expCheckError:   false,


### PR DESCRIPTION
Previous implementation allowed only one alias per address. This allowed
for a reverse lookup (address by name) but also allowed to block an
alias registration. I could register my own name for your address and
prevent you to do the same.

This change removes reverse lookup as the index no longer exists. It
also allows for any number of usernames registered for the same address.

Please double check that my changes make logical sense.

While working on this change I have updated some of the tests. username registration is `bns` most important functionality and I think we should put more effort into bringing it to a great state. Right now, in my opinion, this is not something we should be confident to go to production with.

resolve #714