### PR TITLE
Expose migrations helpers

### DIFF
--- a/migration/orm.go
+++ b/migration/orm.go
@@ -207,18 +207,16 @@ func migrate(
 	return nil
 }
 
-/*
-Migrate will query the current schema of the named package and attempt
-to Migrate the passed value up to the current value.
-
-Returns an error if the passed value is not Migratable,
-not registered with migrations, missing Metadata, has a Schema
-higher than currentSchema, if the final migrated value is invalid,
-or other such conditions.
-
-If this returns no error, you can safely use the contents of value in
-code working with the currentSchema.
-*/
+// Migrate will query the current schema of the named package and attempt
+// to Migrate the passed value up to the current value.
+//
+// Returns an error if the passed value is not Migratable,
+// not registered with migrations, missing Metadata, has a Schema
+// higher than currentSchema, if the final migrated value is invalid,
+// or other such conditions.
+//
+// If this returns no error, you can safely use the contents of value in
+// code working with the currentSchema.
 func Migrate(
 	db weave.ReadOnlyKVStore,
 	packageName string,

--- a/migration/orm.go
+++ b/migration/orm.go
@@ -206,3 +206,23 @@ func migrate(
 	}
 	return nil
 }
+
+/*
+Migrate will query the current schema of the named package and attempt
+to Migrate the passed value up to the current value.
+
+Returns an error if the passed value is not Migratable,
+not registered with migrations, missing Metadata, has a Schema
+higher than currentSchema, if the final migrated value is invalid,
+or other such conditions.
+
+If this returns no error, you can safely use the contents of value in
+code working with the currentSchema.
+*/
+func Migrate(
+	db weave.ReadOnlyKVStore,
+	packageName string,
+	value interface{},
+) error {
+	return migrate(reg, NewSchemaBucket(), packageName, db, value)
+}

--- a/migration/register.go
+++ b/migration/register.go
@@ -140,3 +140,19 @@ var reg *register = newRegister()
 func MustRegister(migrationTo uint32, msgOrModel Migratable, fn Migrator) {
 	reg.MustRegister(migrationTo, msgOrModel, fn)
 }
+
+// Apply updates the object by applying all missing data migrations. Even a no
+// modification migration is updating the metadata to point to the latest data
+// format version.
+//
+// Because changes are applied directly on the passed object (in place), even
+// if this function fails some of the data migrations might be applied.
+//
+// A valid object metadata must contain a schema version greater than zero.
+// Not migrated object (initial state) is always having a metadata schema value
+// set to 1.
+//
+// Validation method is called only on the final version of the object.
+func Apply(db weave.ReadOnlyKVStore, m Migratable, migrateTo uint32) error {
+	return reg.Apply(db, m, migrateTo)
+}


### PR DESCRIPTION
#trivial 

I was working to add migration support to my custom model bucket in the tutorial, and realized it was impossible due to some private methods and objects, notably `reg`. I add two helper functions, so one can add migration support outside of the migrations package (in third party apps).
