### PR TITLE
Fix initial value in comments of Proposal.status/.executor_result

### DIFF
--- a/docs/proto/index.html
+++ b/docs/proto/index.html
@@ -3570,7 +3570,7 @@ to be included in the election. </p></td>
                   <td>status</td>
                   <td><a href="#gov.Proposal.Status">Proposal.Status</a></td>
                   <td></td>
-                  <td><p>Status represents the high level position in the life cycle of the proposal. Initial value is submitted. </p></td>
+                  <td><p>Status represents the high level position in the life cycle of the proposal. Initial value is Submitted. </p></td>
                 </tr>
               
                 <tr>
@@ -3584,7 +3584,7 @@ to be included in the election. </p></td>
                   <td>executor_result</td>
                   <td><a href="#gov.Proposal.ExecutorResult">Proposal.ExecutorResult</a></td>
                   <td></td>
-                  <td><p>Result is the final result based on the votes and election rule. Initial value is Undefined. </p></td>
+                  <td><p>Result is the final result based on the votes and election rule. Initial value is NotRun. </p></td>
                 </tr>
               
             </tbody>

--- a/spec/gogo/x/gov/codec.proto
+++ b/spec/gogo/x/gov/codec.proto
@@ -114,7 +114,7 @@ message Proposal {
     // is Withdrawn.
     PROPOSAL_STATUS_WITHDRAWN = 3 [(gogoproto.enumvalue_customname) = "Withdrawn"];
   }
-  // Status represents the high level position in the life cycle of the proposal. Initial value is submitted.
+  // Status represents the high level position in the life cycle of the proposal. Initial value is Submitted.
   Status status = 12;
   enum Result {
     // An empty value is invalid and not allowed
@@ -138,7 +138,7 @@ message Proposal {
     // The executor returned an error and proposed action didn't update state
     PROPOSAL_EXECUTOR_RESULT_FAILURE = 3 [(gogoproto.enumvalue_customname) = "Failure"];
   }
-  // Result is the final result based on the votes and election rule. Initial value is Undefined.
+  // Result is the final result based on the votes and election rule. Initial value is NotRun.
   ExecutorResult executor_result = 14;
 }
 

--- a/spec/proto/x/gov/codec.proto
+++ b/spec/proto/x/gov/codec.proto
@@ -113,7 +113,7 @@ message Proposal {
     // is Withdrawn.
     PROPOSAL_STATUS_WITHDRAWN = 3 ;
   }
-  // Status represents the high level position in the life cycle of the proposal. Initial value is submitted.
+  // Status represents the high level position in the life cycle of the proposal. Initial value is Submitted.
   Status status = 12;
   enum Result {
     // An empty value is invalid and not allowed
@@ -137,7 +137,7 @@ message Proposal {
     // The executor returned an error and proposed action didn't update state
     PROPOSAL_EXECUTOR_RESULT_FAILURE = 3 ;
   }
-  // Result is the final result based on the votes and election rule. Initial value is Undefined.
+  // Result is the final result based on the votes and election rule. Initial value is NotRun.
   ExecutorResult executor_result = 14;
 }
 

--- a/x/gov/codec.pb.go
+++ b/x/gov/codec.pb.go
@@ -518,11 +518,11 @@ type Proposal struct {
 	Author github_com_iov_one_weave.Address `protobuf:"bytes,10,opt,name=author,proto3,casttype=github.com/iov-one/weave.Address" json:"author,omitempty"`
 	// Result of the election. Contains intermediate tally results while voting period is open.
 	VoteState TallyResult `protobuf:"bytes,11,opt,name=vote_state,json=voteState,proto3" json:"vote_state"`
-	// Status represents the high level position in the life cycle of the proposal. Initial value is submitted.
+	// Status represents the high level position in the life cycle of the proposal. Initial value is Submitted.
 	Status Proposal_Status `protobuf:"varint,12,opt,name=status,proto3,enum=gov.Proposal_Status" json:"status,omitempty"`
 	// Result is the final result based on the votes and election rule. Initial value is Undefined.
 	Result Proposal_Result `protobuf:"varint,13,opt,name=result,proto3,enum=gov.Proposal_Result" json:"result,omitempty"`
-	// Result is the final result based on the votes and election rule. Initial value is Undefined.
+	// Result is the final result based on the votes and election rule. Initial value is NotRun.
 	ExecutorResult Proposal_ExecutorResult `protobuf:"varint,14,opt,name=executor_result,json=executorResult,proto3,enum=gov.Proposal_ExecutorResult" json:"executor_result,omitempty"`
 }
 

--- a/x/gov/codec.proto
+++ b/x/gov/codec.proto
@@ -114,7 +114,7 @@ message Proposal {
     // is Withdrawn.
     PROPOSAL_STATUS_WITHDRAWN = 3 [(gogoproto.enumvalue_customname) = "Withdrawn"];
   }
-  // Status represents the high level position in the life cycle of the proposal. Initial value is submitted.
+  // Status represents the high level position in the life cycle of the proposal. Initial value is Submitted.
   Status status = 12;
   enum Result {
     // An empty value is invalid and not allowed
@@ -138,7 +138,7 @@ message Proposal {
     // The executor returned an error and proposed action didn't update state
     PROPOSAL_EXECUTOR_RESULT_FAILURE = 3 [(gogoproto.enumvalue_customname) = "Failure"];
   }
-  // Result is the final result based on the votes and election rule. Initial value is Undefined.
+  // Result is the final result based on the votes and election rule. Initial value is NotRun.
   ExecutorResult executor_result = 14;
 }
 


### PR DESCRIPTION
hmm, now the ./spec folder gets out of date when I commit such changes from the Web UI.
#trivial