### PR TITLE
refactor of multi error + field error implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## HEAD
 
 - Unified dedupe logic for validator bookkeeping and validator diffs in `app`
+- A new `errors.Field` was added. This allows to bind errors to field names and
+  enables easier testing of group errors.
 - Expose some more Genesis params to extension initializers. Utilise those in
   `x/validators` to store initial validator list and validate updates against
   this list while updating on every successful transaction.

--- a/errors/abci.go
+++ b/errors/abci.go
@@ -39,9 +39,6 @@ func ABCIInfo(err error, debug bool) (uint32, string) {
 	return abciCode(err), encode(err)
 }
 
-// The errEncoder converts an error into a string string representation
-type errEncoder func(error) string
-
 // The debugErrEncoder encodes the error with a stacktrace.
 func debugErrEncoder(err error) string {
 	return fmt.Sprintf("%+v", err)

--- a/errors/abci.go
+++ b/errors/abci.go
@@ -14,8 +14,9 @@ const (
 	// All unclassified errors that do not provide an ABCI code are clubbed
 	// under an internal error code and a generic message instead of
 	// detailed error string.
-	internalABCICode uint32 = 1
-	internalABCILog  string = "internal error"
+	internalABCICode   uint32 = 1
+	internalABCILog    string = "internal error"
+	multiErrorABCICode uint32 = 1000
 )
 
 // ABCIInfo returns the ABCI error information as consumed by the tendermint
@@ -34,12 +35,8 @@ func ABCIInfo(err error, debug bool) (uint32, string) {
 	if debug {
 		encode = debugErrEncoder
 	}
-	code := abciCode(err)
-	if code == multiErrCode {
-		encode = multiErrEncoder(encode)
-	}
 
-	return code, encode(err)
+	return abciCode(err), encode(err)
 }
 
 // The errEncoder converts an error into a string string representation
@@ -53,17 +50,6 @@ func debugErrEncoder(err error) string {
 // The defaultErrEncoder applies Redact on the error before encoding it with its internal error message.
 func defaultErrEncoder(err error) string {
 	return Redact(err).Error()
-}
-
-// The multiErrEncoder wraps an encoder with support for multiErr type
-func multiErrEncoder(enc errEncoder) errEncoder {
-	return func(err error) string {
-		mErr, ok := err.(multiErr)
-		if !ok {
-			return enc(err)
-		}
-		return serializeMultiErr(mErr, enc)
-	}
 }
 
 type coder interface {

--- a/errors/abci_test.go
+++ b/errors/abci_test.go
@@ -197,11 +197,11 @@ func TestABCIInfoSerializeErr(t *testing.T) {
 			debug: true,
 			exp:   fmt.Sprintf("%+v", myErrMsg),
 		},
-		"multiErr default encoder": {
+		"multi error default encoder": {
 			src: Append(myErrMsg, myErrState),
 			exp: Append(myErrMsg, myErrState).Error(),
 		},
-		"multiErr default with internal": {
+		"multi error default with internal": {
 			src: Append(myErrMsg, myPanic),
 			exp: "internal error",
 		},
@@ -213,6 +213,24 @@ func TestABCIInfoSerializeErr(t *testing.T) {
 			src:   myPanic,
 			debug: true,
 			exp:   fmt.Sprintf("%+v", myPanic),
+		},
+		"redact in multi error": {
+			src:   Append(myPanic, myErrMsg),
+			debug: false,
+			exp:   "internal error",
+		},
+		"no redact in multi error": {
+			src:   Append(myPanic, myErrMsg),
+			debug: true,
+			exp: `2 errors occurred:
+	* panic
+	* test: invalid message
+`,
+		},
+		"wrapped multi error with redact": {
+			src:   Wrap(Append(myPanic, myErrMsg), "wrap"),
+			debug: false,
+			exp:   "internal error",
 		},
 	}
 	for msg, spec := range specs {

--- a/errors/abci_test.go
+++ b/errors/abci_test.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -177,12 +176,10 @@ func TestRedact(t *testing.T) {
 
 func TestABCIInfoSerializeErr(t *testing.T) {
 	var (
-		// create errors with stacktrace for equal comparision
-		myErrState          = Wrap(ErrState, "test")
-		myErrMsg            = Wrap(ErrMsg, "test")
-		myPanic             = ErrPanic
-		myErrStateSTJson, _ = json.Marshal(fmt.Sprintf("%+v", myErrState))
-		myErrMsgSTJson, _   = json.Marshal(fmt.Sprintf("%+v", myErrMsg))
+		// Create errors with stacktrace for equal comparision.
+		myErrState = Wrap(ErrState, "test")
+		myErrMsg   = Wrap(ErrMsg, "test")
+		myPanic    = ErrPanic
 	)
 
 	specs := map[string]struct {
@@ -202,20 +199,15 @@ func TestABCIInfoSerializeErr(t *testing.T) {
 		},
 		"multiErr default encoder": {
 			src: Append(myErrMsg, myErrState),
-			exp: `{"data":[{"code":4,"log":"test: invalid message"},{"code":10,"log":"test: invalid state"}]}`,
+			exp: Append(myErrMsg, myErrState).Error(),
 		},
 		"multiErr default with internal": {
 			src: Append(myErrMsg, myPanic),
-			exp: `{"data":[{"code":4,"log":"test: invalid message"},{"code":111222,"log":"internal error"}]}`,
-		},
-		"multiErr debug": {
-			src:   Append(myErrMsg, myErrState),
-			debug: true,
-			exp:   fmt.Sprintf(`{"data":[{"code":4,"log":%s},{"code":10,"log":%s}]}`, string(myErrMsgSTJson), string(myErrStateSTJson)),
+			exp: "internal error",
 		},
 		"redact in default encoder": {
 			src: myPanic,
-			exp: internalABCILog,
+			exp: "internal error",
 		},
 		"do not redact in debug encoder": {
 			src:   myPanic,

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -249,14 +249,6 @@ func (e *wrappedError) Cause() error {
 	return e.parent
 }
 
-// Unpack implementes unpacker interface.
-func (e *wrappedError) Unpack() []error {
-	if u, ok := e.parent.(unpacker); ok {
-		return u.Unpack()
-	}
-	return []error{e.parent}
-}
-
 // Recover captures a panic and stop its propagation. If panic happens it is
 // transformed into a ErrPanic instance and assigned to given error. Call this
 // function using defer in order to work as expected.

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -124,6 +124,16 @@ func TestErrorIs(t *testing.T) {
 			b:      Append(ErrState, ErrNotFound),
 			wantIs: false,
 		},
+		"field error wrapper": {
+			a:      ErrEmpty,
+			b:      Field("name", ErrEmpty, "name is required"),
+			wantIs: true,
+		},
+		"nil field error wrapper": {
+			a:      nil,
+			b:      Field("name", nil, "name is required"),
+			wantIs: true,
+		},
 	}
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -3,7 +3,6 @@ package errors
 import (
 	stdlib "errors"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -130,30 +129,6 @@ func TestErrorIs(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			if got := tc.a.Is(tc.b); got != tc.wantIs {
 				t.Fatalf("unexpected result - got:%v want: %v", got, tc.wantIs)
-			}
-		})
-	}
-}
-
-func TestUnwrap(t *testing.T) {
-	specs := map[string]struct {
-		src    error
-		expErr error
-		expMsg []string
-	}{
-		"Wrapped":        {src: Wrap(ErrNotFound, "myMsg"), expErr: ErrNotFound, expMsg: []string{"myMsg"}},
-		"Double wrapped": {src: Wrap(Wrap(ErrNotFound, "first"), "second"), expErr: ErrNotFound, expMsg: []string{"first", "second"}},
-		"Not Wrapped":    {src: ErrNotFound, expErr: ErrNotFound},
-		"Nil":            {src: nil, expErr: nil},
-	}
-	for msg, spec := range specs {
-		t.Run(msg, func(t *testing.T) {
-			root, msgs := unWrap(spec.src)
-			if exp, got := spec.expErr, root; !reflect.DeepEqual(exp, got) {
-				t.Errorf("expected %T but got %T", exp, got)
-			}
-			if exp, got := spec.expMsg, msgs; !reflect.DeepEqual(exp, got) {
-				t.Errorf("expected %v but got %v", exp, got)
 			}
 		})
 	}

--- a/errors/field.go
+++ b/errors/field.go
@@ -1,0 +1,93 @@
+package errors
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// Field returns an error instance that wraps the original error with
+// additional information.
+// Use this function to create an error instance describing a field/attribute
+// error.
+func Field(fieldName string, err error, description string) error {
+	if isNilErr(err) {
+		return nil
+	}
+
+	// If this error does not carry the stacktrace information yet, attach
+	// one. This should be done only once per error at the lowest frame
+	// possible (most inner wrap).
+	if stackTrace(err) == nil {
+		err = errors.WithStack(err)
+	}
+
+	return &fieldError{
+		parent: err,
+		field:  fieldName,
+		desc:   description,
+	}
+}
+
+type fieldError struct {
+	parent error
+	field  string
+	desc   string
+}
+
+func (err *fieldError) Error() string {
+	if err.desc == "" {
+		return fmt.Sprintf("field %q: %s", err.field, err.parent)
+	}
+	return fmt.Sprintf("field %q: %s: %s", err.field, err.desc, err.parent)
+}
+
+// Cause implements the causer interface.
+func (err *fieldError) Cause() error {
+	return err.parent
+}
+
+// Field implements fielder interface.
+func (err *fieldError) Field() string {
+	return err.field
+}
+
+// FieldErrors returns the list of all errors that are created for the given
+// field name.
+// An error must be implementing a fielder interface and return a matching
+// field name in order to pass the test and be included in the result set.
+func FieldErrors(err error, fieldName string) []error {
+	if isNilErr(err) {
+		return nil
+	}
+
+	var res []error
+	for {
+		if err == nil {
+			return res
+		}
+
+		if f, ok := err.(fielder); ok {
+			if f.Field() == fieldName {
+				return append(res, err)
+			}
+		}
+
+		if u, ok := err.(unpacker); ok {
+			for _, e := range u.Unpack() {
+				res = append(res, FieldErrors(e, fieldName)...)
+			}
+		}
+
+		if c, ok := err.(causer); ok {
+			err = c.Cause()
+		} else {
+			return res
+		}
+	}
+}
+
+type fielder interface {
+	// Field returns the field name that this error is created for.
+	Field() string
+}

--- a/errors/field.go
+++ b/errors/field.go
@@ -7,9 +7,10 @@ import (
 )
 
 // Field returns an error instance that wraps the original error with
-// additional information.
+// additional information. It returns `nil` if provided error is `nil`.
 // Use this function to create an error instance describing a field/attribute
 // error.
+// This function might attach a stack trace information.
 func Field(fieldName string, err error, description string) error {
 	if isNilErr(err) {
 		return nil
@@ -27,6 +28,12 @@ func Field(fieldName string, err error, description string) error {
 		field:  fieldName,
 		desc:   description,
 	}
+}
+
+// AppendField is a shortcut function to club together error(s) with a given
+// field error.
+func AppendField(errorsOrNil error, fieldName string, fieldErrOrNil error) error {
+	return Append(errorsOrNil, Field(fieldName, fieldErrOrNil, ""))
 }
 
 type fieldError struct {

--- a/errors/field.go
+++ b/errors/field.go
@@ -84,6 +84,12 @@ func FieldErrors(err error, fieldName string) []error {
 			for _, e := range u.Unpack() {
 				res = append(res, FieldErrors(e, fieldName)...)
 			}
+			// Unpacker is a superset of causer. If Unpack() can be
+			// called, then we already work on all children of this
+			// error. No need to test for causer as it must not
+			// return an error that was not part of the Unpack()
+			// result.
+			return res
 		}
 
 		if c, ok := err.(causer); ok {

--- a/errors/field_test.go
+++ b/errors/field_test.go
@@ -1,0 +1,83 @@
+package errors
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFieldErrors(t *testing.T) {
+	// Declare errors upfront so that DeepEqual can be used for comparison.
+	var (
+		unauthorizedNameErr = Field("name", ErrUnauthorized, "a")
+		humanNameErr        = Field("name", ErrHuman, "b")
+		emptyGenderErr      = Field("gender", ErrEmpty, "gender is required")
+		userMultiErr        = Field("user", Append(
+			humanNameErr,
+			Append(emptyGenderErr, ErrDeleted),
+		), "user data invalid")
+	)
+
+	cases := map[string]struct {
+		Err   error
+		Field string
+		Want  []error
+	}{
+		"a single error found by the name": {
+			Err:   unauthorizedNameErr,
+			Field: "name",
+			Want:  []error{unauthorizedNameErr},
+		},
+		"two error found by the name": {
+			Err: Append(
+				unauthorizedNameErr,
+				humanNameErr,
+			),
+			Field: "name",
+			Want: []error{
+				unauthorizedNameErr,
+				humanNameErr,
+			},
+		},
+		"field can contain a multierror": {
+			Err:   userMultiErr,
+			Field: "user",
+			Want:  []error{userMultiErr},
+		},
+		"field can inspect errors tree to find match (name)": {
+			Err:   userMultiErr,
+			Field: "name",
+			Want:  []error{humanNameErr},
+		},
+		"field can inspect errors tree to find match (gender)": {
+			Err:   userMultiErr,
+			Field: "gender",
+			Want:  []error{emptyGenderErr},
+		},
+		"nil error returns nothing": {
+			Err:   nil,
+			Field: "foo",
+			Want:  nil,
+		},
+		"error not found by the field name": {
+			Err:   ErrUnauthorized,
+			Field: "foo",
+			Want:  nil,
+		},
+		"error not found by the wrong field name": {
+			Err:   Field("a-name", ErrUnauthorized, "a description"),
+			Field: "foo",
+			Want:  nil,
+		},
+	}
+
+	for testName, tc := range cases {
+		t.Run(testName, func(t *testing.T) {
+			got := FieldErrors(tc.Err, tc.Field)
+			if !reflect.DeepEqual(tc.Want, got) {
+				t.Logf("want: %#v", tc.Want)
+				t.Logf(" got: %#v", got)
+				t.Fatal("unexpected result")
+			}
+		})
+	}
+}

--- a/errors/multi.go
+++ b/errors/multi.go
@@ -103,10 +103,6 @@ func (errs multiError) Error() string {
 
 // StackTrace returns the first stack trace found or nil.
 func (errs multiError) StackTrace() errors.StackTrace {
-	type stackTracer interface {
-		StackTrace() errors.StackTrace
-	}
-
 	for _, err := range errs {
 		if st := stackTrace(err); st != nil {
 			return st

--- a/errors/multi.go
+++ b/errors/multi.go
@@ -9,6 +9,22 @@ import (
 )
 
 // Append clubs together all provided errors. Nil values are ignored.
+//
+// If given error implements unpacker interface, it is flattened. All
+// represented by this error container errors are directly included into the
+// result set rather than through the container. This means that
+//   Append(Append(err1, err2), Append(err3), err4)
+// produce the same result as
+//   Append(err1, err2, err3, err4)
+// Because not all errors implement unpacker interface, the internal
+// representation of the constructed error relation can be a tree. For example,
+// the following code will result in a tree-like error chain.
+//   Append(err1, Wrap(Append(err2, err3), "w"))
+//
+// When implementing an error that satisfies unpacker interface, keep in mind
+// that Append function destroys such error and consume only contained by it
+// errors. Implement unpacker interface only for error containers, that do not
+// carry any additional information.
 func Append(errs ...error) error {
 	// Always build the multi error collection from scratch to avoid slice
 	// modyfications.

--- a/errors/multi_test.go
+++ b/errors/multi_test.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"reflect"
 	"testing"
-
-	"github.com/iov-one/weave/weavetest/assert"
 )
 
 func TestAppend(t *testing.T) {
@@ -265,7 +263,17 @@ func TestMultiErrorMessageFormat(t *testing.T) {
 func TestMultiErrorABCICodeIsRestricted(t *testing.T) {
 	// Ensure thath the multi error code is restricted and cannot by
 	// registered by another error instance.
-	assert.Panics(t, func() {
+	assertPanics(t, func() {
 		_ = Register(multiErrorABCICode, "my error")
 	})
+}
+
+func assertPanics(t testing.TB, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("panic expected")
+		}
+	}()
+	fn()
 }

--- a/errors/stacktrace_test.go
+++ b/errors/stacktrace_test.go
@@ -3,10 +3,9 @@ package errors
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/iov-one/weave/weavetest/assert"
 )
 
 func TestStackTrace(t *testing.T) {
@@ -44,7 +43,9 @@ func TestStackTrace(t *testing.T) {
 
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
-			assert.Equal(t, tc.err.Error(), tc.wantError)
+			if !reflect.DeepEqual(tc.err.Error(), tc.wantError) {
+				t.Fatal("errors not equal")
+			}
 
 			if stackTrace(tc.err) == nil {
 				t.Fatal("expected a stack trace to be present")

--- a/weavetest/assert/assert.go
+++ b/weavetest/assert/assert.go
@@ -3,6 +3,8 @@ package assert
 import (
 	"reflect"
 	"testing"
+
+	"github.com/iov-one/weave/errors"
 )
 
 // Nil fails the test if given value is not nil.
@@ -51,4 +53,33 @@ func Panics(t testing.TB, fn func()) {
 		}
 	}()
 	fn()
+}
+
+// FieldErrors ensures that given error contains the exact match of field
+// errors, tested by their type (.Is method call).
+// To test that no error was found for a given field name, use `nil` as the
+// match value.
+func FieldErrors(t testing.TB, err error, fieldName string, mustMatch ...*errors.Error) {
+	errs := errors.FieldErrors(err, fieldName)
+
+	for _, want := range mustMatch {
+		// This is a special case when we want no errors (nil).
+		if want == nil && len(errs) == 0 {
+			continue
+		}
+		if !containsError(want, errs) {
+			t.Errorf("%q error not found", want)
+		}
+	}
+}
+
+// containsError returns true if at least one element from given collection is
+// of a provided error type.
+func containsError(e *errors.Error, collection []error) bool {
+	for _, element := range collection {
+		if e.Is(element) {
+			return true
+		}
+	}
+	return false
 }

--- a/weavetest/assert/assert_test.go
+++ b/weavetest/assert/assert_test.go
@@ -1,0 +1,75 @@
+package assert
+
+import "testing"
+import "github.com/iov-one/weave/errors"
+
+func TestFieldErrors(t *testing.T) {
+	cases := map[string]struct {
+		Err      error
+		Name     string
+		WantErrs []*errors.Error
+		WantFail int
+	}{
+		"ensure a single error exists": {
+			Err:      errors.Field("name", errors.ErrHuman, "invalid human name"),
+			Name:     "name",
+			WantErrs: []*errors.Error{errors.ErrHuman},
+			WantFail: 0,
+		},
+		"ensure no errors found": {
+			Err:      errors.Field("name", errors.ErrHuman, "invalid human name"),
+			Name:     "unknown name",
+			WantErrs: nil,
+			WantFail: 0,
+		},
+		"use nil to ensure no error was found": {
+			Err:      errors.ErrHuman,
+			Name:     "name",
+			WantErrs: []*errors.Error{nil},
+			WantFail: 0,
+		},
+		"fail if nil is expected to ensure no error was found": {
+			Err:      errors.Field("name", errors.ErrHuman, "invalid human name"),
+			Name:     "name",
+			WantErrs: []*errors.Error{nil},
+			WantFail: 1,
+		},
+	}
+
+	for testName, tc := range cases {
+		t.Run(testName, func(t *testing.T) {
+			mock := &tmock{TB: t}
+			FieldErrors(mock, tc.Err, tc.Name, tc.WantErrs...)
+			if tc.WantFail != mock.failcalls {
+				t.Fatalf("want %d fail calls, got %d", tc.WantFail, mock.failcalls)
+			}
+		})
+	}
+}
+
+// tmock mocks testing.TB and only counts failure calls. It ignores all other
+// input.
+type tmock struct {
+	testing.TB
+	failcalls int
+}
+
+func (t *tmock) Error(args ...interface{}) {
+	t.TB.Log(args...)
+	t.failcalls++
+}
+
+func (t *tmock) Errorf(s string, args ...interface{}) {
+	t.TB.Logf(s, args...)
+	t.failcalls++
+}
+
+func (t *tmock) Fatal(args ...interface{}) {
+	t.TB.Log(args...)
+	t.failcalls++
+}
+
+func (t *tmock) Fatalf(s string, args ...interface{}) {
+	t.TB.Logf(s, args...)
+	t.failcalls++
+}

--- a/x/paychan/msg_test.go
+++ b/x/paychan/msg_test.go
@@ -1,0 +1,24 @@
+package paychan
+
+import (
+	"testing"
+
+	coin "github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/weavetest/assert"
+)
+
+func TestCreatePaymentChannelMsgValidate(t *testing.T) {
+	msg := &CreatePaymentChannelMsg{
+		Total: coin.NewCoinp(1, 0, "IOV"),
+	}
+	err := msg.Validate()
+
+	assert.FieldError(t, err, "Metadata", errors.ErrMetadata)
+	assert.FieldError(t, err, "Src", errors.ErrEmpty)
+	assert.FieldError(t, err, "Recipient", errors.ErrEmpty)
+	assert.FieldError(t, err, "Timeout", errors.ErrInput)
+
+	assert.FieldError(t, err, "Total", nil)
+	assert.FieldError(t, err, "Memo", nil)
+}


### PR DESCRIPTION
This is a big change to how multi-error is implemented internally with a
minimal change to the API.

In the previous implementation, the `multiErr` type was exposed throughout
the `errors` package. Many places were type casting to check if an error
is a `multiErr` instance and provided as special execution path for this
case. This result in an entangled implementation that is hard to extend.
Adding multi-error was breaking the previous pattern where the error
implementations (`Error`, `wrappedError`, stack trace) were not aware of
each other implementation and were using only common interfaces.

This change is a preparation to implement the `Field` function as discussed in
https://github.com/iov-one/weave/issues/730

This change removes all dependency and type check. A new interface
`unpacker` is added that allows to unpack an error and transform it to a
group of errors it represents.
This design has a few consequences:
- multi-error implementation is independent of any other error implementation
- multi-error implementation is not restricted to `weave/errors` package
- errors ~cannot be flattened~ can be flattened in a limited set of cases as we cannot do the typecasting. This was (always?) possible in the previous implementation and could cause unwanted behavior. Nested errors form a tree structure
- because nested errors can form a tree structure, ABCI information can no longer return a flat list of errors. They could return a tree structure containing this information (not implemented)
- `Redact` function silence the whole group of errors that contain `ErrPanic`. It is not possible to hide only the true `ErrPanic`. This is logically correct as multi-error containing `ErrPanic` **is** `ErrPanic`
- ABCI Log message of a multi-error was changed. It is now equal to what `Error()` produce for compatibility with other errors.

~Field error implementation is in progress https://github.com/iov-one/weave/commit/9ba4341fcd06e0fd50bd04c8ebf2767908ca57f4~

---

Because maintaining two active pull request when one is based on another is hard and caused me a lot of merge conflicts :weary: I have included field error (initially by a mistake) into this pull request.

The `x/paychan` extension was ported to use the new error for the validation. Please have a look especially at the [`msg.go`](https://github.com/iov-one/weave/pull/776/files#diff-30d9884b8b78ba7b42b537fadcc0251d) and [`msg_tests.go`](https://github.com/iov-one/weave/pull/776/files#diff-e6a8445caa6b662076ecd052f692c28c).