### PR TITLE
Simplify store iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Breaking changes
 - `cash.UpdateConfigurationMsg` requires `Metadata.Schema`
 - ValidatorUpdate definitions now moved to `weave` package. Weave is using these definitions
 now instead of abci internally.
+- Simplified `Iterator` to 2 methods - Next() and Release()
 
 
 ## 0.16.0

--- a/app/helpers.go
+++ b/app/helpers.go
@@ -3,6 +3,7 @@ package app
 import (
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/store"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
@@ -76,7 +77,7 @@ func (a *ABCIStore) Iterator(start, end []byte) (weave.Iterator, error) {
 		return nil, err
 	}
 
-	return NewSliceIterator(models), nil
+	return store.NewSliceIterator(models), nil
 }
 
 func (a *ABCIStore) ReverseIterator(start, end []byte) (weave.Iterator, error) {
@@ -93,37 +94,4 @@ func toModels(keys, values []byte) ([]weave.Model, error) {
 		return nil, errors.Wrapf(errors.ErrState, "cannot unmarshal values: %v", err.Error())
 	}
 	return JoinResults(&k, &v)
-}
-
-// SliceIterator wraps an Iterator over a slice of models
-type SliceIterator struct {
-	data []weave.Model
-	idx  int
-}
-
-var _ weave.Iterator = (*SliceIterator)(nil)
-
-// NewSliceIterator creates a new Iterator over this slice
-func NewSliceIterator(data []weave.Model) *SliceIterator {
-	return &SliceIterator{
-		data: data,
-	}
-}
-
-// Next moves the iterator to the next sequential key in the database, as
-// defined by order of iteration.
-//
-// Returns (nil, nil, errors.ErrIteratorDone) if there is no more data
-func (s *SliceIterator) Next() (key, value []byte, err error) {
-	if s.idx >= len(s.data) {
-		return nil, nil, errors.Wrap(errors.ErrIteratorDone, "slice iterator")
-	}
-	val := s.data[s.idx]
-	s.idx++
-	return val.Key, val.Value, nil
-}
-
-// Release releases the Iterator.
-func (s *SliceIterator) Release() {
-	s.data = nil
 }

--- a/app/helpers.go
+++ b/app/helpers.go
@@ -110,34 +110,20 @@ func NewSliceIterator(data []weave.Model) *SliceIterator {
 	}
 }
 
-// Valid implements Iterator and returns true iff it can be read
-func (s *SliceIterator) Valid() bool {
-	return s.idx < len(s.data)
-}
-
 // Next moves the iterator to the next sequential key in the database, as
 // defined by order of iteration.
 //
-// If Valid returns false, this method will panic.keys
-func (s *SliceIterator) Next() error {
+// Returns (nil, nil, errors.ErrDone) if there is no more data
+func (s *SliceIterator) Next() (key, value []byte, err error) {
 	if s.idx >= len(s.data) {
-		return errors.Wrap(errors.ErrDatabase, "Passed end of slice")
+		return nil, nil, errors.Wrap(errors.ErrDone, "slice iterator")
 	}
+	val := s.data[s.idx]
 	s.idx++
-	return nil
+	return val.Key, val.Value, nil
 }
 
-// Key returns the key of the cursor.
-func (s *SliceIterator) Key() (key []byte) {
-	return s.data[s.idx].Key
-}
-
-// Value returns the value of the cursor.
-func (s *SliceIterator) Value() (value []byte) {
-	return s.data[s.idx].Value
-}
-
-// Close releases the Iterator.
-func (s *SliceIterator) Close() {
+// Return releases the Iterator.
+func (s *SliceIterator) Return() {
 	s.data = nil
 }

--- a/app/helpers.go
+++ b/app/helpers.go
@@ -123,7 +123,7 @@ func (s *SliceIterator) Next() (key, value []byte, err error) {
 	return val.Key, val.Value, nil
 }
 
-// Return releases the Iterator.
-func (s *SliceIterator) Return() {
+// Release releases the Iterator.
+func (s *SliceIterator) Release() {
 	s.data = nil
 }

--- a/app/helpers.go
+++ b/app/helpers.go
@@ -113,10 +113,10 @@ func NewSliceIterator(data []weave.Model) *SliceIterator {
 // Next moves the iterator to the next sequential key in the database, as
 // defined by order of iteration.
 //
-// Returns (nil, nil, errors.ErrDone) if there is no more data
+// Returns (nil, nil, errors.ErrIteratorDone) if there is no more data
 func (s *SliceIterator) Next() (key, value []byte, err error) {
 	if s.idx >= len(s.data) {
-		return nil, nil, errors.Wrap(errors.ErrDone, "slice iterator")
+		return nil, nil, errors.Wrap(errors.ErrIteratorDone, "slice iterator")
 	}
 	val := s.data[s.idx]
 	s.idx++

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -80,6 +80,9 @@ var (
 	// ErrDeleted is returned whenever a deleted object version is accessed.
 	ErrDeleted = Register(21, "content deleted")
 
+	// ErrDone is returned when an iterator hits the end of the data source.
+	ErrDone = Register(22, "iterator done")
+
 	// ErrNetwork is returned on network failure (only for client libraries)
 	ErrNetwork = Register(100200, "network")
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -80,8 +80,8 @@ var (
 	// ErrDeleted is returned whenever a deleted object version is accessed.
 	ErrDeleted = Register(21, "content deleted")
 
-	// ErrDone is returned when an iterator hits the end of the data source.
-	ErrDone = Register(22, "iterator done")
+	// ErrIteratorDone is returned when an iterator hits the end of the data source.
+	ErrIteratorDone = Register(22, "iterator done")
 
 	// ErrNetwork is returned on network failure (only for client libraries)
 	ErrNetwork = Register(100200, "network")

--- a/orm/index.go
+++ b/orm/index.go
@@ -183,7 +183,7 @@ func (i Index) GetPrefix(db weave.ReadOnlyKVStore, prefix []byte) ([][]byte, err
 	if err != nil {
 		return nil, err
 	}
-	defer itr.Return()
+	defer itr.Release()
 
 	var data [][]byte
 	_, value, err := itr.Next()

--- a/orm/index.go
+++ b/orm/index.go
@@ -200,7 +200,7 @@ func (i Index) GetPrefix(db weave.ReadOnlyKVStore, prefix []byte) ([][]byte, err
 		}
 		_, value, err = itr.Next()
 	}
-	if !errors.ErrDone.Is(err) {
+	if !errors.ErrIteratorDone.Is(err) {
 		return nil, err
 	}
 	return data, nil

--- a/orm/query.go
+++ b/orm/query.go
@@ -23,7 +23,7 @@ func consumeIterator(itr weave.Iterator) ([]weave.Model, error) {
 		res = append(res, weave.Model{Key: key, Value: value})
 		key, value, err = itr.Next()
 	}
-	if !errors.ErrDone.Is(err) {
+	if !errors.ErrIteratorDone.Is(err) {
 		return nil, err
 	}
 	return res, nil

--- a/orm/query.go
+++ b/orm/query.go
@@ -15,7 +15,7 @@ func RegisterQuery(qr weave.QueryRouter) {
 // consumeIterator will read all remaining data into an
 // array and close the iterator
 func consumeIterator(itr weave.Iterator) ([]weave.Model, error) {
-	defer itr.Return()
+	defer itr.Release()
 
 	var res []weave.Model
 	key, value, err := itr.Next()

--- a/orm/query.go
+++ b/orm/query.go
@@ -1,6 +1,9 @@
 package orm
 
-import "github.com/iov-one/weave"
+import (
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/errors"
+)
 
 // RegisterQuery will register a root query (literal keys)
 // under "/"
@@ -12,19 +15,16 @@ func RegisterQuery(qr weave.QueryRouter) {
 // consumeIterator will read all remaining data into an
 // array and close the iterator
 func consumeIterator(itr weave.Iterator) ([]weave.Model, error) {
-	defer itr.Close()
+	defer itr.Return()
 
 	var res []weave.Model
-	for itr.Valid() {
-		mod := weave.Model{
-			Key:   itr.Key(),
-			Value: itr.Value(),
-		}
-		res = append(res, mod)
-		err := itr.Next()
-		if err != nil {
-			return nil, err
-		}
+	key, value, err := itr.Next()
+	for err == nil {
+		res = append(res, weave.Model{Key: key, Value: value})
+		key, value, err = itr.Next()
+	}
+	if !errors.ErrDone.Is(err) {
+		return nil, err
 	}
 	return res, nil
 }

--- a/store.go
+++ b/store.go
@@ -56,7 +56,7 @@ keys. These may all be preloaded, or loaded on demand.
   Usage:
 
   var itr Iterator = ...
-  defer itr.Return()
+  defer itr.Release()
 
   k, v, err := itr.Next()
   for err == nil {
@@ -71,12 +71,10 @@ keys. These may all be preloaded, or loaded on demand.
 type Iterator interface {
 	// Next moves the iterator to the next sequential key in the database, as
 	// defined by order of iteration.
-	//
-	//
 	Next() (key, value []byte, err error)
 
-	// Return releases the Iterator, allowing it to do any needed cleanup.
-	Return()
+	// Release releases the Iterator, allowing it to do any needed cleanup.
+	Release()
 }
 
 ///////////////////////////////////////////////////////////

--- a/store.go
+++ b/store.go
@@ -63,8 +63,8 @@ keys. These may all be preloaded, or loaded on demand.
 	// ... do stuff with k, v
 	k, v, err = itr.Next()
   }
-  // ErrDone means we hit the end, otherwise this is a real error
-  if !errors.ErrDone.Is(err) {
+  // ErrIteratorDone means we hit the end, otherwise this is a real error
+  if !errors.ErrIteratorDone.Is(err) {
 	  return err
   }
 */
@@ -72,7 +72,7 @@ type Iterator interface {
 	// Next moves the iterator to the next sequential key in the database, as
 	// defined by order of iteration.
 	//
-	// Returns (nil, nil, errors.ErrDone) if there is no more data
+	// Returns (nil, nil, errors.ErrIteratorDone) if there is no more data
 	Next() (key, value []byte, err error)
 
 	// Release releases the Iterator, allowing it to do any needed cleanup.

--- a/store.go
+++ b/store.go
@@ -64,13 +64,15 @@ keys. These may all be preloaded, or loaded on demand.
 	k, v, err = itr.Next()
   }
   // ErrDone means we hit the end, otherwise this is a real error
-  if err != errors.ErrDone {
+  if !errors.ErrDone.Is(err) {
 	  return err
   }
 */
 type Iterator interface {
 	// Next moves the iterator to the next sequential key in the database, as
 	// defined by order of iteration.
+	//
+	// Returns (nil, nil, errors.ErrDone) if there is no more data
 	Next() (key, value []byte, err error)
 
 	// Release releases the Iterator, allowing it to do any needed cleanup.

--- a/store.go
+++ b/store.go
@@ -56,40 +56,27 @@ keys. These may all be preloaded, or loaded on demand.
   Usage:
 
   var itr Iterator = ...
-  defer itr.Close()
+  defer itr.Return()
 
-  for ; itr.Valid(); itr.Next() {
-    k, v := itr.Key(); itr.Value()
-    // ...
+  k, v, err := itr.Next()
+  for err == nil {
+	// ... do stuff with k, v
+	k, v, err = itr.Next()
   }
-
-Note that Valid(), Key() and Value() are assumed to use a cached state
-(read on initialization or Next) and should never return errors.
-Next() may well return a read error.
+  // ErrDone means we hit the end, otherwise this is a real error
+  if err != errors.ErrDone {
+	  return err
+  }
 */
 type Iterator interface {
-	// Valid returns whether the current position is valid.
-	// Once invalid, an Iterator is forever invalid.
-	Valid() bool
-
 	// Next moves the iterator to the next sequential key in the database, as
 	// defined by order of iteration.
 	//
-	// If Valid returns false, this method will panic.
-	Next() error
+	//
+	Next() (key, value []byte, err error)
 
-	// Key returns the key of the cursor.
-	// If Valid returns false, this method will panic.
-	// CONTRACT: key readonly []byte
-	Key() (key []byte)
-
-	// Value returns the value of the cursor.
-	// If Valid returns false, this method will panic.
-	// CONTRACT: value readonly []byte
-	Value() (value []byte)
-
-	// Close releases the Iterator.
-	Close()
+	// Return releases the Iterator, allowing it to do any needed cleanup.
+	Return()
 }
 
 ///////////////////////////////////////////////////////////

--- a/store/helpers.go
+++ b/store/helpers.go
@@ -22,47 +22,22 @@ func NewSliceIterator(data []Model) *SliceIterator {
 	}
 }
 
-// Valid implements Iterator and returns true iff it can be read
-func (s *SliceIterator) Valid() bool {
-	return s.idx < len(s.data)
-}
-
 // Next moves the iterator to the next sequential key in the database, as
 // defined by order of iteration.
 //
-// If Valid returns false, this method will panic.
-func (s *SliceIterator) Next() error {
+// Returns (nil, nil, errors.ErrDone) if there is no more data
+func (s *SliceIterator) Next() (key, value []byte, err error) {
 	if s.idx >= len(s.data) {
-		return errors.Wrap(errors.ErrDatabase, "Passed end of slice")
+		return nil, nil, errors.Wrap(errors.ErrDone, "slice iterator")
 	}
+	val := s.data[s.idx]
 	s.idx++
-	return nil
+	return val.Key, val.Value, nil
 }
 
-// Key returns the key of the cursor.
-func (s *SliceIterator) Key() (key []byte) {
-	return s.data[s.idx].Key
-}
-
-// Value returns the value of the cursor.
-func (s *SliceIterator) Value() (value []byte) {
-	return s.data[s.idx].Value
-}
-
-// Close releases the Iterator.
-func (s *SliceIterator) Close() {
+// Return releases the Iterator.
+func (s *SliceIterator) Return() {
 	s.data = nil
-}
-
-// TakeFirst is a helper when you only want the first value.
-// It closes the Iterator after reading, and is not meant for loops,
-// but rather to implement First/Last.
-func TakeFirst(iter Iterator) (key, value []byte, err error) {
-	if !iter.Valid() {
-		return nil, nil, errors.Wrap(errors.ErrNotFound, "iterator invalid")
-	}
-	defer iter.Close()
-	return iter.Key(), iter.Value(), nil
 }
 
 /////////////////////////////////////////////////////

--- a/store/helpers.go
+++ b/store/helpers.go
@@ -35,8 +35,8 @@ func (s *SliceIterator) Next() (key, value []byte, err error) {
 	return val.Key, val.Value, nil
 }
 
-// Return releases the Iterator.
-func (s *SliceIterator) Return() {
+// Release releases the Iterator.
+func (s *SliceIterator) Release() {
 	s.data = nil
 }
 

--- a/store/helpers.go
+++ b/store/helpers.go
@@ -22,10 +22,6 @@ func NewSliceIterator(data []Model) *SliceIterator {
 	}
 }
 
-// Next moves the iterator to the next sequential key in the database, as
-// defined by order of iteration.
-//
-// Returns (nil, nil, errors.ErrDone) if there is no more data
 func (s *SliceIterator) Next() (key, value []byte, err error) {
 	if s.idx >= len(s.data) {
 		return nil, nil, errors.Wrap(errors.ErrDone, "slice iterator")

--- a/store/helpers.go
+++ b/store/helpers.go
@@ -24,7 +24,7 @@ func NewSliceIterator(data []Model) *SliceIterator {
 
 func (s *SliceIterator) Next() (key, value []byte, err error) {
 	if s.idx >= len(s.data) {
-		return nil, nil, errors.Wrap(errors.ErrDone, "slice iterator")
+		return nil, nil, errors.Wrap(errors.ErrIteratorDone, "slice iterator")
 	}
 	val := s.data[s.idx]
 	s.idx++

--- a/store/helpers_test.go
+++ b/store/helpers_test.go
@@ -36,7 +36,7 @@ func TestSliceIterator(t *testing.T) {
 	it := NewSliceIterator(models)
 	_, _, err = it.Next()
 	assert.Nil(t, err)
-	it.Return()
+	it.Release()
 	_, _, err = it.Next()
 	if !errors.ErrDone.Is(err) {
 		t.Fatal("closed iterator must be invalid")

--- a/store/helpers_test.go
+++ b/store/helpers_test.go
@@ -29,8 +29,8 @@ func TestSliceIterator(t *testing.T) {
 		key, value, err = iter.Next()
 	}
 	assert.Equal(t, size, i)
-	if !errors.ErrDone.Is(err) {
-		t.Fatalf("Expected ErrDone, got %+v", err)
+	if !errors.ErrIteratorDone.Is(err) {
+		t.Fatalf("Expected ErrIteratorDone, got %+v", err)
 	}
 
 	it := NewSliceIterator(models)
@@ -38,7 +38,7 @@ func TestSliceIterator(t *testing.T) {
 	assert.Nil(t, err)
 	it.Release()
 	_, _, err = it.Next()
-	if !errors.ErrDone.Is(err) {
+	if !errors.ErrIteratorDone.Is(err) {
 		t.Fatal("closed iterator must be invalid")
 	}
 }

--- a/store/iavl/adapter.go
+++ b/store/iavl/adapter.go
@@ -181,7 +181,7 @@ func (a adapter) Iterator(start, end []byte) (store.Iterator, error) {
 	iter := newLazyIterator()
 	go func() {
 		a.tree.IterateRange(start, end, true, iter.add)
-		iter.Return()
+		iter.Release()
 	}()
 
 	return iter, nil
@@ -194,7 +194,7 @@ func (a adapter) ReverseIterator(start, end []byte) (store.Iterator, error) {
 	iter := newLazyIterator()
 	go func() {
 		a.tree.IterateRange(start, end, false, iter.add)
-		iter.Return()
+		iter.Release()
 	}()
 
 	return iter, nil

--- a/store/iavl/adapter.go
+++ b/store/iavl/adapter.go
@@ -181,10 +181,10 @@ func (a adapter) Iterator(start, end []byte) (store.Iterator, error) {
 	iter := newLazyIterator()
 	go func() {
 		a.tree.IterateRange(start, end, true, iter.add)
-		iter.Close()
+		iter.Return()
 	}()
 
-	return iter, iter.Next()
+	return iter, nil
 }
 
 // ReverseIterator over a domain of keys in descending order. End is exclusive.
@@ -194,8 +194,8 @@ func (a adapter) ReverseIterator(start, end []byte) (store.Iterator, error) {
 	iter := newLazyIterator()
 	go func() {
 		a.tree.IterateRange(start, end, false, iter.add)
-		iter.Close()
+		iter.Return()
 	}()
 
-	return iter, iter.Next()
+	return iter, nil
 }

--- a/store/iavl/iterator.go
+++ b/store/iavl/iterator.go
@@ -45,7 +45,7 @@ func (i *lazyIterator) Next() ([]byte, []byte, error) {
 	return data.Key, data.Value, nil
 }
 
-func (i *lazyIterator) Return() {
+func (i *lazyIterator) Release() {
 	// make sure we only close once to avoid panics and halts on i.stop
 	i.once.Do(func() {
 		close(i.stop)

--- a/store/iavl/iterator.go
+++ b/store/iavl/iterator.go
@@ -40,7 +40,7 @@ func (i *lazyIterator) add(key []byte, value []byte) bool {
 func (i *lazyIterator) Next() ([]byte, []byte, error) {
 	data, hasMore := <-i.read
 	if !hasMore {
-		return nil, nil, errors.Wrap(errors.ErrDone, "iavl lazy iterator")
+		return nil, nil, errors.Wrap(errors.ErrIteratorDone, "iavl lazy iterator")
 	}
 	return data.Key, data.Value, nil
 }

--- a/store/iterator.go
+++ b/store/iterator.go
@@ -101,7 +101,7 @@ func (b *btreeIter) wrap(parent Iterator) *itemIter {
 func (b *btreeIter) Next() (keyer, error) {
 	data, hasMore := <-b.read
 	if !hasMore {
-		return nil, errors.Wrap(errors.ErrDone, "btree iterator")
+		return nil, errors.Wrap(errors.ErrIteratorDone, "btree iterator")
 	}
 	key, ok := data.(keyer)
 	if !ok {
@@ -135,7 +135,7 @@ var _ Iterator = (*itemIter)(nil)
 // and set cached value as well as done flags.
 //
 // it will skip closed and missing iterators.
-// doesn't return ErrDone, but only unexpected data errors.
+// doesn't return ErrIteratorDone, but only unexpected data errors.
 func (i *itemIter) advanceParent() error {
 	if i.parent == nil {
 		i.parentDone = true
@@ -145,7 +145,7 @@ func (i *itemIter) advanceParent() error {
 	}
 
 	key, value, err := i.parent.Next()
-	if errors.ErrDone.Is(err) {
+	if errors.ErrIteratorDone.Is(err) {
 		i.parentDone = true
 	} else if err != nil {
 		return errors.Wrap(err, "advance parent")
@@ -162,12 +162,12 @@ func (i *itemIter) advanceParent() error {
 // It will skip any deleted items before the i.cachedParent.Key value
 //
 // it will skip closed and missing iterators.
-// doesn't return ErrDone, but only unexpected data errors.
+// doesn't return ErrIteratorDone, but only unexpected data errors.
 func (i *itemIter) advanceWrap() error {
 	for !i.wrapDone && i.cachedWrap == nil {
 		var err error
 		i.cachedWrap, err = i.wrap.Next()
-		if errors.ErrDone.Is(err) {
+		if errors.ErrIteratorDone.Is(err) {
 			i.wrapDone = true
 			return nil
 		} else if err != nil {
@@ -226,7 +226,7 @@ func (i *itemIter) Next() (key, value []byte, err error) {
 // returns cached item from wrap (helper for Next)
 func (i *itemIter) returnCachedWrap() (key, value []byte, err error) {
 	if i.wrapDone {
-		return nil, nil, errors.Wrap(errors.ErrDone, "itemIter wrap done")
+		return nil, nil, errors.Wrap(errors.ErrIteratorDone, "itemIter wrap done")
 	}
 	item := i.cachedWrap.(setItem)
 	i.cachedWrap = nil
@@ -237,7 +237,7 @@ func (i *itemIter) returnCachedWrap() (key, value []byte, err error) {
 // returns cached item from parent (helper for Next)
 func (i *itemIter) returnCachedParent() (key, value []byte, err error) {
 	if i.parentDone {
-		return nil, nil, errors.Wrap(errors.ErrDone, "itemIter parent done")
+		return nil, nil, errors.Wrap(errors.ErrIteratorDone, "itemIter parent done")
 	}
 	key, value = i.cachedParent.Key, i.cachedParent.Value
 	i.cachedParent = weave.Model{}

--- a/store/iterator.go
+++ b/store/iterator.go
@@ -183,10 +183,6 @@ func (i *itemIter) advanceWrap() error {
 	return nil
 }
 
-// Next moves the iterator to the next sequential key in the database, as
-// defined by order of iteration.
-//
-// If Valid returns false, this method will panic.
 func (i *itemIter) Next() (key, value []byte, err error) {
 	// this guarantees that both have xxxDone == true or cachedXxx != nil
 	if err := i.advanceParent(); err != nil {

--- a/store/iterator.go
+++ b/store/iterator.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"bytes"
-	"fmt"
 	"sync"
 
 	"github.com/google/btree"
@@ -226,21 +225,18 @@ func (i *itemIter) Next() (key, value []byte, err error) {
 		return i.returnCachedWrap()
 	}
 
-	// both are valid... try it
-	_, isSet := i.cachedWrap.(setItem)
-	fmt.Printf("Set: %t (parent: %X, wrap: %X)\n", isSet, i.cachedParent.Key, i.cachedWrap.Key())
+	// both are valid... see which is first
 	switch bytes.Compare(i.cachedParent.Key, i.cachedWrap.Key()) {
 	case -i.first: // cachedWrap first
 		return i.returnCachedWrap()
 	case i.first: // cachedParent first
 		return i.returnCachedParent()
 	case 0: // at the same key
-		// if it is set, use wrap
+		i.cachedParent = weave.Model{}
 		if _, ok := i.cachedWrap.(setItem); ok {
 			return i.returnCachedWrap()
 		}
 		// if it is a delete, then we unset both and continue again
-		i.cachedParent = weave.Model{}
 		i.cachedWrap = nil
 		return i.Next()
 	}

--- a/store/iterator.go
+++ b/store/iterator.go
@@ -110,7 +110,7 @@ func (b *btreeIter) Next() (keyer, error) {
 	return key, nil
 }
 
-func (b *btreeIter) Return() {
+func (b *btreeIter) Release() {
 	b.once.Do(func() {
 		b.stop <- struct{}{}
 	})
@@ -245,8 +245,8 @@ func (i *itemIter) returnCachedParent() (key, value []byte, err error) {
 	return key, value, nil
 }
 
-// Return releases the Iterator.
-func (i *itemIter) Return() {
-	i.parent.Return()
-	i.wrap.Return()
+// Release releases the Iterator.
+func (i *itemIter) Release() {
+	i.parent.Release()
+	i.wrap.Release()
 }

--- a/store/test_suite.go
+++ b/store/test_suite.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -231,7 +232,6 @@ func (s *TestSuite) IteratorWithConflicts(t *testing.T) {
 				// query for the values in child
 				{nil, nil, false, expect0},
 				{expect0[1].Key, expect0[2].Key, false, expect0[1:2]},
-
 				{nil, nil, true, reverse(expect0)},
 			},
 		},
@@ -241,7 +241,6 @@ func (s *TestSuite) IteratorWithConflicts(t *testing.T) {
 				// query for the values in child
 				{nil, nil, false, expect0},
 				{expect0[1].Key, expect0[2].Key, false, expect0[1:2]},
-
 				{nil, nil, true, reverse(expect0)},
 			},
 		},
@@ -251,9 +250,8 @@ func (s *TestSuite) IteratorWithConflicts(t *testing.T) {
 			queries: []rangeQuery{
 				// query for the values in child
 				{nil, nil, false, expect0},
-				// {expect0[1].Key, expect0[2].Key, false, expect0[1:2]},
-
-				// {nil, nil, true, reverse(expect0)},
+				{expect0[1].Key, expect0[2].Key, false, expect0[1:2]},
+				{nil, nil, true, reverse(expect0)},
 			},
 		},
 		"overwrite data should show child data": {
@@ -263,7 +261,6 @@ func (s *TestSuite) IteratorWithConflicts(t *testing.T) {
 				// query for the values in child
 				{nil, nil, false, expect1},
 				{expect1[1].Key, expect1[3].Key, false, expect1[1:3]},
-
 				{nil, nil, true, reverse(expect1)},
 			},
 		},
@@ -341,7 +338,7 @@ func (i iterCase) verify(t testing.TB, base CacheableKVStore) {
 		assert.Nil(t, op.Apply(child))
 	}
 
-	for _, q := range i.queries {
+	for i, q := range i.queries {
 		var iter Iterator
 		var err error
 		if q.reverse {
@@ -350,6 +347,7 @@ func (i iterCase) verify(t testing.TB, base CacheableKVStore) {
 			iter, err = child.Iterator(q.start, q.end)
 		}
 		assert.Nil(t, err)
+		fmt.Printf("query %d\n", i)
 
 		// Make sure proper iteration works.
 		for i := 0; i < len(q.expected); i++ {

--- a/store/test_suite.go
+++ b/store/test_suite.go
@@ -251,9 +251,9 @@ func (s *TestSuite) IteratorWithConflicts(t *testing.T) {
 			queries: []rangeQuery{
 				// query for the values in child
 				{nil, nil, false, expect0},
-				{expect0[1].Key, expect0[2].Key, false, expect0[1:2]},
+				// {expect0[1].Key, expect0[2].Key, false, expect0[1:2]},
 
-				{nil, nil, true, reverse(expect0)},
+				// {nil, nil, true, reverse(expect0)},
 			},
 		},
 		"overwrite data should show child data": {
@@ -338,7 +338,7 @@ func (i iterCase) verify(t testing.TB, base CacheableKVStore) {
 
 	child := base.CacheWrap()
 	for _, op := range i.child {
-		assert.Nil(t, op.Apply(base))
+		assert.Nil(t, op.Apply(child))
 	}
 
 	for _, q := range i.queries {
@@ -350,6 +350,7 @@ func (i iterCase) verify(t testing.TB, base CacheableKVStore) {
 			iter, err = child.Iterator(q.start, q.end)
 		}
 		assert.Nil(t, err)
+
 		// Make sure proper iteration works.
 		for i := 0; i < len(q.expected); i++ {
 			key, value, err := iter.Next()

--- a/store/test_suite.go
+++ b/store/test_suite.go
@@ -358,8 +358,8 @@ func (i iterCase) verify(t testing.TB, base CacheableKVStore) {
 			assert.Equal(t, q.expected[i].Value, value)
 		}
 		_, _, err = iter.Next()
-		if !errors.ErrDone.Is(err) {
-			t.Fatalf("Expected ErrDone, got %+v", err)
+		if !errors.ErrIteratorDone.Is(err) {
+			t.Fatalf("Expected ErrIteratorDone, got %+v", err)
 		}
 	}
 }

--- a/store/test_suite.go
+++ b/store/test_suite.go
@@ -3,7 +3,6 @@ package store
 import (
 	"bytes"
 	"crypto/rand"
-	"fmt"
 	"sort"
 	"testing"
 
@@ -338,7 +337,7 @@ func (i iterCase) verify(t testing.TB, base CacheableKVStore) {
 		assert.Nil(t, op.Apply(child))
 	}
 
-	for i, q := range i.queries {
+	for _, q := range i.queries {
 		var iter Iterator
 		var err error
 		if q.reverse {
@@ -347,13 +346,14 @@ func (i iterCase) verify(t testing.TB, base CacheableKVStore) {
 			iter, err = child.Iterator(q.start, q.end)
 		}
 		assert.Nil(t, err)
-		fmt.Printf("query %d\n", i)
 
 		// Make sure proper iteration works.
 		for i := 0; i < len(q.expected); i++ {
 			key, value, err := iter.Next()
 			assert.Nil(t, err)
-			assert.Equal(t, q.expected[i].Key, key)
+			if !bytes.Equal(q.expected[i].Key, key) {
+				t.Fatalf("Expected key: %X\nGot keys %d = %X", q.expected[i].Key, i, key)
+			}
 			assert.Equal(t, q.expected[i].Value, value)
 		}
 		_, _, err = iter.Next()

--- a/store/test_suite.go
+++ b/store/test_suite.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/weavetest/assert"
 )
 
@@ -351,12 +352,15 @@ func (i iterCase) verify(t testing.TB, base CacheableKVStore) {
 		assert.Nil(t, err)
 		// Make sure proper iteration works.
 		for i := 0; i < len(q.expected); i++ {
-			assert.Equal(t, iter.Valid(), true)
-			assert.Equal(t, q.expected[i].Key, iter.Key())
-			assert.Equal(t, q.expected[i].Value, iter.Value())
-			assert.Nil(t, iter.Next())
+			key, value, err := iter.Next()
+			assert.Nil(t, err)
+			assert.Equal(t, q.expected[i].Key, key)
+			assert.Equal(t, q.expected[i].Value, value)
 		}
-		assert.Equal(t, iter.Valid(), false)
+		_, _, err = iter.Next()
+		if !errors.ErrDone.Is(err) {
+			t.Fatalf("Expected ErrDone, got %+v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #763 

Updated weave.Iterator interface to:

```golang
type Iterator interface {
        // Next returns (nil, nil, ErrDone) when there are no more value left
	Next() (key []byte, value []byte, err error)
	Release()
}
```

Updated all code in store and orm that relied on it (including some larger refactoring of the btree iterator, which made it nicer to read).

No functionality changed, just API