### PR TITLE
Handle cache write error 

### DIFF
--- a/x/utils/savepoint.go
+++ b/x/utils/savepoint.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/errors"
 )
 
 // Savepoint will isolate all data inside of the call,
@@ -50,8 +51,9 @@ func (s Savepoint) Check(ctx weave.Context, store weave.KVStore, tx weave.Tx, ne
 	if res, err := next.Check(ctx, cache, tx); err != nil {
 		cache.Discard()
 		return nil, err
+	} else if werr := cache.Write(); werr != nil {
+		return nil, errors.Wrap(werr, "writing savepoint")
 	} else {
-		cache.Write()
 		return res, nil
 	}
 }
@@ -71,8 +73,9 @@ func (s Savepoint) Deliver(ctx weave.Context, store weave.KVStore, tx weave.Tx, 
 	if res, err := next.Deliver(ctx, cache, tx); err != nil {
 		cache.Discard()
 		return nil, err
+	} else if werr := cache.Write(); werr != nil {
+		return nil, errors.Wrap(werr, "writing savepoint")
 	} else {
-		cache.Write()
 		return res, nil
 	}
 }


### PR DESCRIPTION
Closes #778 

This ensures we properly handle errors when writing the cache to the backing store in DynamicFeeDecorator. I also fixed the same issue in Savepoint. The only other point in our stack that flushes Cache is app.CommitStore.Commit, which already properly handled any errors on write.

#trivial  