### PR TITLE
unify all message path values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+Breaking changes
+
+- Unify all message paths to follow pattern `<package>/<message_name>`
+
 ## 0.17.0
 
 - Unified dedupe logic for validator bookkeeping and validator diffs in `app`

--- a/cmd/bnsd/app/testdata/fixtures/app.go
+++ b/cmd/bnsd/app/testdata/fixtures/app.go
@@ -145,7 +145,7 @@ func appStateGenesis(keyAddress weave.Address) []byte {
 		},
 		"msgfee": []interface{}{
 			dict{
-				"msg_path": "distribution/newrevenue",
+				"msg_path": "distribution/create",
 				"fee":      "2 FRNK",
 			},
 			dict{
@@ -153,11 +153,11 @@ func appStateGenesis(keyAddress weave.Address) []byte {
 				"fee":      "0.2FRNK",
 			},
 			dict{
-				"msg_path": "distribution/resetRevenue",
+				"msg_path": "distribution/reset",
 				"fee":      "1 FRNK",
 			},
 			dict{
-				"msg_path": "username/registerUsernameToken",
+				"msg_path": "username/register_token",
 				"fee":      "5 FRNK",
 			},
 		},

--- a/cmd/bnsd/client/testdata/genesis.json
+++ b/cmd/bnsd/client/testdata/genesis.json
@@ -99,7 +99,7 @@
          "whole": 2,
          "ticker": "CASH"
        },
-       "msg_path": "distribution/newrevenue"
+       "msg_path": "distribution/create"
      },
      {
        "fee": {
@@ -114,14 +114,14 @@
          "whole": 1,
          "ticker": "CASH"
        },
-       "msg_path": "distribution/resetRevenue"
+       "msg_path": "distribution/reset"
      },
      {
        "fee": {
          "whole": 5,
          "ticker": "CASH"
        },
-       "msg_path": "username/transferUsernameToken"
+       "msg_path": "username/transfer_token"
      }
    ]
    }

--- a/cmd/bnsd/x/username/msg.go
+++ b/cmd/bnsd/x/username/msg.go
@@ -25,7 +25,7 @@ func (m *RegisterTokenMsg) Validate() error {
 }
 
 func (RegisterTokenMsg) Path() string {
-	return "username/registerToken"
+	return "username/register_token"
 }
 
 func (m *TransferTokenMsg) Validate() error {
@@ -42,7 +42,7 @@ func (m *TransferTokenMsg) Validate() error {
 }
 
 func (TransferTokenMsg) Path() string {
-	return "username/transferToken"
+	return "username/transfer_token"
 }
 
 func (m *ChangeTokenTargetsMsg) Validate() error {
@@ -59,5 +59,5 @@ func (m *ChangeTokenTargetsMsg) Validate() error {
 }
 
 func (ChangeTokenTargetsMsg) Path() string {
-	return "username/changeTokenTargets"
+	return "username/change_token_targets"
 }

--- a/tx.go
+++ b/tx.go
@@ -14,13 +14,17 @@ type Msg interface {
 	Persistent
 
 	// Return the message path.
-	// This is used by the Router to locate the proper Handler.
-	// Msg should be created alongside the Handler that corresponds to them.
+	// This is used by the Router to locate the proper Handler. Msg should
+	// be created alongside the Handler that corresponds to them.
 	//
-	// Multiple types may have the same value, and will end up at the
-	// same Handler.
+	// Multiple message types may return the same path value and will end
+	// up being processed by the same Handler.
 	//
-	// Must be alphanumeric [0-9A-Za-z_\-]+
+	// Path value must be constructed following several rules:
+	// - name must be snake_case
+	// - value must be in format <extension_name>/<message_type_name> where
+	//   extension_name is the same as the Go package name and the
+	//   message_type_name is the snake_case converted message name.
 	Path() string
 
 	// Validate performs a sanity checks on this message. It returns an

--- a/x/aswap/handler.go
+++ b/x/aswap/handler.go
@@ -26,7 +26,7 @@ func RegisterRoutes(r weave.Registry, auth x.Authenticator, cashctrl cash.Contro
 
 	r.Handle(pathCreateSwap, CreateSwapHandler{auth, bucket, cashctrl})
 	r.Handle(pathReleaseSwap, ReleaseSwapHandler{auth, bucket, cashctrl})
-	r.Handle(pathReturnReturn, ReturnSwapHandler{auth, bucket, cashctrl})
+	r.Handle(pathReturnSwap, ReturnSwapHandler{auth, bucket, cashctrl})
 }
 
 // RegisterQuery will register this bucket as "/aswaps"

--- a/x/aswap/msg.go
+++ b/x/aswap/msg.go
@@ -16,9 +16,9 @@ func init() {
 }
 
 const (
-	pathCreateSwap   = "swap/create"
-	pathReleaseSwap  = "swap/release"
-	pathReturnReturn = "swap/return"
+	pathCreateSwap  = "aswap/create"
+	pathReleaseSwap = "aswap/release"
+	pathReturnSwap  = "aswap/return"
 
 	maxMemoSize int = 128
 	// preimage size in bytes
@@ -42,7 +42,7 @@ func (ReleaseMsg) Path() string {
 }
 
 func (ReturnSwapMsg) Path() string {
-	return pathReturnReturn
+	return pathReturnSwap
 }
 
 // VALIDATION, Validate method makes sure basic rules are enforced upon input data and fulfills weave.Msg interface

--- a/x/batch/msg.go
+++ b/x/batch/msg.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	PathExecuteBatchMsg = "batch/execute"
+	PathExecuteBatchMsg = "batch/execute_batch"
 )
 
 type Msg interface {

--- a/x/cash/handler.go
+++ b/x/cash/handler.go
@@ -14,7 +14,7 @@ func RegisterRoutes(r weave.Registry, auth x.Authenticator, control Controller) 
 	r = migration.SchemaMigratingRegistry("cash", r)
 
 	r.Handle(pathSendMsg, NewSendHandler(auth, control))
-	r.Handle(pathConfigurationUpdateMsg, NewConfigHandler(auth))
+	r.Handle(pathUpdateConfigurationMsg, NewConfigHandler(auth))
 }
 
 // RegisterQuery will register this bucket as "/wallets"

--- a/x/cash/msg.go
+++ b/x/cash/msg.go
@@ -17,7 +17,7 @@ var _ weave.Msg = (*SendMsg)(nil)
 
 const (
 	pathSendMsg                      = "cash/send"
-	pathConfigurationUpdateMsg       = "cash/update_config"
+	pathUpdateConfigurationMsg       = "cash/update_configuration"
 	sendTxCost                 int64 = 100
 
 	maxMemoSize int = 128
@@ -130,5 +130,5 @@ func (m *UpdateConfigurationMsg) Validate() error {
 }
 
 func (*UpdateConfigurationMsg) Path() string {
-	return pathConfigurationUpdateMsg
+	return pathUpdateConfigurationMsg
 }

--- a/x/currency/msg.go
+++ b/x/currency/msg.go
@@ -14,7 +14,7 @@ func init() {
 var _ weave.Msg = (*CreateMsg)(nil)
 
 func (CreateMsg) Path() string {
-	return "currency/tokeninfo"
+	return "currency/create"
 }
 
 func (t *CreateMsg) Validate() error {

--- a/x/distribution/msg.go
+++ b/x/distribution/msg.go
@@ -12,9 +12,9 @@ func init() {
 }
 
 const (
-	pathCreateMsg = "distribution/createRevenue"
-	pathDistributeMsg    = "distribution/distribute"
-	pathResetMsg  = "distribution/resetRevenue"
+	pathCreateMsg     = "distribution/create"
+	pathDistributeMsg = "distribution/distribute"
+	pathResetMsg      = "distribution/reset"
 )
 
 func (msg *CreateMsg) Validate() error {

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -38,7 +38,7 @@ func RegisterRoutes(r weave.Registry, auth x.Authenticator, decoder OptionDecode
 	r.Handle(pathCreateProposalMsg, newCreateProposalHandler(auth, decoder))
 	r.Handle(pathDeleteProposalMsg, newDeleteProposalHandler(auth))
 	r.Handle(pathUpdateElectorateMsg, newUpdateElectorateHandler(auth))
-	r.Handle(pathUpdateElectionRulesMsg, newUpdateElectionRuleHandler(auth))
+	r.Handle(pathUpdateElectionRuleMsg, newUpdateElectionRuleHandler(auth))
 	// We do NOT register the TextResultionHandler here... this is only for the proposal Executor
 }
 
@@ -46,8 +46,8 @@ func RegisterRoutes(r weave.Registry, auth x.Authenticator, decoder OptionDecode
 func RegisterBasicProposalRouters(r weave.Registry, auth x.Authenticator) {
 	r = migration.SchemaMigratingRegistry(packageName, r)
 	r.Handle(pathUpdateElectorateMsg, newUpdateElectorateHandler(auth))
-	r.Handle(pathUpdateElectionRulesMsg, newUpdateElectionRuleHandler(auth))
-	r.Handle(pathTextResolutionMsg, newCreateTextResolutionHandler(auth))
+	r.Handle(pathUpdateElectionRuleMsg, newUpdateElectionRuleHandler(auth))
+	r.Handle(pathCreateTextResolutionMsg, newCreateTextResolutionHandler(auth))
 }
 
 type VoteHandler struct {

--- a/x/gov/msg.go
+++ b/x/gov/msg.go
@@ -6,13 +6,13 @@ import (
 )
 
 const (
-	pathCreateProposalMsg      = "gov/create"
-	pathDeleteProposalMsg      = "gov/delete"
-	pathVoteMsg                = "gov/vote"
-	pathTallyMsg               = "gov/tally"
-	pathTextResolutionMsg      = "gov/resolution"
-	pathUpdateElectorateMsg    = "gov/electorate/update"
-	pathUpdateElectionRulesMsg = "gov/electionRules/update"
+	pathCreateProposalMsg       = "gov/create_proposal"
+	pathDeleteProposalMsg       = "gov/delete_proposal"
+	pathVoteMsg                 = "gov/vote"
+	pathTallyMsg                = "gov/tally"
+	pathCreateTextResolutionMsg = "gov/create_text_resolution"
+	pathUpdateElectorateMsg     = "gov/update_electorate"
+	pathUpdateElectionRuleMsg   = "gov/update_election_rule"
 )
 
 func init() {
@@ -112,7 +112,7 @@ func (m TallyMsg) Validate() error {
 }
 
 func (UpdateElectionRuleMsg) Path() string {
-	return pathUpdateElectionRulesMsg
+	return pathUpdateElectionRuleMsg
 }
 
 func (m UpdateElectionRuleMsg) Validate() error {
@@ -132,7 +132,7 @@ func (m UpdateElectionRuleMsg) Validate() error {
 }
 
 func (CreateTextResolutionMsg) Path() string {
-	return pathTextResolutionMsg
+	return pathCreateTextResolutionMsg
 }
 
 func (m CreateTextResolutionMsg) Validate() error {

--- a/x/sigs/msg.go
+++ b/x/sigs/msg.go
@@ -10,7 +10,7 @@ func init() {
 }
 
 const (
-	pathBumpSequenceMsg = "sigs/bumpSequence"
+	pathBumpSequenceMsg = "sigs/bump_sequence"
 
 	maxSequenceIncrement = 1000
 	minSequenceIncrement = 1

--- a/x/validators/handler.go
+++ b/x/validators/handler.go
@@ -11,7 +11,7 @@ import (
 // all handlers in this package.
 func RegisterRoutes(r weave.Registry, auth x.Authenticator) {
 	bucket := NewAccountBucket()
-	r.Handle(pathUpdate, migration.SchemaMigratingHandler("validators", &updateHandler{
+	r.Handle(pathApplyDiffMsg, migration.SchemaMigratingHandler("validators", &updateHandler{
 		auth:   auth,
 		bucket: bucket,
 	}))

--- a/x/validators/msg.go
+++ b/x/validators/msg.go
@@ -14,11 +14,11 @@ func init() {
 // Ensure we implement the Msg interface
 var _ weave.Msg = (*ApplyDiffMsg)(nil)
 
-const pathUpdate = "validators/update"
+const pathApplyDiffMsg = "validators/apply_diff"
 
 // Path returns the routing path for this message
 func (*ApplyDiffMsg) Path() string {
-	return pathUpdate
+	return pathApplyDiffMsg
 }
 
 func (m *ApplyDiffMsg) Validate() error {


### PR DESCRIPTION
Unify all message path values to follow the same set of rules.

- all messages must follow the same naming pattern
  `<package>/<message_name>`
- message path must be snake case
- `/` must be used only once as the package name separator
- `<package>` is the package name, for example `escrow` or `cash`
- `<message_name>` is the message name converted to snake case, for
  example `CreateRevenueMsg` is `create_revenue`

resolve #802