### PR TITLE
Action tagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `bnsd/x/username` genesis initializer implemented and included in `bnsd`.
 - Support gov proposal vote, deletion and tally in `bnscli` 
+- Added `x/utils.ActionTagger`: all `bnsd` transactions now have
+  `action=${msg.Path()}` tags. If there is a batch, there is one tag per
+  sub-message. If it is a governance tally, the TallyMsg as well as the
+  option (message executed on behalf of the governance stack) is tagged.
 
 Breaking changes
 

--- a/cmd/bnsd/app/app.go
+++ b/cmd/bnsd/app/app.go
@@ -59,6 +59,7 @@ func Chain(authFn x.Authenticator, minFee coin.Coin) app.Decorators {
 		msgfee.NewAntispamFeeDecorator(minFee),
 		msgfee.NewFeeDecorator(),
 		batch.NewDecorator(),
+		utils.NewActionTagger(),
 	)
 }
 

--- a/cmd/bnsd/app/app_test.go
+++ b/cmd/bnsd/app/app_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/iov-one/weave/x/cash"
 	"github.com/iov-one/weave/x/multisig"
 	"github.com/iov-one/weave/x/sigs"
+	"github.com/iov-one/weave/x/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -164,8 +165,8 @@ func TestApp(t *testing.T) {
 func tagsAsString(pairs []common.KVPair) string {
 	r := make([]string, len(pairs))
 	for i, v := range pairs {
-		if string(v.Key) == "action" {
-			r[i] = "action"
+		if string(v.Key) == utils.ActionKey {
+			r[i] = utils.ActionKey
 			continue
 		}
 		x, err := hex.DecodeString(string(v.Key))

--- a/cmd/bnsd/app/app_test.go
+++ b/cmd/bnsd/app/app_test.go
@@ -46,9 +46,10 @@ func TestApp(t *testing.T) {
 	dres := sendToken(t, myApp, appFixture.ChainID, 2, []Signer{{pk, 0}}, addr, addr2, 2000, "ETH", "Have a great trip!")
 
 	// ensure 4 keys for all accounts that are modified by a transaction
-	require.Equal(t, 4, len(dres.Tags), tagsAsString(dres.Tags))
+	require.Equal(t, 5, len(dres.Tags), tagsAsString(dres.Tags))
 	feeDistAddr := weave.NewCondition("dist", "revenue", []byte{0, 0, 0, 0, 0, 0, 0, 1}).Address()
 	wantKeys := []string{
+		"action",
 		toHex("cash:") + addr.String(),        // sender balance decreased
 		toHex("cash:") + addr2.String(),       // receiver balance increased
 		toHex("sigs:") + addr.String(),        // sender sequence incremented
@@ -62,11 +63,13 @@ func TestApp(t *testing.T) {
 		require.True(t, found, "not found tag %s in %s", want, tagsAsString(dres.Tags))
 	}
 
-	require.Equal(t, []string{"s", "s", "s", "s"}, []string{
+	// first tag is the action tagger, following are key tagger
+	require.Equal(t, []string{"cash/send", "s", "s", "s", "s"}, []string{
 		string(dres.Tags[0].Value),
 		string(dres.Tags[1].Value),
 		string(dres.Tags[2].Value),
 		string(dres.Tags[3].Value),
+		string(dres.Tags[4].Value),
 	})
 
 	// Query for fees stored
@@ -161,6 +164,10 @@ func TestApp(t *testing.T) {
 func tagsAsString(pairs []common.KVPair) string {
 	r := make([]string, len(pairs))
 	for i, v := range pairs {
+		if string(v.Key) == "action" {
+			r[i] = "action"
+			continue
+		}
 		x, err := hex.DecodeString(string(v.Key))
 		if err != nil {
 			panic(err)
@@ -236,23 +243,37 @@ func sendBatch(t *testing.T, baseApp abci.Application, chainID string, height in
 
 	dres := signAndCommit(t, baseApp, tx, signers, chainID, height)
 
-	// make sure the tags are only present once (not once per item)
+	// make sure the key tags are only present once (not once per item)
+	// action tag should be present for each message (important if different types)
 	feeDistAddr := weave.NewCondition("dist", "revenue", []byte{0, 0, 0, 0, 0, 0, 0, 1}).Address()
-	if len(dres.Tags) != 4 {
-		t.Fatalf("%#v", dres.Tags)
+	if len(dres.Tags) != 14 {
+		t.Fatalf("%v", len(dres.Tags))
 	}
+	// we need to sort the db keys for consistent ordering
 	wantKeys := []string{
+		// the actual movement
 		toHex("cash:") + from.String(),
 		toHex("cash:") + to.String(),
 		toHex("sigs:") + from.String(),
 		toHex("cash:") + feeDistAddr.String(), // fee destination
 	}
 	sort.Strings(wantKeys)
-	gotKeys := []string{
-		string(dres.Tags[0].Key),
-		string(dres.Tags[1].Key),
-		string(dres.Tags[2].Key),
-		string(dres.Tags[3].Key),
+	// all the action tagger for batch are before the key tagger
+	wantKeys = append([]string{
+		"action",
+		"action",
+		"action",
+		"action",
+		"action",
+		"action",
+		"action",
+		"action",
+		"action",
+		"action",
+	}, wantKeys...)
+	var gotKeys []string
+	for _, t := range dres.Tags {
+		gotKeys = append(gotKeys, string(t.Key))
 	}
 	assert.Equal(t, wantKeys, gotKeys)
 

--- a/cmd/bnsd/app/gov_handler.go
+++ b/cmd/bnsd/app/gov_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iov-one/weave/x/distribution"
 	"github.com/iov-one/weave/x/escrow"
 	"github.com/iov-one/weave/x/gov"
+	"github.com/iov-one/weave/x/utils"
 	"github.com/iov-one/weave/x/validators"
 )
 
@@ -39,8 +40,12 @@ func proposalOptionsExecutor(ctrl cash.Controller) gov.Executor {
 	migration.RegisterRoutes(r, auth)
 	gov.RegisterBasicProposalRouters(r, auth)
 
-	// We must wrap with batch middleware so it can process ExecuteProposalBatchMsg
-	stack := app.ChainDecorators(batch.NewDecorator()).WithHandler(r)
+	// We must wrap with batch middleware so it can process ExecuteProposalBatchMsg.
+	// We add ActionTagger here, so the messages executed as a result of a governance vote also get properly tagged.
+	stack := app.ChainDecorators(
+		batch.NewDecorator(),
+		utils.NewActionTagger(),
+	).WithHandler(r)
 
 	return gov.HandlerAsExecutor(stack)
 }

--- a/weavetest/handlers.go
+++ b/weavetest/handlers.go
@@ -29,7 +29,9 @@ func (h *Handler) Check(ctx weave.Context, db weave.KVStore, tx weave.Tx) (*weav
 	if h.CheckErr != nil {
 		return nil, h.CheckErr
 	}
-	return &h.CheckResult, nil
+	// you cannot return a reference to the stored result, as we pass a pointer and it may be modified
+	res := h.CheckResult
+	return &res, nil
 }
 
 func (h *Handler) Deliver(ctx weave.Context, db weave.KVStore, tx weave.Tx) (*weave.DeliverResult, error) {
@@ -37,7 +39,9 @@ func (h *Handler) Deliver(ctx weave.Context, db weave.KVStore, tx weave.Tx) (*we
 	if h.DeliverErr != nil {
 		return nil, h.DeliverErr
 	}
-	return &h.DeliverResult, nil
+	// you cannot return a reference to the stored result, as we pass a pointer and it may be modified
+	res := h.DeliverResult
+	return &res, nil
 }
 
 func (h *Handler) CheckCallCount() int {

--- a/x/utils/action_tagger.go
+++ b/x/utils/action_tagger.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"fmt"
-
 	"github.com/iov-one/weave"
 	"github.com/tendermint/tendermint/libs/common"
 )
@@ -46,7 +44,6 @@ func (ActionTagger) Deliver(ctx weave.Context, db weave.KVStore, tx weave.Tx, ne
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("append: %s\n", msg.Path())
 	tag := common.KVPair{
 		Key:   []byte(ActionKey),
 		Value: []byte(msg.Path()),

--- a/x/utils/action_tagger.go
+++ b/x/utils/action_tagger.go
@@ -19,12 +19,15 @@ type ActionTagger struct{}
 
 var _ weave.Decorator = ActionTagger{}
 
+// ActionKey is used by ActionTagger as the Key in the Tag it appends
+const ActionKey = "action"
+
 // NewActionTagger creates a ActionTagger decorator
 func NewActionTagger() ActionTagger {
 	return ActionTagger{}
 }
 
-// Check does nothing
+// Check just passes the request along
 func (ActionTagger) Check(ctx weave.Context, db weave.KVStore, tx weave.Tx, next weave.Checker) (*weave.CheckResult, error) {
 	return next.Check(ctx, db, tx)
 }
@@ -42,7 +45,7 @@ func (ActionTagger) Deliver(ctx weave.Context, db weave.KVStore, tx weave.Tx, ne
 		return nil, err
 	}
 	tag := common.KVPair{
-		Key:   []byte("action"),
+		Key:   []byte(ActionKey),
 		Value: []byte(msg.Path()),
 	}
 	res.Tags = append(res.Tags, tag)

--- a/x/utils/action_tagger.go
+++ b/x/utils/action_tagger.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"fmt"
+
 	"github.com/iov-one/weave"
 	"github.com/tendermint/tendermint/libs/common"
 )
@@ -44,6 +46,7 @@ func (ActionTagger) Deliver(ctx weave.Context, db weave.KVStore, tx weave.Tx, ne
 	if err != nil {
 		return nil, err
 	}
+	fmt.Printf("append: %s\n", msg.Path())
 	tag := common.KVPair{
 		Key:   []byte(ActionKey),
 		Value: []byte(msg.Path()),

--- a/x/utils/action_tagger.go
+++ b/x/utils/action_tagger.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"github.com/iov-one/weave"
+	"github.com/tendermint/tendermint/libs/common"
+)
+
+// ActionTagger will inspect the message being executed and
+// add a tag `action = msg.Path()`. This should be applied as
+// a decorator so clients have a standard way to search / subscribe
+// to eg. proposal creation.
+//
+// Note that for best results, this should be at the end of the
+// ChainDecorators call, after Batch (so it is tagged with each submessage type).
+// You will also want to wrap the governance router with this, so the result of
+// a successful election will be tagged (and there won't be validators.ApplyDiffMsg
+// being executed that do not show up in a search).
+type ActionTagger struct{}
+
+var _ weave.Decorator = ActionTagger{}
+
+// NewActionTagger creates a ActionTagger decorator
+func NewActionTagger() ActionTagger {
+	return ActionTagger{}
+}
+
+// Check does nothing
+func (ActionTagger) Check(ctx weave.Context, db weave.KVStore, tx weave.Tx, next weave.Checker) (*weave.CheckResult, error) {
+	return next.Check(ctx, db, tx)
+}
+
+// Deliver appends a tag on the result if there is a success.
+func (ActionTagger) Deliver(ctx weave.Context, db weave.KVStore, tx weave.Tx, next weave.Deliverer) (*weave.DeliverResult, error) {
+	// if we error in reporting, let's do so early before dispatching
+	msg, err := tx.GetMsg()
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := next.Deliver(ctx, db, tx)
+	if err != nil {
+		return nil, err
+	}
+	tag := common.KVPair{
+		Key:   []byte("action"),
+		Value: []byte(msg.Path()),
+	}
+	res.Tags = append(res.Tags, tag)
+	return res, nil
+}

--- a/x/utils/action_tagger_test.go
+++ b/x/utils/action_tagger_test.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/store"
+	"github.com/iov-one/weave/weavetest"
+	"github.com/iov-one/weave/weavetest/assert"
+)
+
+func TestActionTagger(t *testing.T) {
+	h := &weavetest.Handler{}
+	msg := &weavetest.Msg{RoutePath: "foobar/create"}
+	tx := &weavetest.Tx{Msg: msg}
+
+	a := NewActionTagger()
+
+	ctx := context.Background()
+	store := store.MemStore()
+
+	// ensure handler works as expected
+	res, err := h.Deliver(ctx, store, tx)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(res.Tags))
+
+	// we get tagged on success
+	res, err = a.Deliver(ctx, store, tx, h)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(res.Tags))
+	assert.Equal(t, "action", string(res.Tags[0].Key))
+	assert.Equal(t, "foobar/create", string(res.Tags[0].Value))
+
+	badh := &weavetest.Handler{DeliverErr: errors.ErrHuman}
+	res, err = a.Deliver(ctx, store, tx, badh)
+	assert.Nil(t, res)
+	if !errors.ErrHuman.Is(err) {
+		t.Fatalf("Expected ErrHuman, got %v", err)
+	}
+}

--- a/x/utils/action_tagger_test.go
+++ b/x/utils/action_tagger_test.go
@@ -2,7 +2,6 @@ package utils_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/iov-one/weave"
@@ -89,10 +88,6 @@ func TestActionTagger(t *testing.T) {
 				return
 			}
 			assert.Nil(t, err)
-			fmt.Println("")
-			for _, t := range res.Tags {
-				fmt.Printf("%s = %s\n", string(t.Key), string(t.Value))
-			}
 			assert.Equal(t, len(tc.tags), len(res.Tags))
 			for i := range tc.tags {
 				assert.Equal(t, string(tc.tags[i].Key), string(res.Tags[i].Key))

--- a/x/utils/action_tagger_test.go
+++ b/x/utils/action_tagger_test.go
@@ -1,30 +1,77 @@
-package utils
+package utils_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/app"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/weavetest"
 	"github.com/iov-one/weave/weavetest/assert"
+	"github.com/iov-one/weave/x/batch"
+	"github.com/iov-one/weave/x/utils"
 	"github.com/tendermint/tendermint/libs/common"
 )
 
+func stringTag(key, value string) common.KVPair {
+	return common.KVPair{
+		Key:   []byte(key),
+		Value: []byte(value),
+	}
+}
+
 func TestActionTagger(t *testing.T) {
 	cases := map[string]struct {
-		wrap weave.Decorator
-		h    weave.Handler
-		tx   weave.Tx
-		err  *errors.Error
-		tags []common.KVPair
+		stack weave.Handler
+		tx    weave.Tx
+		err   *errors.Error
+		tags  []common.KVPair
 	}{
 		"simple call": {
-			wrap: NewActionTagger(),
-			h:    &weavetest.Handler{},
+			stack: app.ChainDecorators(utils.NewActionTagger()).WithHandler(
+				&weavetest.Handler{},
+			),
 			tx:   &weavetest.Tx{Msg: &weavetest.Msg{RoutePath: "foobar/create"}},
-			tags: []common.KVPair{{Key: []byte("action"), Value: []byte("foobar/create")}},
+			tags: []common.KVPair{stringTag(utils.ActionKey, "foobar/create")},
+		},
+		"passes through error": {
+			stack: app.ChainDecorators(utils.NewActionTagger()).WithHandler(
+				&weavetest.Handler{DeliverErr: errors.ErrHuman},
+			),
+			tx:  &weavetest.Tx{Msg: &weavetest.Msg{RoutePath: "foobar/create"}},
+			err: errors.ErrHuman,
+		},
+		"tags are additive": {
+			stack: app.ChainDecorators(utils.NewActionTagger()).WithHandler(
+				&weavetest.Handler{
+					DeliverResult: weave.DeliverResult{Tags: []common.KVPair{stringTag(utils.ActionKey, "random")}},
+				},
+			),
+			tx:   &weavetest.Tx{Msg: &weavetest.Msg{RoutePath: "foobar/create"}},
+			tags: []common.KVPair{stringTag(utils.ActionKey, "random"), stringTag(utils.ActionKey, "foobar/create")},
+		},
+		"all in batch are tagged": {
+			stack: app.ChainDecorators(
+				batch.NewDecorator(),
+				utils.NewActionTagger(),
+			).WithHandler(
+				&weavetest.Handler{},
+			),
+			tx: &weavetest.Tx{Msg: &batchMsg{
+				msgs: []weave.Msg{
+					&weavetest.Msg{RoutePath: "username/register"},
+					&weavetest.Msg{RoutePath: "cash/send"},
+					&weavetest.Msg{RoutePath: "gov/vote"},
+				},
+			}},
+			tags: []common.KVPair{
+				stringTag(utils.ActionKey, "username/register"),
+				stringTag(utils.ActionKey, "cash/send"),
+				stringTag(utils.ActionKey, "gov/vote"),
+			},
 		},
 	}
 
@@ -34,7 +81,7 @@ func TestActionTagger(t *testing.T) {
 			store := store.MemStore()
 
 			// we get tagged on success
-			res, err := tc.wrap.Deliver(ctx, store, tc.tx, tc.h)
+			res, err := tc.stack.Deliver(ctx, store, tc.tx)
 			if tc.err != nil {
 				if !tc.err.Is(err) {
 					t.Fatalf("Unexpected error type returned: %v", err)
@@ -42,6 +89,10 @@ func TestActionTagger(t *testing.T) {
 				return
 			}
 			assert.Nil(t, err)
+			fmt.Println("")
+			for _, t := range res.Tags {
+				fmt.Printf("%s = %s\n", string(t.Key), string(t.Value))
+			}
 			assert.Equal(t, len(tc.tags), len(res.Tags))
 			for i := range tc.tags {
 				assert.Equal(t, string(tc.tags[i].Key), string(res.Tags[i].Key))
@@ -49,4 +100,30 @@ func TestActionTagger(t *testing.T) {
 			}
 		})
 	}
+}
+
+var _ batch.Msg = (*batchMsg)(nil)
+
+type batchMsg struct {
+	msgs []weave.Msg
+}
+
+func (m *batchMsg) Marshal() ([]byte, error) {
+	panic("implement me")
+}
+
+func (m *batchMsg) Unmarshal([]byte) error {
+	panic("implement me")
+}
+
+func (m *batchMsg) Path() string {
+	panic("implement me")
+}
+
+func (m *batchMsg) Validate() error {
+	return nil
+}
+
+func (m *batchMsg) MsgList() ([]weave.Msg, error) {
+	return m.msgs, nil
 }

--- a/x/utils/key_tagger_test.go
+++ b/x/utils/key_tagger_test.go
@@ -126,7 +126,6 @@ func TestKeyTagger(t *testing.T) {
 			} else {
 				assert.Nil(t, err)
 				// tags are set properly
-				fmt.Printf("%T vs %T\n", tc.tags, res.Tags)
 				assert.Equal(t, tc.tags, res.Tags)
 			}
 


### PR DESCRIPTION
Closes #596 

* Simple decorator to add standard action=msg.Path() tags.
* Added to the bnsd Stack as an example.
* Update tests