### PR TITLE
change app.Router interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 ## HEAD
 
 - `bnsd/x/username` genesis initializer implemented and included in `bnsd`.
-- Support gov proposal vote, deletion and tally in `bnscli` 
+- Support gov proposal vote, deletion and tally in `bnscli`
 
 Breaking changes
 
 - Unify all message paths to follow pattern `<package>/<message_name>`
+- `app.Router` interface was changed. Handler registration requires a message
+  and not message path.
 
 ## 0.17.0
 

--- a/app/router.go
+++ b/app/router.go
@@ -34,7 +34,7 @@ func NewRouter() *Router {
 	}
 }
 
-// Handle implementes weave.Registry interface.
+// Handle implements weave.Registry interface.
 func (r *Router) Handle(m weave.Msg, h weave.Handler) {
 	path := m.Path()
 	if !isPath(path) {

--- a/app/router.go
+++ b/app/router.go
@@ -8,9 +8,6 @@ import (
 	"github.com/iov-one/weave/errors"
 )
 
-// DefaultRouterSize pre-allocates this much space to hold routes
-const DefaultRouterSize = 10
-
 // isPath is the RegExp to ensure the routes make sense
 var isPath = regexp.MustCompile(`^[a-zA-Z0-9_/]+$`).MatchString
 
@@ -27,75 +24,66 @@ type Router struct {
 	routes map[string]weave.Handler
 }
 
-var _ weave.Registry = Router{}
-var _ weave.Handler = Router{}
+var _ weave.Registry = (*Router)(nil)
+var _ weave.Handler = (*Router)(nil)
 
-// NewRouter initializes a router with no routes
-func NewRouter() Router {
-	return Router{
-		routes: make(map[string]weave.Handler, DefaultRouterSize),
+// NewRouter returns a new empty router instance.
+func NewRouter() *Router {
+	return &Router{
+		routes: make(map[string]weave.Handler),
 	}
 }
 
-// Handle adds a new Handler for the given path.
-// panics if another Handler was already registered
-func (r Router) Handle(path string, h weave.Handler) {
+// Handle implementes weave.Registry interface.
+func (r *Router) Handle(m weave.Msg, h weave.Handler) {
+	path := m.Path()
 	if !isPath(path) {
-		panic(fmt.Sprintf("Invalid path: %s", path))
+		panic(fmt.Sprintf("invalid path: %T: %s", m, path))
 	}
 	if _, ok := r.routes[path]; ok {
-		panic(fmt.Sprintf("Re-registering route: %s", path))
+		panic(fmt.Sprintf("re-registering route: %T: %s", m, path))
 	}
 	r.routes[path] = h
 }
 
-// Handler returns the registered Handler for this path.
-// If no path is found, returns a noSuchPath Handler
-// Always returns a non-nil Handler
-func (r Router) Handler(path string) weave.Handler {
-	h, ok := r.routes[path]
-	if !ok {
-		return noSuchPathHandler{path}
+// handler returns the registered Handler for this path. If no path is found,
+// returns a noSuchPath Handler.  This method always returns a non-nil Handler.
+func (r *Router) handler(m weave.Msg) weave.Handler {
+	path := m.Path()
+	if h, ok := r.routes[path]; ok {
+		return h
 	}
-	return h
+	return notFoundHandler(path)
 }
 
 // Check dispatches to the proper handler based on path
-func (r Router) Check(ctx weave.Context, store weave.KVStore, tx weave.Tx) (*weave.CheckResult, error) {
-	msg, _ := tx.GetMsg()
-	if msg == nil {
-		return nil, errors.Wrap(errors.ErrInput, "unable to decode")
+func (r *Router) Check(ctx weave.Context, store weave.KVStore, tx weave.Tx) (*weave.CheckResult, error) {
+	msg, err := tx.GetMsg()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot load msg")
 	}
-	path := msg.Path()
-	h := r.Handler(path)
+	h := r.handler(msg)
 	return h.Check(ctx, store, tx)
 }
 
 // Deliver dispatches to the proper handler based on path
-func (r Router) Deliver(ctx weave.Context, store weave.KVStore, tx weave.Tx) (*weave.DeliverResult, error) {
-	msg, _ := tx.GetMsg()
-	if msg == nil {
-		return nil, errors.Wrap(errors.ErrInput, "unable to decode")
+func (r *Router) Deliver(ctx weave.Context, store weave.KVStore, tx weave.Tx) (*weave.DeliverResult, error) {
+	msg, err := tx.GetMsg()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot load msg")
 	}
-	path := msg.Path()
-	h := r.Handler(path)
+	h := r.handler(msg)
 	return h.Deliver(ctx, store, tx)
 }
 
-//-------------------- error handler ---------------
+// notFoundHandler always returns ErrNotFound error regardless of the arguments
+// provided.
+type notFoundHandler string
 
-type noSuchPathHandler struct {
-	path string
+func (path notFoundHandler) Check(ctx weave.Context, store weave.KVStore, tx weave.Tx) (*weave.CheckResult, error) {
+	return nil, errors.Wrapf(errors.ErrNotFound, "no handler for message path %q", path)
 }
 
-var _ weave.Handler = noSuchPathHandler{}
-
-// Check always returns ErrNoSuchPath
-func (h noSuchPathHandler) Check(ctx weave.Context, store weave.KVStore, tx weave.Tx) (*weave.CheckResult, error) {
-	return nil, errors.Wrapf(errors.ErrNotFound, "path: %s", h.path)
-}
-
-// Deliver always returns ErrNoSuchPath
-func (h noSuchPathHandler) Deliver(ctx weave.Context, store weave.KVStore, tx weave.Tx) (*weave.DeliverResult, error) {
-	return nil, errors.Wrapf(errors.ErrNotFound, "path: %s", h.path)
+func (path notFoundHandler) Deliver(ctx weave.Context, store weave.KVStore, tx weave.Tx) (*weave.DeliverResult, error) {
+	return nil, errors.Wrapf(errors.ErrNotFound, "no handler for message path %q", path)
 }

--- a/cmd/bnsd/app/app.go
+++ b/cmd/bnsd/app/app.go
@@ -64,7 +64,7 @@ func Chain(authFn x.Authenticator, minFee coin.Coin) app.Decorators {
 
 // Router returns a default router, only dispatching to the
 // cash.SendMsg
-func Router(authFn x.Authenticator, issuer weave.Address) app.Router {
+func Router(authFn x.Authenticator, issuer weave.Address) *app.Router {
 	r := app.NewRouter()
 
 	// ctrl can be initialized with any implementation, but must be used

--- a/cmd/bnsd/x/username/handlers.go
+++ b/cmd/bnsd/x/username/handlers.go
@@ -18,9 +18,9 @@ func RegisterRoutes(r weave.Registry, auth x.Authenticator) {
 	r = migration.SchemaMigratingRegistry("username", r)
 
 	b := NewTokenBucket()
-	r.Handle(RegisterTokenMsg{}.Path(), &registerTokenHandler{auth: auth, bucket: b})
-	r.Handle(TransferTokenMsg{}.Path(), &transferTokenHandler{auth: auth, bucket: b})
-	r.Handle(ChangeTokenTargetsMsg{}.Path(), &changeTokenTargetsHandler{auth: auth, bucket: b})
+	r.Handle(&RegisterTokenMsg{}, &registerTokenHandler{auth: auth, bucket: b})
+	r.Handle(&TransferTokenMsg{}, &transferTokenHandler{auth: auth, bucket: b})
+	r.Handle(&ChangeTokenTargetsMsg{}, &changeTokenTargetsHandler{auth: auth, bucket: b})
 }
 
 type registerTokenHandler struct {

--- a/cmd/bnsd/x/username/msg.go
+++ b/cmd/bnsd/x/username/msg.go
@@ -1,6 +1,7 @@
 package username
 
 import (
+	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
 )
@@ -10,6 +11,8 @@ func init() {
 	migration.MustRegister(1, &TransferTokenMsg{}, migration.NoModification)
 	migration.MustRegister(1, &ChangeTokenTargetsMsg{}, migration.NoModification)
 }
+
+var _ weave.Msg = (*RegisterTokenMsg)(nil)
 
 func (m *RegisterTokenMsg) Validate() error {
 	if err := m.Metadata.Validate(); err != nil {
@@ -28,6 +31,8 @@ func (RegisterTokenMsg) Path() string {
 	return "username/register_token"
 }
 
+var _ weave.Msg = (*TransferTokenMsg)(nil)
+
 func (m *TransferTokenMsg) Validate() error {
 	if err := m.Metadata.Validate(); err != nil {
 		return errors.Wrap(err, "metadata")
@@ -44,6 +49,8 @@ func (m *TransferTokenMsg) Validate() error {
 func (TransferTokenMsg) Path() string {
 	return "username/transfer_token"
 }
+
+var _ weave.Msg = (*ChangeTokenTargetsMsg)(nil)
 
 func (m *ChangeTokenTargetsMsg) Validate() error {
 	if err := m.Metadata.Validate(); err != nil {

--- a/handler.go
+++ b/handler.go
@@ -43,7 +43,11 @@ type Ticker interface {
 // Registry is an interface to register your handler,
 // the setup side of a Router
 type Registry interface {
-	Handle(path string, h Handler)
+	// Handle assigns given handler to handle processing of every message
+	// of provided type.
+	// Using a message with an invalid path panics.
+	// Registering a handler for a message more than ones panics.
+	Handle(Msg, Handler)
 }
 
 // Options are the app options

--- a/migration/handler.go
+++ b/migration/handler.go
@@ -25,8 +25,8 @@ type schemaMigratingRegistry struct {
 	reg         weave.Registry
 }
 
-func (r *schemaMigratingRegistry) Handle(path string, h weave.Handler) {
-	r.reg.Handle(path, SchemaMigratingHandler(r.packageName, h))
+func (r *schemaMigratingRegistry) Handle(m weave.Msg, h weave.Handler) {
+	r.reg.Handle(m, SchemaMigratingHandler(r.packageName, h))
 }
 
 // SchemaMigratingHandler returns a weave handler that will ensure incoming
@@ -90,7 +90,7 @@ func (h *schemaMigratingHandler) migrate(db weave.ReadOnlyKVStore, tx weave.Tx) 
 // RegisterRoutes registers handlers for feedlist message processing.
 func RegisterRoutes(r weave.Registry, auth x.Authenticator) {
 	bucket := NewSchemaBucket()
-	r.Handle(pathUpgradeSchemaMsg, &upgradeSchemaHandler{
+	r.Handle(&UpgradeSchemaMsg{}, &upgradeSchemaHandler{
 		bucket: bucket,
 		auth:   auth,
 	})

--- a/migration/msg.go
+++ b/migration/msg.go
@@ -5,10 +5,6 @@ import (
 	"github.com/iov-one/weave/errors"
 )
 
-const (
-	pathUpgradeSchemaMsg = "migration/upgrade_schema"
-)
-
 var _ weave.Msg = (*UpgradeSchemaMsg)(nil)
 
 func (msg *UpgradeSchemaMsg) Validate() error {
@@ -19,5 +15,5 @@ func (msg *UpgradeSchemaMsg) Validate() error {
 }
 
 func (UpgradeSchemaMsg) Path() string {
-	return pathUpgradeSchemaMsg
+	return "migration/upgrade_schema"
 }

--- a/x/aswap/handler.go
+++ b/x/aswap/handler.go
@@ -24,9 +24,9 @@ func RegisterRoutes(r weave.Registry, auth x.Authenticator, cashctrl cash.Contro
 	r = migration.SchemaMigratingRegistry("aswap", r)
 	bucket := NewBucket()
 
-	r.Handle(pathCreateSwap, CreateSwapHandler{auth, bucket, cashctrl})
-	r.Handle(pathReleaseSwap, ReleaseSwapHandler{auth, bucket, cashctrl})
-	r.Handle(pathReturnSwap, ReturnSwapHandler{auth, bucket, cashctrl})
+	r.Handle(&CreateMsg{}, CreateSwapHandler{auth, bucket, cashctrl})
+	r.Handle(&ReleaseMsg{}, ReleaseSwapHandler{auth, bucket, cashctrl})
+	r.Handle(&ReturnSwapMsg{}, ReturnSwapHandler{auth, bucket, cashctrl})
 }
 
 // RegisterQuery will register this bucket as "/aswaps"

--- a/x/aswap/msg.go
+++ b/x/aswap/msg.go
@@ -1,6 +1,7 @@
 package aswap
 
 import (
+	"github.com/iov-one/weave"
 	coin "github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
@@ -19,6 +20,8 @@ const (
 	// preimageHash size in bytes
 	preimageHashSize int = 32
 )
+
+var _ weave.Msg = (*CreateMsg)(nil)
 
 func (CreateMsg) Path() string {
 	return "aswap/create"
@@ -54,6 +57,8 @@ func (m *CreateMsg) Validate() error {
 	return err
 }
 
+var _ weave.Msg = (*ReleaseMsg)(nil)
+
 func (ReleaseMsg) Path() string {
 	return "aswap/release"
 }
@@ -72,6 +77,8 @@ func (m *ReleaseMsg) Validate() error {
 	}
 	return nil
 }
+
+var _ weave.Msg = (*ReturnSwapMsg)(nil)
 
 func (ReturnSwapMsg) Path() string {
 	return "aswap/return"

--- a/x/aswap/msg.go
+++ b/x/aswap/msg.go
@@ -1,25 +1,18 @@
 package aswap
 
 import (
-	"github.com/iov-one/weave"
 	coin "github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
 )
 
 func init() {
-	// Migration needs to be registered for every message introduced in the codec.
-	// This is the convention to message versioning.
 	migration.MustRegister(1, &CreateMsg{}, migration.NoModification)
 	migration.MustRegister(1, &ReleaseMsg{}, migration.NoModification)
 	migration.MustRegister(1, &ReturnSwapMsg{}, migration.NoModification)
 }
 
 const (
-	pathCreateSwap  = "aswap/create"
-	pathReleaseSwap = "aswap/release"
-	pathReturnSwap  = "aswap/return"
-
 	maxMemoSize int = 128
 	// preimage size in bytes
 	preimageSize int = 32
@@ -27,25 +20,9 @@ const (
 	preimageHashSize int = 32
 )
 
-var _ weave.Msg = (*CreateMsg)(nil)
-var _ weave.Msg = (*ReleaseMsg)(nil)
-var _ weave.Msg = (*ReturnSwapMsg)(nil)
-
-// ROUTING, Path method fulfills weave.Msg interface to allow routing
-
 func (CreateMsg) Path() string {
-	return pathCreateSwap
+	return "aswap/create"
 }
-
-func (ReleaseMsg) Path() string {
-	return pathReleaseSwap
-}
-
-func (ReturnSwapMsg) Path() string {
-	return pathReturnSwap
-}
-
-// VALIDATION, Validate method makes sure basic rules are enforced upon input data and fulfills weave.Msg interface
 
 func (m *CreateMsg) Validate() error {
 	if err := m.Metadata.Validate(); err != nil {
@@ -77,6 +54,10 @@ func (m *CreateMsg) Validate() error {
 	return err
 }
 
+func (ReleaseMsg) Path() string {
+	return "aswap/release"
+}
+
 func (m *ReleaseMsg) Validate() error {
 	if err := m.Metadata.Validate(); err != nil {
 		return errors.Wrap(err, "metadata")
@@ -90,6 +71,11 @@ func (m *ReleaseMsg) Validate() error {
 		return errors.Wrapf(errors.ErrInput, "preimage should be exactly %d byte long", preimageSize)
 	}
 	return nil
+}
+
+func (ReturnSwapMsg) Path() string {
+	return "aswap/return"
+
 }
 
 func (m *ReturnSwapMsg) Validate() error {

--- a/x/cash/handler.go
+++ b/x/cash/handler.go
@@ -13,8 +13,8 @@ import (
 func RegisterRoutes(r weave.Registry, auth x.Authenticator, control Controller) {
 	r = migration.SchemaMigratingRegistry("cash", r)
 
-	r.Handle(pathSendMsg, NewSendHandler(auth, control))
-	r.Handle(pathUpdateConfigurationMsg, NewConfigHandler(auth))
+	r.Handle(&SendMsg{}, NewSendHandler(auth, control))
+	r.Handle(&UpdateConfigurationMsg{}, NewConfigHandler(auth))
 }
 
 // RegisterQuery will register this bucket as "/wallets"

--- a/x/cash/msg.go
+++ b/x/cash/msg.go
@@ -12,9 +12,6 @@ func init() {
 	migration.MustRegister(1, &UpdateConfigurationMsg{}, migration.NoModification)
 }
 
-// Ensure we implement the Msg interface
-var _ weave.Msg = (*SendMsg)(nil)
-
 const (
 	sendTxCost int64 = 100
 
@@ -22,12 +19,14 @@ const (
 	maxRefSize  int = 64
 )
 
-// Path returns the routing path for this message
+var _ weave.Msg = (*SendMsg)(nil)
+
+// Path returns the routing path for this message.
 func (SendMsg) Path() string {
 	return "cash/send"
 }
 
-// Validate makes sure that this is sensible
+// Validate makes sure that this is sensible.
 func (s *SendMsg) Validate() error {
 	var err error
 	if coin.IsEmpty(s.Amount) || !s.Amount.IsPositive() {
@@ -63,8 +62,7 @@ func (s *SendMsg) DefaultSource(addr []byte) *SendMsg {
 	}
 }
 
-// FeeTx exposes information about the fees that
-// should be paid
+// FeeTx exposes information about the fees that should be paid.
 type FeeTx interface {
 	GetFees() *FeeInfo
 }

--- a/x/cash/msg.go
+++ b/x/cash/msg.go
@@ -16,9 +16,7 @@ func init() {
 var _ weave.Msg = (*SendMsg)(nil)
 
 const (
-	pathSendMsg                      = "cash/send"
-	pathUpdateConfigurationMsg       = "cash/update_configuration"
-	sendTxCost                 int64 = 100
+	sendTxCost int64 = 100
 
 	maxMemoSize int = 128
 	maxRefSize  int = 64
@@ -26,7 +24,7 @@ const (
 
 // Path returns the routing path for this message
 func (SendMsg) Path() string {
-	return pathSendMsg
+	return "cash/send"
 }
 
 // Validate makes sure that this is sensible
@@ -130,5 +128,5 @@ func (m *UpdateConfigurationMsg) Validate() error {
 }
 
 func (*UpdateConfigurationMsg) Path() string {
-	return pathUpdateConfigurationMsg
+	return "cash/update_configuration"
 }

--- a/x/currency/handler.go
+++ b/x/currency/handler.go
@@ -16,7 +16,7 @@ func RegisterQuery(qr weave.QueryRouter) {
 func RegisterRoutes(r weave.Registry, auth x.Authenticator, issuer weave.Address) {
 	r = migration.SchemaMigratingRegistry("currency", r)
 
-	r.Handle(CreateMsg{}.Path(), newCreateTokenInfoHandler(auth, issuer))
+	r.Handle(&CreateMsg{}, newCreateTokenInfoHandler(auth, issuer))
 }
 
 func newCreateTokenInfoHandler(auth x.Authenticator, issuer weave.Address) weave.Handler {

--- a/x/currency/msg.go
+++ b/x/currency/msg.go
@@ -1,7 +1,6 @@
 package currency
 
 import (
-	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
@@ -10,8 +9,6 @@ import (
 func init() {
 	migration.MustRegister(1, &CreateMsg{}, migration.NoModification)
 }
-
-var _ weave.Msg = (*CreateMsg)(nil)
 
 func (CreateMsg) Path() string {
 	return "currency/create"

--- a/x/distribution/handler.go
+++ b/x/distribution/handler.go
@@ -32,17 +32,17 @@ type CashController interface {
 func RegisterRoutes(r weave.Registry, auth x.Authenticator, ctrl CashController) {
 	r = migration.SchemaMigratingRegistry("distribution", r)
 	bucket := NewRevenueBucket()
-	r.Handle(pathCreateMsg, &createRevenueHandler{
+	r.Handle(&CreateMsg{}, &createRevenueHandler{
 		auth:   auth,
 		bucket: bucket,
 		ctrl:   ctrl,
 	})
-	r.Handle(pathDistributeMsg, &distributeHandler{
+	r.Handle(&DistributeMsg{}, &distributeHandler{
 		auth:   auth,
 		bucket: bucket,
 		ctrl:   ctrl,
 	})
-	r.Handle(pathResetMsg, &resetRevenueHandler{
+	r.Handle(&ResetMsg{}, &resetRevenueHandler{
 		auth:   auth,
 		bucket: bucket,
 		ctrl:   ctrl,

--- a/x/distribution/msg.go
+++ b/x/distribution/msg.go
@@ -1,6 +1,7 @@
 package distribution
 
 import (
+	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
 )
@@ -10,6 +11,8 @@ func init() {
 	migration.MustRegister(1, &DistributeMsg{}, migration.NoModification)
 	migration.MustRegister(1, &ResetMsg{}, migration.NoModification)
 }
+
+var _ weave.Msg = (*CreateMsg)(nil)
 
 func (msg *CreateMsg) Validate() error {
 	if err := msg.Metadata.Validate(); err != nil {
@@ -28,6 +31,8 @@ func (CreateMsg) Path() string {
 	return "distribution/create"
 }
 
+var _ weave.Msg = (*DistributeMsg)(nil)
+
 func (msg *DistributeMsg) Validate() error {
 	if err := msg.Metadata.Validate(); err != nil {
 		return errors.Wrap(err, "invalid metadata")
@@ -41,6 +46,8 @@ func (msg *DistributeMsg) Validate() error {
 func (DistributeMsg) Path() string {
 	return "distribution/distribute"
 }
+
+var _ weave.Msg = (*ResetMsg)(nil)
 
 func (msg *ResetMsg) Validate() error {
 	if err := msg.Metadata.Validate(); err != nil {

--- a/x/distribution/msg.go
+++ b/x/distribution/msg.go
@@ -11,12 +11,6 @@ func init() {
 	migration.MustRegister(1, &ResetMsg{}, migration.NoModification)
 }
 
-const (
-	pathCreateMsg     = "distribution/create"
-	pathDistributeMsg = "distribution/distribute"
-	pathResetMsg      = "distribution/reset"
-)
-
 func (msg *CreateMsg) Validate() error {
 	if err := msg.Metadata.Validate(); err != nil {
 		return errors.Wrap(err, "invalid metadata")
@@ -31,7 +25,7 @@ func (msg *CreateMsg) Validate() error {
 }
 
 func (CreateMsg) Path() string {
-	return pathCreateMsg
+	return "distribution/create"
 }
 
 func (msg *DistributeMsg) Validate() error {
@@ -45,7 +39,7 @@ func (msg *DistributeMsg) Validate() error {
 }
 
 func (DistributeMsg) Path() string {
-	return pathDistributeMsg
+	return "distribution/distribute"
 }
 
 func (msg *ResetMsg) Validate() error {
@@ -59,5 +53,5 @@ func (msg *ResetMsg) Validate() error {
 }
 
 func (ResetMsg) Path() string {
-	return pathResetMsg
+	return "distribution/reset"
 }

--- a/x/escrow/handler.go
+++ b/x/escrow/handler.go
@@ -24,18 +24,16 @@ func RegisterRoutes(r weave.Registry, auth x.Authenticator, cashctrl cash.Contro
 	r = migration.SchemaMigratingRegistry("escrow", r)
 	bucket := NewBucket()
 
-	r.Handle(pathCreateMsg, CreateEscrowHandler{auth, bucket, cashctrl})
-	r.Handle(pathReleaseMsg, ReleaseEscrowHandler{auth, bucket, cashctrl})
-	r.Handle(pathReturnMsg, ReturnEscrowHandler{auth, bucket, cashctrl})
-	r.Handle(pathUpdatePartiesMsg, UpdateEscrowHandler{auth, bucket})
+	r.Handle(&CreateMsg{}, CreateEscrowHandler{auth, bucket, cashctrl})
+	r.Handle(&ReleaseMsg{}, ReleaseEscrowHandler{auth, bucket, cashctrl})
+	r.Handle(&ReturnMsg{}, ReturnEscrowHandler{auth, bucket, cashctrl})
+	r.Handle(&UpdatePartiesMsg{}, UpdateEscrowHandler{auth, bucket})
 }
 
 // RegisterQuery will register this bucket as "/escrows"
 func RegisterQuery(qr weave.QueryRouter) {
 	NewBucket().Register("escrows", qr)
 }
-
-//---- create
 
 // CreateEscrowHandler will set a name for objects in this bucket
 type CreateEscrowHandler struct {

--- a/x/escrow/msg.go
+++ b/x/escrow/msg.go
@@ -38,6 +38,8 @@ func NewCreateMsg(
 	}
 }
 
+var _ weave.Msg = (*CreateMsg)(nil)
+
 func (CreateMsg) Path() string {
 	return "escrow/create"
 }
@@ -71,6 +73,8 @@ func (m *CreateMsg) Validate() error {
 	return nil
 }
 
+var _ weave.Msg = (*ReleaseMsg)(nil)
+
 func (ReleaseMsg) Path() string {
 	return "escrow/release"
 }
@@ -90,6 +94,8 @@ func (m *ReleaseMsg) Validate() error {
 	return validateAmount(m.Amount)
 }
 
+var _ weave.Msg = (*ReturnMsg)(nil)
+
 func (ReturnMsg) Path() string {
 	return "escrow/return"
 }
@@ -101,6 +107,8 @@ func (m *ReturnMsg) Validate() error {
 	}
 	return validateEscrowID(m.EscrowId)
 }
+
+var _ weave.Msg = (*UpdatePartiesMsg)(nil)
 
 func (UpdatePartiesMsg) Path() string {
 	return "escrow/update"

--- a/x/escrow/msg.go
+++ b/x/escrow/msg.go
@@ -15,42 +15,8 @@ func init() {
 }
 
 const (
-	pathCreateMsg        = "escrow/create"
-	pathReleaseMsg       = "escrow/release"
-	pathReturnMsg        = "escrow/return"
-	pathUpdatePartiesMsg = "escrow/update"
-
 	maxMemoSize int = 128
 )
-
-var _ weave.Msg = (*CreateMsg)(nil)
-var _ weave.Msg = (*ReleaseMsg)(nil)
-var _ weave.Msg = (*ReturnMsg)(nil)
-var _ weave.Msg = (*UpdatePartiesMsg)(nil)
-
-//--------- Path routing --------
-
-// Path fulfills weave.Msg interface to allow routing
-func (CreateMsg) Path() string {
-	return pathCreateMsg
-}
-
-// Path fulfills weave.Msg interface to allow routing
-func (ReleaseMsg) Path() string {
-	return pathReleaseMsg
-}
-
-// Path fulfills weave.Msg interface to allow routing
-func (ReturnMsg) Path() string {
-	return pathReturnMsg
-}
-
-// Path fulfills weave.Msg interface to allow routing
-func (UpdatePartiesMsg) Path() string {
-	return pathUpdatePartiesMsg
-}
-
-//--------- Validation --------
 
 // NewCreateMsg is a helper to quickly build a create escrow message
 func NewCreateMsg(
@@ -70,6 +36,10 @@ func NewCreateMsg(
 		Timeout:   timeout,
 		Memo:      memo,
 	}
+}
+
+func (CreateMsg) Path() string {
+	return "escrow/create"
 }
 
 // Validate makes sure that this is sensible
@@ -101,6 +71,10 @@ func (m *CreateMsg) Validate() error {
 	return nil
 }
 
+func (ReleaseMsg) Path() string {
+	return "escrow/release"
+}
+
 // Validate makes sure that this is sensible
 func (m *ReleaseMsg) Validate() error {
 	if err := m.Metadata.Validate(); err != nil {
@@ -116,12 +90,20 @@ func (m *ReleaseMsg) Validate() error {
 	return validateAmount(m.Amount)
 }
 
+func (ReturnMsg) Path() string {
+	return "escrow/return"
+}
+
 // Validate always returns true for no data
 func (m *ReturnMsg) Validate() error {
 	if err := m.Metadata.Validate(); err != nil {
 		return errors.Wrap(err, "metadata")
 	}
 	return validateEscrowID(m.EscrowId)
+}
+
+func (UpdatePartiesMsg) Path() string {
+	return "escrow/update"
 }
 
 // Validate makes sure any included items are valid permissions

--- a/x/escrow/msg_test.go
+++ b/x/escrow/msg_test.go
@@ -135,7 +135,6 @@ func TestCreateMsg(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
-			assert.Equal(t, pathCreateMsg, tc.msg.Path())
 			err := tc.msg.Validate()
 			assert.True(t, tc.check(err), "%+v", err)
 		})
@@ -221,7 +220,6 @@ func TestReleaseMsg(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
-			assert.Equal(t, pathReleaseMsg, tc.msg.Path())
 			err := tc.msg.Validate()
 			assert.True(t, tc.check(err), "%+v", err)
 		})
@@ -265,7 +263,6 @@ func TestReturnMsg(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
-			assert.Equal(t, pathReturnMsg, tc.msg.Path())
 			err := tc.msg.Validate()
 			assert.True(t, tc.check(err), "%+v", err)
 		})
@@ -334,7 +331,6 @@ func TestUpdateEscrowMsg(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
-			assert.Equal(t, pathUpdatePartiesMsg, tc.msg.Path())
 			err := tc.msg.Validate()
 			assert.True(t, tc.check(err), "%+v", err)
 		})

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -33,21 +33,21 @@ func RegisterQuery(qr weave.QueryRouter) {
 // RegisterRoutes registers handlers for governance message processing.
 func RegisterRoutes(r weave.Registry, auth x.Authenticator, decoder OptionDecoder, executor Executor) {
 	r = migration.SchemaMigratingRegistry(packageName, r)
-	r.Handle(pathVoteMsg, newVoteHandler(auth))
-	r.Handle(pathTallyMsg, newTallyHandler(auth, decoder, executor))
-	r.Handle(pathCreateProposalMsg, newCreateProposalHandler(auth, decoder))
-	r.Handle(pathDeleteProposalMsg, newDeleteProposalHandler(auth))
-	r.Handle(pathUpdateElectorateMsg, newUpdateElectorateHandler(auth))
-	r.Handle(pathUpdateElectionRuleMsg, newUpdateElectionRuleHandler(auth))
+	r.Handle(&VoteMsg{}, newVoteHandler(auth))
+	r.Handle(&TallyMsg{}, newTallyHandler(auth, decoder, executor))
+	r.Handle(&CreateProposalMsg{}, newCreateProposalHandler(auth, decoder))
+	r.Handle(&DeleteProposalMsg{}, newDeleteProposalHandler(auth))
+	r.Handle(&UpdateElectorateMsg{}, newUpdateElectorateHandler(auth))
+	r.Handle(&UpdateElectionRuleMsg{}, newUpdateElectionRuleHandler(auth))
 	// We do NOT register the TextResultionHandler here... this is only for the proposal Executor
 }
 
 // RegisterBasicProposalRouters register the routes we accept for executing governance decisions.
 func RegisterBasicProposalRouters(r weave.Registry, auth x.Authenticator) {
 	r = migration.SchemaMigratingRegistry(packageName, r)
-	r.Handle(pathUpdateElectorateMsg, newUpdateElectorateHandler(auth))
-	r.Handle(pathUpdateElectionRuleMsg, newUpdateElectionRuleHandler(auth))
-	r.Handle(pathCreateTextResolutionMsg, newCreateTextResolutionHandler(auth))
+	r.Handle(&UpdateElectorateMsg{}, newUpdateElectorateHandler(auth))
+	r.Handle(&UpdateElectionRuleMsg{}, newUpdateElectionRuleHandler(auth))
+	r.Handle(&CreateTextResolutionMsg{}, newCreateTextResolutionHandler(auth))
 }
 
 type VoteHandler struct {

--- a/x/gov/msg.go
+++ b/x/gov/msg.go
@@ -5,16 +5,6 @@ import (
 	"github.com/iov-one/weave/migration"
 )
 
-const (
-	pathCreateProposalMsg       = "gov/create_proposal"
-	pathDeleteProposalMsg       = "gov/delete_proposal"
-	pathVoteMsg                 = "gov/vote"
-	pathTallyMsg                = "gov/tally"
-	pathCreateTextResolutionMsg = "gov/create_text_resolution"
-	pathUpdateElectorateMsg     = "gov/update_electorate"
-	pathUpdateElectionRuleMsg   = "gov/update_election_rule"
-)
-
 func init() {
 	migration.MustRegister(1, &CreateProposalMsg{}, migration.NoModification)
 	migration.MustRegister(1, &VoteMsg{}, migration.NoModification)
@@ -25,7 +15,7 @@ func init() {
 }
 
 func (CreateProposalMsg) Path() string {
-	return pathCreateProposalMsg
+	return "gov/create_proposal"
 }
 
 func (m CreateProposalMsg) Validate() error {
@@ -62,7 +52,7 @@ func (m CreateProposalMsg) Validate() error {
 }
 
 func (DeleteProposalMsg) Path() string {
-	return pathDeleteProposalMsg
+	return "gov/delete_proposal"
 }
 
 func (m DeleteProposalMsg) Validate() error {
@@ -77,7 +67,7 @@ func (m DeleteProposalMsg) Validate() error {
 }
 
 func (VoteMsg) Path() string {
-	return pathVoteMsg
+	return "gov/vote"
 }
 
 func (m VoteMsg) Validate() error {
@@ -97,7 +87,7 @@ func (m VoteMsg) Validate() error {
 }
 
 func (TallyMsg) Path() string {
-	return pathTallyMsg
+	return "gov/tally"
 }
 
 func (m TallyMsg) Validate() error {
@@ -112,7 +102,7 @@ func (m TallyMsg) Validate() error {
 }
 
 func (UpdateElectionRuleMsg) Path() string {
-	return pathUpdateElectionRuleMsg
+	return "gov/update_election_rule"
 }
 
 func (m UpdateElectionRuleMsg) Validate() error {
@@ -132,7 +122,7 @@ func (m UpdateElectionRuleMsg) Validate() error {
 }
 
 func (CreateTextResolutionMsg) Path() string {
-	return pathCreateTextResolutionMsg
+	return "gov/create_text_resolution"
 }
 
 func (m CreateTextResolutionMsg) Validate() error {
@@ -146,7 +136,7 @@ func (m CreateTextResolutionMsg) Validate() error {
 }
 
 func (UpdateElectorateMsg) Path() string {
-	return pathUpdateElectorateMsg
+	return "gov/update_electorate"
 }
 
 func (m UpdateElectorateMsg) Validate() error {

--- a/x/gov/msg.go
+++ b/x/gov/msg.go
@@ -1,6 +1,7 @@
 package gov
 
 import (
+	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
 )
@@ -13,6 +14,8 @@ func init() {
 	migration.MustRegister(1, &UpdateElectionRuleMsg{}, migration.NoModification)
 	migration.MustRegister(1, &UpdateElectorateMsg{}, migration.NoModification)
 }
+
+var _ weave.Msg = (*CreateProposalMsg)(nil)
 
 func (CreateProposalMsg) Path() string {
 	return "gov/create_proposal"
@@ -51,6 +54,8 @@ func (m CreateProposalMsg) Validate() error {
 	return nil
 }
 
+var _ weave.Msg = (*DeleteProposalMsg)(nil)
+
 func (DeleteProposalMsg) Path() string {
 	return "gov/delete_proposal"
 }
@@ -65,6 +70,8 @@ func (m DeleteProposalMsg) Validate() error {
 	}
 	return nil
 }
+
+var _ weave.Msg = (*VoteMsg)(nil)
 
 func (VoteMsg) Path() string {
 	return "gov/vote"
@@ -86,6 +93,8 @@ func (m VoteMsg) Validate() error {
 	return nil
 }
 
+var _ weave.Msg = (*TallyMsg)(nil)
+
 func (TallyMsg) Path() string {
 	return "gov/tally"
 }
@@ -100,6 +109,8 @@ func (m TallyMsg) Validate() error {
 	}
 	return nil
 }
+
+var _ weave.Msg = (*UpdateElectionRuleMsg)(nil)
 
 func (UpdateElectionRuleMsg) Path() string {
 	return "gov/update_election_rule"
@@ -121,6 +132,8 @@ func (m UpdateElectionRuleMsg) Validate() error {
 	return m.Threshold.Validate()
 }
 
+var _ weave.Msg = (*CreateTextResolutionMsg)(nil)
+
 func (CreateTextResolutionMsg) Path() string {
 	return "gov/create_text_resolution"
 }
@@ -134,6 +147,8 @@ func (m CreateTextResolutionMsg) Validate() error {
 	}
 	return nil
 }
+
+var _ weave.Msg = (*UpdateElectorateMsg)(nil)
 
 func (UpdateElectorateMsg) Path() string {
 	return "gov/update_electorate"

--- a/x/multisig/handlers.go
+++ b/x/multisig/handlers.go
@@ -13,8 +13,8 @@ import (
 func RegisterRoutes(r weave.Registry, auth x.Authenticator) {
 	r = migration.SchemaMigratingRegistry("multisig", r)
 	bucket := NewContractBucket()
-	r.Handle(pathCreateMsg, CreateMsgHandler{auth, bucket})
-	r.Handle(pathUpdateMsg, UpdateMsgHandler{auth, bucket})
+	r.Handle(&CreateMsg{}, CreateMsgHandler{auth, bucket})
+	r.Handle(&UpdateMsg{}, UpdateMsgHandler{auth, bucket})
 }
 
 // RegisterQuery register queries from buckets in this package

--- a/x/multisig/msg.go
+++ b/x/multisig/msg.go
@@ -1,6 +1,7 @@
 package multisig
 
 import (
+	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
 )
@@ -18,6 +19,8 @@ const (
 	// allowed to be part of a single contract.
 	maxParticipantsAllowed = 100
 )
+
+var _ weave.Msg = (*CreateMsg)(nil)
 
 // Path fulfills weave.Msg interface to allow routing.
 func (CreateMsg) Path() string {
@@ -38,6 +41,8 @@ func (c *CreateMsg) Validate() error {
 	return validateWeights(errors.ErrMsg,
 		c.Participants, c.ActivationThreshold, c.AdminThreshold)
 }
+
+var _ weave.Msg = (*UpdateMsg)(nil)
 
 // Path fulfills weave.Msg interface to allow routing.
 func (UpdateMsg) Path() string {

--- a/x/multisig/msg.go
+++ b/x/multisig/msg.go
@@ -11,9 +11,6 @@ func init() {
 }
 
 const (
-	pathCreateMsg = "multisig/create"
-	pathUpdateMsg = "multisig/update"
-
 	creationCost int64 = 300 // 3x more expensive than SendMsg
 	updateCost   int64 = 150 // Half the creation cost
 
@@ -22,9 +19,9 @@ const (
 	maxParticipantsAllowed = 100
 )
 
-// Path fulfills weave.Msg interface to allow routing
+// Path fulfills weave.Msg interface to allow routing.
 func (CreateMsg) Path() string {
-	return pathCreateMsg
+	return "multisig/create"
 }
 
 // Validate enforces sigs and threshold boundaries
@@ -42,9 +39,9 @@ func (c *CreateMsg) Validate() error {
 		c.Participants, c.ActivationThreshold, c.AdminThreshold)
 }
 
-// Path fulfills weave.Msg interface to allow routing
+// Path fulfills weave.Msg interface to allow routing.
 func (UpdateMsg) Path() string {
-	return pathUpdateMsg
+	return "multisig/update"
 }
 
 // Validate enforces sigs and threshold boundaries

--- a/x/paychan/handler.go
+++ b/x/paychan/handler.go
@@ -25,11 +25,11 @@ func RegisterRoutes(r weave.Registry, auth x.Authenticator, cash cash.Controller
 	r = migration.SchemaMigratingRegistry("paychan", r)
 
 	bucket := NewPaymentChannelBucket()
-	r.Handle(pathCreateMsg,
+	r.Handle(&CreateMsg{},
 		&createPaymentChannelHandler{auth: auth, bucket: bucket, cash: cash})
-	r.Handle(pathTransferMsg,
+	r.Handle(&TransferMsg{},
 		&transferPaymentChannelHandler{auth: auth, bucket: bucket, cash: cash})
-	r.Handle(pathCloseMsg,
+	r.Handle(&CloseMsg{},
 		&closePaymentChannelHandler{auth: auth, bucket: bucket, cash: cash})
 }
 

--- a/x/paychan/msg.go
+++ b/x/paychan/msg.go
@@ -12,6 +12,8 @@ func init() {
 	migration.MustRegister(1, &CloseMsg{}, migration.NoModification)
 }
 
+var _ weave.Msg = (*CreateMsg)(nil)
+
 func (m *CreateMsg) Validate() error {
 	var errs error
 
@@ -42,6 +44,8 @@ func (m *CreateMsg) Validate() error {
 func (CreateMsg) Path() string {
 	return "paychan/create"
 }
+
+var _ weave.Msg = (*TransferMsg)(nil)
 
 func (m *TransferMsg) Validate() error {
 	var errs error
@@ -74,6 +78,8 @@ func (m *TransferMsg) Validate() error {
 func (TransferMsg) Path() string {
 	return "paychan/transfer"
 }
+
+var _ weave.Msg = (*CloseMsg)(nil)
 
 func (m *CloseMsg) Validate() error {
 	var errs error

--- a/x/paychan/msg.go
+++ b/x/paychan/msg.go
@@ -6,21 +6,11 @@ import (
 	"github.com/iov-one/weave/migration"
 )
 
-var _ weave.Msg = (*CreateMsg)(nil)
-var _ weave.Msg = (*TransferMsg)(nil)
-var _ weave.Msg = (*CloseMsg)(nil)
-
 func init() {
 	migration.MustRegister(1, &CreateMsg{}, migration.NoModification)
 	migration.MustRegister(1, &TransferMsg{}, migration.NoModification)
 	migration.MustRegister(1, &CloseMsg{}, migration.NoModification)
 }
-
-const (
-	pathCreateMsg   = "paychan/create"
-	pathTransferMsg = "paychan/transfer"
-	pathCloseMsg    = "paychan/close"
-)
 
 func (m *CreateMsg) Validate() error {
 	var errs error
@@ -50,7 +40,7 @@ func (m *CreateMsg) Validate() error {
 }
 
 func (CreateMsg) Path() string {
-	return pathCreateMsg
+	return "paychan/create"
 }
 
 func (m *TransferMsg) Validate() error {
@@ -82,7 +72,7 @@ func (m *TransferMsg) Validate() error {
 }
 
 func (TransferMsg) Path() string {
-	return pathTransferMsg
+	return "paychan/transfer"
 }
 
 func (m *CloseMsg) Validate() error {
@@ -102,7 +92,7 @@ func (m *CloseMsg) Validate() error {
 }
 
 func (CloseMsg) Path() string {
-	return pathCloseMsg
+	return "paychan/close"
 }
 
 // inThePast represents time value for Monday, January 1, 2018 2:00:00 AM GMT+01:00

--- a/x/sigs/handler.go
+++ b/x/sigs/handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 func RegisterRoutes(r weave.Registry, auth x.Authenticator) {
-	r.Handle(pathBumpSequenceMsg, migration.SchemaMigratingHandler("sigs",
+	r.Handle(&BumpSequenceMsg{}, migration.SchemaMigratingHandler("sigs",
 		&bumpSequenceHandler{
 			b:    NewBucket(),
 			auth: auth,

--- a/x/sigs/msg.go
+++ b/x/sigs/msg.go
@@ -10,8 +10,6 @@ func init() {
 }
 
 const (
-	pathBumpSequenceMsg = "sigs/bump_sequence"
-
 	maxSequenceIncrement = 1000
 	minSequenceIncrement = 1
 )
@@ -30,5 +28,5 @@ func (msg *BumpSequenceMsg) Validate() error {
 }
 
 func (BumpSequenceMsg) Path() string {
-	return pathBumpSequenceMsg
+	return "sigs/bump_sequence"
 }

--- a/x/sigs/msg.go
+++ b/x/sigs/msg.go
@@ -1,6 +1,7 @@
 package sigs
 
 import (
+	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
 )
@@ -13,6 +14,8 @@ const (
 	maxSequenceIncrement = 1000
 	minSequenceIncrement = 1
 )
+
+var _ weave.Msg = (*BumpSequenceMsg)(nil)
 
 func (msg *BumpSequenceMsg) Validate() error {
 	if err := msg.Metadata.Validate(); err != nil {

--- a/x/validators/handler.go
+++ b/x/validators/handler.go
@@ -11,7 +11,7 @@ import (
 // all handlers in this package.
 func RegisterRoutes(r weave.Registry, auth x.Authenticator) {
 	bucket := NewAccountBucket()
-	r.Handle(pathApplyDiffMsg, migration.SchemaMigratingHandler("validators", &updateHandler{
+	r.Handle(&ApplyDiffMsg{}, migration.SchemaMigratingHandler("validators", &updateHandler{
 		auth:   auth,
 		bucket: bucket,
 	}))

--- a/x/validators/msg.go
+++ b/x/validators/msg.go
@@ -1,7 +1,6 @@
 package validators
 
 import (
-	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -11,14 +10,9 @@ func init() {
 	migration.MustRegister(1, &ApplyDiffMsg{}, migration.NoModification)
 }
 
-// Ensure we implement the Msg interface
-var _ weave.Msg = (*ApplyDiffMsg)(nil)
-
-const pathApplyDiffMsg = "validators/apply_diff"
-
-// Path returns the routing path for this message
+// Path implements weave.Msg interface.
 func (*ApplyDiffMsg) Path() string {
-	return pathApplyDiffMsg
+	return "validators/apply_diff"
 }
 
 func (m *ApplyDiffMsg) Validate() error {

--- a/x/validators/msg.go
+++ b/x/validators/msg.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -9,6 +10,8 @@ import (
 func init() {
 	migration.MustRegister(1, &ApplyDiffMsg{}, migration.NoModification)
 }
+
+var _ weave.Msg = (*ApplyDiffMsg)(nil)
 
 // Path implements weave.Msg interface.
 func (*ApplyDiffMsg) Path() string {


### PR DESCRIPTION
Change the `app.Router` to require a message reference instead of the
message path as the first argument.

Remove all `const` declaration of message paths as they are no longer
needed and can be embeded directly in message `Path` method.

resolve #817