### PR TITLE
configure trafis to use cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ addons:
     packages:
     - docker-ce
 
+cache:
+  directories:
+    - $HOME/.cache/go-build
+    - $HOME/gopath/pkg/mod
+
 os:
 - linux
 


### PR DESCRIPTION
Use cache for Go modules when running Travis CI.


Before: 9min and 10min 30sec.
After: 5min and 6min. 
:speedboat: 