### PR TITLE
weave/store: iterator tests added

### DIFF
--- a/store/iterator_test.go
+++ b/store/iterator_test.go
@@ -19,3 +19,17 @@ func TestCacheIteratorReleaseRaceCondition(t *testing.T) {
 	it.Release()
 	assert.Nil(t, db.Delete([]byte("a")))
 }
+
+func TestCacheReverseIteratorReleaseRaceCondition(t *testing.T) {
+	db := MemStore()
+	assert.Nil(t, db.Set([]byte("a"), []byte("A")))
+	cache := db.CacheWrap()
+
+	it, err := cache.ReverseIterator([]byte("a"), []byte("z"))
+	if err != nil {
+		t.Fatalf("cannot create iterator: %s", err)
+	}
+	// Release must be a synchronous operation.
+	it.Release()
+	assert.Nil(t, db.Delete([]byte("a")))
+}

--- a/store/iterator_test.go
+++ b/store/iterator_test.go
@@ -1,0 +1,21 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/iov-one/weave/weavetest/assert"
+)
+
+func TestCacheIteratorReleaseRaceCondition(t *testing.T) {
+	db := MemStore()
+	assert.Nil(t, db.Set([]byte("a"), []byte("A")))
+	cache := db.CacheWrap()
+
+	it, err := cache.Iterator([]byte("a"), []byte("z"))
+	if err != nil {
+		t.Fatalf("cannot create iterator: %s", err)
+	}
+	// Release must be a synchronous operation.
+	it.Release()
+	assert.Nil(t, db.Delete([]byte("a")))
+}


### PR DESCRIPTION
```
WARNING: DATA RACE
Write at 0x00c0002348b0 by goroutine 15:
  github.com/google/btree.(*BTree).ReplaceOrInsert()
      /home/piotr/go/pkg/mod/github.com/google/btree@v1.0.0/btree.go:693 +0xfc
  github.com/iov-one/weave/store.BTreeCacheWrap.Delete()
      /home/piotr/weave/store/btree.go:128 +0x9c   
  github.com/iov-one/weave/store.(*BTreeCacheWrap).Delete()
      <autogenerated>:1 +0xe8                    
  github.com/iov-one/weave/store.TestCacheIteratorReleaseRaceCondition()
      /home/piotr/weave/store/iterator_test.go:21 +0x628
  testing.tRunner()                                       
      /home/piotr/.go_1.12.5/src/testing/testing.go:865 +0x163
```

#trivial