### PR TITLE
bnscli: update distribution commands

### DIFF
--- a/cmd/bnscli/clitests/csv.test
+++ b/cmd/bnscli/clitests/csv.test
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+
+csvfile=`mktemp`
+
+# first write the header
+echo "name,age,description" >> $csvfile
+
+echo "bobby,12,a boy" >> $csvfile
+echo "wendy,16,a girl" >> $csvfile
+
+# multi line row
+echo '"Jimmy' >> $csvfile
+echo 'The Man",42,' >> $csvfile
+
+
+echo "# skip 1; cols 2,1,3"
+bnscli csv -skip 1 -cols "2,1, 3" < $csvfile
+
+
+echo
+echo "# skip 2; cols 1,2"
+bnscli csv -skip 2 -cols "1,2" < $csvfile
+
+
+echo
+echo "# skip 2; cols 1,44"
+bnscli csv -skip 2 -cols "1,44" < $csvfile
+
+rm $csvfile

--- a/cmd/bnscli/clitests/csv.test.gold
+++ b/cmd/bnscli/clitests/csv.test.gold
@@ -1,0 +1,12 @@
+# skip 1; cols 2,1,3
+12	bobby	a boy
+16	wendy	a girl
+42	Jimmy The Man	
+
+# skip 2; cols 1,2
+wendy	16
+Jimmy The Man	42
+
+# skip 2; cols 1,44
+wendy
+Jimmy The Man

--- a/cmd/bnscli/clitests/reset_revenue.test
+++ b/cmd/bnscli/clitests/reset_revenue.test
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+
+# Pretend there is a CSV with the configuration we want to apply.
+destination_csv=`mktemp`
+
+echo "id,address,weight,description" >> $destination_csv
+echo "1,b1ca7e78f74423ae01da3b51e676934d9105f282,32,validator bob" >> $destination_csv
+echo "2,f427d624ed29c1fae0e2f427d624ed29c1fae0e2,99,our best validator" >> $destination_csv
+
+
+# Create the empty reset revenue transaction.
+tx=`mktemp`
+bnscli reset-revenue -id 313233343536373839300a > $tx
+
+
+# Parse the CSV file and for every line, attach a destination to the reset
+# revenue transaction.
+bnscli csv -skip 1 -cols 3,2 < $destination_csv \
+	| while read -r line
+	do
+		weight=`echo $line | cut -f1 -d ' '`
+		addr=`echo $line | cut -f2 -d ' '`
+
+		next=`mktemp`
+		bnscli with-destination -weight "$weight" -addr "$addr" < $tx > $next
+		mv $next $tx
+	done
+
+
+# tx contains the transaction that can be submitted or viewed.
+bnscli view < $tx
+
+rm $tx

--- a/cmd/bnscli/cmd_csv.go
+++ b/cmd/bnscli/cmd_csv.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+func cmdCSV(input io.Reader, output io.Writer, args []string) error {
+	fl := flag.NewFlagSet("", flag.ExitOnError)
+	fl.Usage = func() {
+		fmt.Fprintln(flag.CommandLine.Output(), `
+Read CSV file from the standard input and return selected content in an easy to
+parse way.
+		`)
+		fl.PrintDefaults()
+	}
+	var (
+		skipHeadFl = fl.Int("skip", 0, "Skip first N lines of the CSV file. Use this if the CSV file contains header.")
+		delimFl    = fl.String("delim", ",", "Delimiter to be used.")
+		colsFl     = fl.String("cols", "", "A list of comma separated column numbers to return (in order). Index starts at 1.")
+	)
+	fl.Parse(args)
+
+	if len(*delimFl) != 1 {
+		flagDie(`"delim" must be a single character`)
+	}
+
+	cols := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+	if *colsFl != "" {
+		cols = nil
+		for i, raw := range strings.Split(*colsFl, ",") {
+			n, err := strconv.Atoi(strings.TrimSpace(raw))
+			if err != nil {
+				flagDie("invalid \"cols\" value: %dth column index: %s", i, err)
+			}
+			if n < 1 {
+				flagDie("invalid \"cols\" value: index value starts with 1")
+			}
+			cols = append(cols, n)
+		}
+	}
+
+	rd := csv.NewReader(input)
+	rd.Comma = []rune((*delimFl))[0]
+
+	for i := 0; i < *skipHeadFl; i++ {
+		if _, err := rd.Read(); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("cannot read CSV file: %s", err)
+		}
+	}
+
+	for {
+		row, err := rd.Read()
+		switch err {
+		case nil:
+			// All good.
+		case io.EOF:
+			return nil
+		default:
+			return fmt.Errorf("cannot read CSV row: %s", err)
+		}
+
+		res := make([]string, 0, len(cols))
+		for _, c := range cols {
+			idx := c - 1 // Cols count from 1.
+			if idx >= len(row) {
+				// Ignore out of bound columns.
+				continue
+			}
+			val := row[idx]
+
+			// Transform the CSV cell value to an acceptable state.
+			val = strings.TrimSpace(val)
+			val = strings.ReplaceAll(val, "\n", " ")
+			val = strings.ReplaceAll(val, "\t", " ")
+
+			res = append(res, val)
+		}
+
+		for i, val := range res {
+			io.WriteString(output, val)
+			if i < len(res)-1 {
+				io.WriteString(output, "\t")
+			}
+		}
+		io.WriteString(output, "\n")
+	}
+}

--- a/cmd/bnscli/main.go
+++ b/cmd/bnscli/main.go
@@ -38,6 +38,7 @@ var commands = map[string]func(input io.Reader, output io.Writer, args []string)
 	"as-batch":                  cmdAsBatch,
 	"as-proposal":               cmdAsProposal,
 	"as-sequence":               cmdAsSequence,
+	"csv":                       cmdCSV,
 	"del-proposal":              cmdDelProposal,
 	"from-sequence":             cmdFromSequence,
 	"keyaddr":                   cmdKeyaddr,
@@ -53,16 +54,17 @@ var commands = map[string]func(input io.Reader, output io.Writer, args []string)
 	"submit":                    cmdSubmitTransaction,
 	"tally":                     cmdTally,
 	"text-resolution":           cmdTextResolution,
-	"update-electorate":         cmdUpdateElectorate,
 	"update-election-rule":      cmdUpdateElectionRule,
+	"update-electorate":         cmdUpdateElectorate,
 	"version":                   cmdVersion,
 	"view":                      cmdTransactionView,
 	"vote":                      cmdVote,
+	"with-blockchain-address":   cmdWithBlockchainAddress,
+	"with-destination":          cmdWithDestination,
+	"with-elector":              cmdWithElector,
 	"with-fee":                  cmdWithFee,
 	"with-multisig":             cmdWithMultisig,
-	"with-elector":              cmdWithElector,
 	"with-multisig-participant": cmdWithMultisigParticipant,
-	"with-blockchain-address":   cmdWithBlockchainAddress,
 }
 
 func main() {


### PR DESCRIPTION
Instead of passing a CSV file as an input of transaction building
command, provide tooling for parsing CSV so that it could be read by the
shell script and used to pass command line arguments to the command.


---

One of the workflows for `bnscli` is to create a revenue reset transaction with a list of destinations (address & weight). The current implementation is reading a CSV file as an input, which I think will be a problem after working with the username import and bunch of CSV files as well. So as an improvement, I have changed transaction creation and split it into two commands
- one to create a reset transaction without any destinations
- second to read a reset transaction and attach a destination to it. Having that, I need a generic tool (shell cannot do this) to parse a CSV. So I have added a `csv` command to the `bnscli`. All was good, until I wrote the flow script. [Look at this monster!](https://github.com/iov-one/weave/commit/a848b0939c3f344582fdf99a14028375c80d8b26#diff-00fddf23088fa8a42ec88d56a2da64f0 ):zombie:

My question is - how to make it acceptable. I am wondering if it would not be better to rollback the changes to the reset transaction creation (let it take a CSV file) and keep `bnscli csv` in case the CSV needs basic preprocessing. What do you think?