### PR TITLE
Allow to use !nochangelog to mark pull request.

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -3,7 +3,7 @@
 has_code_changes = !git.modified_files.grep(/\.go$/).empty?
 
 # Let people say that this isn't worth a CHANGELOG entry in the PR if they choose
-declared_trivial = (github.pr_title + github.pr_body).include?("#trivial") || !has_code_changes
+declared_trivial = github.pr_body.include?("#trivial") || github.pr_body.include?("!nochangelog") || !has_code_changes
 
 if !git.modified_files.include?("CHANGELOG.md") && !declared_trivial
   fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/iov-one/weave/blob/master/CHANGELOG.md).", sticky: false)

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ but good to go through it to be sure.
 Once you are set up, you should be able to run something
 like the following to compile both `bnsd` (IOV blockchain application)
 and `bnscli` (a client side app to interact with `bnsd`).
-You will have to 
-[install a compatible version of tendermint](https://github.com/tendermint/tendermint/blob/master/docs/introduction/install.md) 
+You will have to
+[install a compatible version of tendermint](https://github.com/tendermint/tendermint/blob/master/docs/introduction/install.md)
 separately. (Currently we use the v0.31.5 release).
 
 ```
@@ -127,9 +127,11 @@ open ./docs/proto/index.html
 ```
 
 ## Contributions
-When opening a PR with a minor fix that does not need a CHANGELOG.md entry
-make sure to add `#trivial` to the title/description of said PR.  
-That's only needed if you are changing any of the `*.go` files in the repo.
+
+When opening a pull request with a change that does not require a CHANGELOG
+entry, include `!nochangelog` in the description. This will inform our build
+system to not fail the build due to a missing CHANGELOG update. This
+instruction is needed only if you are changing any of the Go source files.
 
 ## History
 


### PR DESCRIPTION
We use `#trivial` to allow merging a pull request without any
modyfications to the CHANGELOG file.

In addition, allow to use `!nochangelog` string to achieve the same
result.
`#trivial` is triggering GitHub's stupid autocompletion. It might also
be [confusing to people from outside of the project](https://github.com/iov-one/weave/pull/879#issuecomment-509959187) what it means.

Do not search for any of those strings in the pull request title as we
never put it there.