### PR TITLE
Fix and polish flacky sigs/Decorator test

### DIFF
--- a/x/sigs/decorator_test.go
+++ b/x/sigs/decorator_test.go
@@ -13,67 +13,97 @@ import (
 )
 
 func TestDecorator(t *testing.T) {
-	kv := store.MemStore()
-	migration.MustInitPkg(kv, "sigs")
-	checkKv := kv.CacheWrap()
-	signers := new(SigCheckHandler)
-	d := NewDecorator()
 	chainID := "deco-rate"
-	ctx := weave.WithChainID(context.Background(), chainID)
 
 	priv := weavetest.NewKey()
-	perms := []weave.Condition{priv.PublicKey().Condition()}
 
-	bz := []byte("art")
-	tx := NewStdTx(bz)
-	sig, err := SignTx(priv, tx, chainID, 0)
+	tx := NewStdTx([]byte("art"))
+	sig0, err := SignTx(priv, tx, chainID, 0)
 	assert.Nil(t, err)
 	sig1, err := SignTx(priv, tx, chainID, 1)
 	assert.Nil(t, err)
 
-	// Order of calling first check and then deliver is important.
-	cases := map[string]func(weave.Decorator, weave.Tx) error{
-		"check": func(dec weave.Decorator, my weave.Tx) error {
-			_, err := dec.Check(ctx, checkKv, my, signers)
-			return err
-		},
-		"deliver": func(dec weave.Decorator, my weave.Tx) error {
-			_, err := dec.Deliver(ctx, kv, my, signers)
-			return err
-		},
+	ctx := weave.WithChainID(context.Background(), chainID)
+
+	incrSequence := func(db store.KVStore, d Decorator, h *SigCheckHandler) {
+		tx.Signatures = []*StdSignature{sig0}
+		_, err := d.Check(ctx, db, tx, h)
+		assert.Nil(t, err)
 	}
 
-	for testName, fn := range cases {
+	cases := map[string]struct {
+		setup            func(store.KVStore, Decorator, *SigCheckHandler)
+		allowMissingSigs bool
+		srcSign          []*StdSignature
+		expCheckErr      *errors.Error
+		expDeliverErr    *errors.Error
+		expSigners       []weave.Condition
+	}{
+		"with no sigs": {
+			expCheckErr:   errors.ErrUnauthorized,
+			expDeliverErr: errors.ErrUnauthorized,
+		},
+		"single signature": {
+			srcSign:    []*StdSignature{sig0},
+			expSigners: []weave.Condition{priv.PublicKey().Condition()},
+		},
+		"with replay": {
+			setup:         incrSequence,
+			srcSign:       []*StdSignature{sig0},
+			expCheckErr:   ErrInvalidSequence,
+			expDeliverErr: ErrInvalidSequence,
+		},
+		"with next sequence": {
+			setup:      incrSequence,
+			srcSign:    []*StdSignature{sig1},
+			expSigners: []weave.Condition{priv.PublicKey().Condition()},
+		},
+		"allowing none": {
+			allowMissingSigs: true,
+			expSigners:       []weave.Condition{},
+		},
+		"allowing none, with next sequence": {
+			setup:            incrSequence,
+			allowMissingSigs: true,
+			srcSign:          []*StdSignature{sig1},
+			expSigners:       []weave.Condition{priv.PublicKey().Condition()},
+		},
+	}
+	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
-			// test with no sigs
-			tx.Signatures = nil
-			if err := fn(d, tx); !errors.ErrUnauthorized.Is(err) {
-				t.Fatalf("unexpected error: %+v", err)
+			db := store.MemStore()
+			migration.MustInitPkg(db, "sigs")
+			captureSigners := new(SigCheckHandler)
+
+			d := NewDecorator()
+			if tc.allowMissingSigs {
+				d = d.AllowMissingSigs()
 			}
 
-			// test with one
-			tx.Signatures = []*StdSignature{sig}
-			err = fn(d, tx)
-			assert.Nil(t, err)
-			assert.Equal(t, perms, signers.Signers)
+			if tc.setup != nil {
+				tc.setup(db, d, captureSigners)
+			}
+			cache := db.CacheWrap()
+			tx.Signatures = tc.srcSign
 
-			// test with replay
-			if err := fn(d, tx); !ErrInvalidSequence.Is(err) {
+			// when
+			_, err := d.Check(ctx, cache, tx, captureSigners)
+			if !tc.expCheckErr.Is(err) {
 				t.Fatalf("unexpected errror: %+v", err)
+
 			}
 
-			// test allowing none
-			ad := d.AllowMissingSigs()
-			tx.Signatures = nil
-			err = fn(ad, tx)
-			assert.Nil(t, err)
-			assert.Equal(t, []weave.Condition{}, signers.Signers)
+			cache.Discard()
+			// and when
+			if _, err := d.Deliver(ctx, cache, tx, captureSigners); !tc.expDeliverErr.Is(err) {
+				t.Fatalf("unexpected deliver error: %+v", err)
+			}
 
-			// test allowing, with next sequence
-			tx.Signatures = []*StdSignature{sig1}
-			err = fn(ad, tx)
-			assert.Nil(t, err)
-			assert.Equal(t, perms, signers.Signers)
+			if tc.expDeliverErr != nil {
+				// If we expect an error than it make no sense to continue the flow.
+				return
+			}
+			assert.Equal(t, tc.expSigners, captureSigners.Signers)
 		})
 	}
 


### PR DESCRIPTION
The decorator test expected a fix order of calls. With the refactoring to map based test cases this order got lost and tests began to fail randomly.

This fix is also a refactoring of the test to separate the test cases which.
#trivial