### PR TITLE
use multierror for validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## HEAD
 
+- update all extensions to use multi-error for gathering validation errors.
+
+
 ## 0.19.0
+
 - Remove `testify` dependency from our tests
 - A new extension `x/cron` is added. It allows to configure weave application
   to be able to schedule messages for future execution.

--- a/errors/field.go
+++ b/errors/field.go
@@ -14,7 +14,9 @@ import (
 //
 // Use Go naming for the field name. For example, UserName or MaxAge. When the
 // error is for a nested field, use dot notation to constrct the path. For
-// example, User.Age or User.Name.
+// example, User.Age or User.Name. When the path includes an iterable, use the
+// element index starting with 0 as the name, for example Tags.0 or
+// Profiles.2.ID
 func Field(fieldName string, err error, description string, args ...interface{}) error {
 	if isNilErr(err) {
 		return nil
@@ -43,7 +45,9 @@ func Field(fieldName string, err error, description string, args ...interface{})
 //
 // Use Go naming for the field name. For example, UserName or MaxAge. When the
 // error is for a nested field, use dot notation to constrct the path. For
-// example, User.Age or User.Name.
+// example, User.Age or User.Name. When the path includes an iterable, use the
+// element index starting with 0 as the name, for example Tags.0 or
+// Profiles.2.ID
 func AppendField(errorsOrNil error, fieldName string, fieldErrOrNil error) error {
 	return Append(errorsOrNil, Field(fieldName, fieldErrOrNil, ""))
 }

--- a/errors/field.go
+++ b/errors/field.go
@@ -11,7 +11,11 @@ import (
 // Use this function to create an error instance describing a field/attribute
 // error.
 // This function might attach a stack trace information.
-func Field(fieldName string, err error, description string) error {
+//
+// Use Go naming for the field name. For example, UserName or MaxAge. When the
+// error is for a nested field, use dot notation to constrct the path. For
+// example, User.Age or User.Name.
+func Field(fieldName string, err error, description string, args ...interface{}) error {
 	if isNilErr(err) {
 		return nil
 	}
@@ -23,6 +27,10 @@ func Field(fieldName string, err error, description string) error {
 		err = errors.WithStack(err)
 	}
 
+	if len(args) > 0 {
+		description = fmt.Sprintf(description, args...)
+	}
+
 	return &fieldError{
 		parent: err,
 		field:  fieldName,
@@ -32,6 +40,10 @@ func Field(fieldName string, err error, description string) error {
 
 // AppendField is a shortcut function to club together error(s) with a given
 // field error.
+//
+// Use Go naming for the field name. For example, UserName or MaxAge. When the
+// error is for a nested field, use dot notation to constrct the path. For
+// example, User.Age or User.Name.
 func AppendField(errorsOrNil error, fieldName string, fieldErrOrNil error) error {
 	return Append(errorsOrNil, Field(fieldName, fieldErrOrNil, ""))
 }

--- a/x/aswap/msg.go
+++ b/x/aswap/msg.go
@@ -28,33 +28,30 @@ func (CreateMsg) Path() string {
 }
 
 func (m *CreateMsg) Validate() error {
-	if err := m.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "metadata")
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", m.Metadata.Validate())
+	if len(m.PreimageHash) != preimageHashSize {
+		errs = errors.Append(errs, errors.Field("PreimageHash", errors.ErrInput, "preimage hash has to be exactly %d bytes", preimageHashSize))
 	}
-	if err := validatePreimageHash(m.PreimageHash); err != nil {
-		return err
-	}
-	if err := m.Source.Validate(); err != nil {
-		return errors.Wrap(err, "src")
-	}
-	if err := m.Destination.Validate(); err != nil {
-		return errors.Wrap(err, "destination")
-	}
+
+	errs = errors.AppendField(errs, "Source", m.Source.Validate())
+	errs = errors.AppendField(errs, "Destination", m.Destination.Validate())
 	if m.Timeout == 0 {
 		// Zero timeout is a valid value that dates to 1970-01-01. We
 		// know that this value is in the past and makes no sense. Most
 		// likely value was not provided and a zero value remained.
-		return errors.Wrap(errors.ErrInput, "timeout is required")
+		errs = errors.Append(errs, errors.Field("Timeout", errors.ErrInput, "timeout is required"))
 	}
-	if err := m.Timeout.Validate(); err != nil {
-		return errors.Wrap(err, "invalid timeout value")
-	}
+	errs = errors.AppendField(errs, "Timeout", m.Timeout.Validate())
 	if len(m.Memo) > maxMemoSize {
-		return errors.Wrapf(errors.ErrInput, "memo %s", m.Memo)
+		errs = errors.Append(errs, errors.Field("Memo", errors.ErrInput, "memo must be not longer than %d characters", maxMemoSize))
 	}
-	var err error
-	m.Amount, err = validateAmount(m.Amount)
-	return err
+	if cs := coin.Coins(m.Amount); !cs.IsPositive() {
+		errs = errors.Append(errs, errors.Field("Amount", errors.ErrAmount, "must be positive"))
+	} else {
+		errs = errors.AppendField(errs, "Amount", cs.Validate())
+	}
+	return errs
 }
 
 var _ weave.Msg = (*ReleaseMsg)(nil)
@@ -64,18 +61,13 @@ func (ReleaseMsg) Path() string {
 }
 
 func (m *ReleaseMsg) Validate() error {
-	if err := m.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "metadata")
-	}
-
-	if err := validateSwapID(m.SwapID); err != nil {
-		return errors.Wrap(err, "SwapID")
-	}
-
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", m.Metadata.Validate())
+	errs = errors.AppendField(errs, "SwapID", validateSwapID(m.SwapID))
 	if len(m.Preimage) != preimageSize {
-		return errors.Wrapf(errors.ErrInput, "preimage should be exactly %d byte long", preimageSize)
+		errs = errors.Append(errs, errors.Field("Preimage", errors.ErrInput, "preimage has to be exactly %d bytes", preimageSize))
 	}
-	return nil
+	return errs
 }
 
 var _ weave.Msg = (*ReturnMsg)(nil)
@@ -86,40 +78,15 @@ func (ReturnMsg) Path() string {
 }
 
 func (m *ReturnMsg) Validate() error {
-	if err := m.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "metadata")
-	}
-	if err := validateSwapID(m.SwapID); err != nil {
-		return errors.Wrap(err, "SwapID")
-	}
-	return nil
-}
-
-// validateAmount makes sure the amount is positive and coins are of valid format
-func validateAmount(amount coin.Coins) (coin.Coins, error) {
-	c, err := coin.NormalizeCoins(amount)
-	if err != nil {
-		return c, errors.Wrap(err, "unable to normalize")
-	}
-
-	positive := c.IsPositive()
-	if !positive {
-		return c, errors.Wrapf(errors.ErrAmount, "non-positive CreateMsg: %#v", &c)
-	}
-	return c, c.Validate()
-}
-
-func validatePreimageHash(preimageHash []byte) error {
-	if len(preimageHash) != preimageHashSize {
-		return errors.Wrapf(errors.ErrInput, "preimge hash is sha256 and therefore should be exactly "+
-			"%d bytes", preimageHashSize)
-	}
-	return nil
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", m.Metadata.Validate())
+	errs = errors.AppendField(errs, "SwapID", validateSwapID(m.SwapID))
+	return errs
 }
 
 func validateSwapID(id []byte) error {
 	if len(id) != 8 {
-		return errors.Wrapf(errors.ErrInput, "SwapID: %X", id)
+		return errors.Wrap(errors.ErrInput, "swap ID must be 8 bytes long")
 	}
 	return nil
 }

--- a/x/batch/msg.go
+++ b/x/batch/msg.go
@@ -15,14 +15,12 @@ type Msg interface {
 }
 
 func Validate(msg Msg) error {
-	l, err := msg.MsgList()
+	msgs, err := msg.MsgList()
 	if err != nil {
 		return errors.Wrap(err, "cannot retrieve batch message")
 	}
-
-	msgNum := len(l)
-	if msgNum > MaxBatchMessages {
-		return errors.Wrapf(errors.ErrInput, "transaction is too large, max: %d vs current: %d", MaxBatchMessages, msgNum)
+	if len(msgs) > MaxBatchMessages {
+		return errors.Wrapf(errors.ErrInput, "transaction is too large, max is %d", MaxBatchMessages)
 	}
 	return nil
 }

--- a/x/cash/model.go
+++ b/x/cash/model.go
@@ -22,9 +22,10 @@ var _ Coinage = (*Set)(nil)
 
 // Validate requires that all coins are in alphabetical
 func (s *Set) Validate() error {
-	err := errors.Wrap(s.Metadata.Validate(), "metadata")
-	err = errors.Append(err, errors.Wrap(XCoins(s).Validate(), "coins"))
-	return err
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", s.Metadata.Validate())
+	errs = errors.AppendField(errs, "Coins", XCoins(s).Validate())
+	return errs
 }
 
 // Copy makes a new set with the same coins

--- a/x/cron/model.go
+++ b/x/cron/model.go
@@ -2,6 +2,7 @@ package cron
 
 import (
 	weave "github.com/iov-one/weave"
+	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
 	"github.com/iov-one/weave/orm"
 )
@@ -13,7 +14,10 @@ func init() {
 var _ orm.CloneableData = (*TaskResult)(nil)
 
 func (t *TaskResult) Validate() error {
-	return nil
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", t.Metadata.Validate())
+	errs = errors.AppendField(errs, "ExecTime", t.ExecTime.Validate())
+	return errs
 }
 
 func (t *TaskResult) Copy() orm.CloneableData {

--- a/x/currency/model.go
+++ b/x/currency/model.go
@@ -28,13 +28,12 @@ func NewTokenInfo(ticker, name string) orm.Object {
 }
 
 func (t *TokenInfo) Validate() error {
-	if err := t.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "metadata")
-	}
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", t.Metadata.Validate())
 	if !isTokenName(t.Name) {
-		return errors.Wrapf(errors.ErrState, "invalid token name %v", t.Name)
+		errs = errors.AppendField(errs, "Name", errors.ErrState)
 	}
-	return nil
+	return errs
 }
 
 func (t *TokenInfo) Copy() orm.CloneableData {

--- a/x/currency/msg.go
+++ b/x/currency/msg.go
@@ -14,15 +14,14 @@ func (CreateMsg) Path() string {
 	return "currency/create"
 }
 
-func (t *CreateMsg) Validate() error {
-	if err := t.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "metadata")
+func (msg *CreateMsg) Validate() error {
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", msg.Metadata.Validate())
+	if !coin.IsCC(msg.Ticker) {
+		errs = errors.AppendField(errs, "Ticker", errors.ErrCurrency)
 	}
-	if !coin.IsCC(t.Ticker) {
-		return errors.Wrapf(errors.ErrCurrency, "invalid ticker: %s", t.Ticker)
+	if !isTokenName(msg.Name) {
+		errs = errors.AppendField(errs, "Name", errors.ErrState)
 	}
-	if !isTokenName(t.Name) {
-		return errors.Wrapf(errors.ErrState, "invalid token name %v", t.Name)
-	}
-	return nil
+	return errs
 }

--- a/x/distribution/msg.go
+++ b/x/distribution/msg.go
@@ -15,16 +15,13 @@ func init() {
 var _ weave.Msg = (*CreateMsg)(nil)
 
 func (msg *CreateMsg) Validate() error {
-	if err := msg.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "invalid metadata")
-	}
-	if err := msg.Admin.Validate(); err != nil {
-		return errors.Wrap(err, "invalid admin address")
-	}
-	if err := validateDestinations(msg.Destinations, errors.ErrMsg); err != nil {
-		return err
-	}
-	return nil
+	var errs error
+
+	errs = errors.AppendField(errs, "Metadata", msg.Metadata.Validate())
+	errs = errors.AppendField(errs, "Admin", msg.Admin.Validate())
+	errs = errors.AppendField(errs, "Destinatinos", validateDestinations(msg.Destinations, errors.ErrMsg))
+
+	return errs
 }
 
 func (CreateMsg) Path() string {
@@ -34,13 +31,14 @@ func (CreateMsg) Path() string {
 var _ weave.Msg = (*DistributeMsg)(nil)
 
 func (msg *DistributeMsg) Validate() error {
-	if err := msg.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "invalid metadata")
-	}
+	var errs error
+
+	errs = errors.AppendField(errs, "Metadata", msg.Metadata.Validate())
 	if len(msg.RevenueID) == 0 {
-		return errors.Wrap(errors.ErrMsg, "revenue ID missing")
+		errs = errors.Append(errs, errors.Field("RevenueID", errors.ErrMsg, "revenue ID is required"))
 	}
-	return nil
+
+	return errs
 }
 
 func (DistributeMsg) Path() string {
@@ -50,13 +48,12 @@ func (DistributeMsg) Path() string {
 var _ weave.Msg = (*ResetMsg)(nil)
 
 func (msg *ResetMsg) Validate() error {
-	if err := msg.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "invalid metadata")
-	}
-	if err := validateDestinations(msg.Destinations, errors.ErrMsg); err != nil {
-		return err
-	}
-	return nil
+	var errs error
+
+	errs = errors.AppendField(errs, "Metadata", msg.Metadata.Validate())
+	errs = errors.AppendField(errs, "Destinatinos", validateDestinations(msg.Destinations, errors.ErrMsg))
+
+	return errs
 }
 
 func (ResetMsg) Path() string {

--- a/x/gov/model.go
+++ b/x/gov/model.go
@@ -1,6 +1,7 @@
 package gov
 
 import (
+	fmt "fmt"
 	"math/big"
 	"regexp"
 	"time"
@@ -34,37 +35,29 @@ func (m *Electorate) SetVersion(v uint32) {
 }
 
 func (m Electorate) Validate() error {
-	if err := m.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "invalid metadata")
-	}
-
-	if len(m.Electors) == 0 {
-		return errors.Wrap(errors.ErrInput, "electors must not be empty")
-	}
-	if len(m.Electors) > maxElectors {
-		return errors.Wrapf(errors.ErrInput, "electors must not exceed: %d", maxElectors)
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", m.Metadata.Validate())
+	if n := len(m.Electors); n == 0 {
+		errs = errors.Append(errs, errors.Field("Electors", errors.ErrInput, "electors must not be empty"))
+	} else if n > maxElectors {
+		errs = errors.Append(errs, errors.Field("Electors", errors.ErrInput, "electors size must not exceed %d", maxElectors))
 	}
 	if !validTitle(m.Title) {
-		return errors.Wrapf(errors.ErrInput, "title: %q", m.Title)
+		errs = errors.AppendField(errs, "Title", errors.ErrInput)
 	}
-
 	var totalWeight uint64
-	for _, v := range m.Electors {
-		if err := v.Validate(); err != nil {
-			return err
-		}
+	for i, v := range m.Electors {
+		errs = errors.AppendField(errs, fmt.Sprintf("Electors.%d", i), v.Validate())
 		totalWeight += uint64(v.Weight)
 	}
 	if diff := len(m.Electors) - newMerger(m.Electors).size(); diff != 0 {
-		return errors.Wrapf(errors.ErrInput, "duplicate electors: %d", diff)
+		errs = errors.Append(errs, errors.Field("Electors", errors.ErrInput, "duplicate electors: %d", diff))
 	}
 	if m.TotalElectorateWeight != totalWeight {
-		return errors.Wrap(errors.ErrInput, "total weight does not match sum")
+		errs = errors.Append(errs, errors.Field("TotalElectorateWeight", errors.ErrInput, "total weight does not match sum"))
 	}
-	if err := m.Admin.Validate(); err != nil {
-		return errors.Wrap(err, "admin")
-	}
-	return nil
+	errs = errors.AppendField(errs, "Admin", m.Admin.Validate())
+	return errs
 }
 
 func (m Electorate) Copy() orm.CloneableData {
@@ -367,35 +360,29 @@ func (m TallyResult) TotalVotes() uint64 {
 }
 
 func (m TallyResult) Validate() error {
+	var errs error
 	if m.Quorum != nil {
-		if err := m.Quorum.Validate(); err != nil {
-			return errors.Wrap(errors.ErrState, "quorum")
-		}
+		errs = errors.AppendField(errs, "Quorum", m.Quorum.Validate())
 	}
 	if m.TotalElectorateWeight == 0 {
-		return errors.Wrap(errors.ErrState, "totalElectorateWeight")
+		errs = errors.Append(errs, errors.Field("TotalElectorateWeight", errors.ErrState, "must not be zero"))
 	}
 	if m.TotalVotes() > m.TotalElectorateWeight {
-		return errors.Wrap(errors.ErrState, "votes must not exceed totalElectorateWeight")
+		errs = errors.Append(errs, errors.Field("TotalElectorateWeight", errors.ErrState, "votes must not exceed TotalElectorateWeight"))
 	}
-	if err := m.Threshold.Validate(); err != nil {
-		return errors.Wrap(errors.ErrState, "threshold")
-	}
-	return nil
+	errs = errors.AppendField(errs, "Threshold", m.Threshold.Validate())
+	return errs
 }
 
 // validate vote object contains valid elector and voted option
 func (m Vote) Validate() error {
-	if err := m.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "invalid metadata")
-	}
-	if err := m.Elector.Validate(); err != nil {
-		return errors.Wrap(err, "invalid elector")
-	}
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", m.Metadata.Validate())
+	errs = errors.AppendField(errs, "Elector", m.Elector.Validate())
 	if m.Voted == VoteOption_Invalid {
-		return errors.Wrap(errors.ErrInput, "invalid vote option")
+		errs = errors.AppendField(errs, "Voted", errors.ErrInput)
 	}
-	return nil
+	return errs
 }
 
 func (m Vote) Copy() orm.CloneableData {
@@ -403,23 +390,4 @@ func (m Vote) Copy() orm.CloneableData {
 		Elector: m.Elector,
 		Voted:   m.Voted,
 	}
-}
-
-// DiffElectors contains the changes that should be applied. Adding an address should have a positive weight, removing
-// with weight=0.
-type ElectorsDiff []Elector
-
-func (e ElectorsDiff) Validate() error {
-	if len(e) == 0 {
-		return errors.Wrap(errors.ErrEmpty, "electors")
-	}
-	for i, v := range e {
-		if v.Weight > maxWeight {
-			return errors.Wrap(errors.ErrInput, "must not be greater max weight")
-		}
-		if err := v.Address.Validate(); err != nil {
-			return errors.Wrapf(err, "address at position: %d", i)
-		}
-	}
-	return nil
 }

--- a/x/msgfee/model.go
+++ b/x/msgfee/model.go
@@ -15,19 +15,17 @@ func init() {
 var _ orm.CloneableData = (*MsgFee)(nil)
 
 func (mf *MsgFee) Validate() error {
-	if err := mf.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "metadata")
-	}
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", mf.Metadata.Validate())
 	if mf.MsgPath == "" {
-		return errors.Wrap(errors.ErrModel, "invalid message path")
+		errs = errors.Append(errs, errors.Field("MsgPath", errors.ErrModel, "required"))
 	}
 	if mf.Fee.IsZero() {
-		return errors.Wrap(errors.ErrModel, "invalid fee")
+		errs = errors.AppendField(errs, "Fee", errors.ErrModel)
+	} else {
+		errs = errors.AppendField(errs, "Fee", mf.Fee.Validate())
 	}
-	if err := mf.Fee.Validate(); err != nil {
-		return errors.Wrap(err, "invalid fee")
-	}
-	return nil
+	return errs
 }
 
 func (mf *MsgFee) Copy() orm.CloneableData {

--- a/x/multisig/msg.go
+++ b/x/multisig/msg.go
@@ -27,19 +27,18 @@ func (CreateMsg) Path() string {
 	return "multisig/create"
 }
 
-// Validate enforces sigs and threshold boundaries
+// Validate enforces sigs and threshold boundaries.
 func (c *CreateMsg) Validate() error {
-	if err := c.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "metadata")
-	}
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", c.Metadata.Validate())
 	switch n := len(c.Participants); {
 	case n == 0:
-		return errors.Wrap(errors.ErrMsg, "no participants")
+		errs = errors.Append(errs, errors.Field("Participants", errors.ErrMsg, "required"))
 	case n > maxParticipantsAllowed:
-		return errors.Wrap(errors.ErrMsg, "too many participants")
+		errs = errors.Append(errs, errors.Field("Participants", errors.ErrModel, "too many participants, max %d allowed", maxParticipantsAllowed))
 	}
-	return validateWeights(errors.ErrMsg,
-		c.Participants, c.ActivationThreshold, c.AdminThreshold)
+	errs = errors.Append(errs, validateWeights(errors.ErrMsg, c.Participants, c.ActivationThreshold, c.AdminThreshold))
+	return errs
 }
 
 var _ weave.Msg = (*UpdateMsg)(nil)
@@ -49,19 +48,18 @@ func (UpdateMsg) Path() string {
 	return "multisig/update"
 }
 
-// Validate enforces sigs and threshold boundaries
+// Validate enforces sigs and threshold boundaries.
 func (c *UpdateMsg) Validate() error {
-	if err := c.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "metadata")
-	}
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", c.Metadata.Validate())
 	switch n := len(c.Participants); {
 	case n == 0:
-		return errors.Wrap(errors.ErrMsg, "no participants")
+		errs = errors.Append(errs, errors.Field("Participants", errors.ErrMsg, "required"))
 	case n > maxParticipantsAllowed:
-		return errors.Wrap(errors.ErrMsg, "too many participants")
+		errs = errors.Append(errs, errors.Field("Participants", errors.ErrModel, "too many participants, max %d allowed", maxParticipantsAllowed))
 	}
-	return validateWeights(errors.ErrMsg,
-		c.Participants, c.ActivationThreshold, c.AdminThreshold)
+	errs = errors.Append(errs, validateWeights(errors.ErrMsg, c.Participants, c.ActivationThreshold, c.AdminThreshold))
+	return errs
 }
 
 // validateWeights returns an error if given participants and thresholds

--- a/x/sigs/msg.go
+++ b/x/sigs/msg.go
@@ -18,16 +18,17 @@ const (
 var _ weave.Msg = (*BumpSequenceMsg)(nil)
 
 func (msg *BumpSequenceMsg) Validate() error {
-	if err := msg.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "metadata")
-	}
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", msg.Metadata.Validate())
 	if msg.Increment < minSequenceIncrement {
-		return errors.Wrapf(errors.ErrMsg, "increment must be at least %d", minSequenceIncrement)
+		errs = errors.Append(errs,
+			errors.Field("Increment", errors.ErrMsg, "increment must be at least %d", minSequenceIncrement))
 	}
 	if msg.Increment > maxSequenceIncrement {
-		return errors.Wrapf(errors.ErrMsg, "increment must not be greater than %d", maxSequenceIncrement)
+		return errors.Append(errs,
+			errors.Field("Increment", errors.ErrMsg, "increment must not be greater than %d", maxSequenceIncrement))
 	}
-	return nil
+	return errs
 }
 
 func (BumpSequenceMsg) Path() string {

--- a/x/validators/model.go
+++ b/x/validators/model.go
@@ -1,6 +1,8 @@
 package validators
 
 import (
+	"fmt"
+
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
@@ -24,14 +26,11 @@ type WeaveAccounts struct {
 }
 
 func (wa WeaveAccounts) Validate() error {
-	for _, v := range wa.Addresses {
-		err := v.Validate()
-		if err != nil {
-			return err
-		}
+	var errs error
+	for i, v := range wa.Addresses {
+		errs = errors.AppendField(errs, fmt.Sprintf("Addresses.%d", i), v.Validate())
 	}
-
-	return nil
+	return errs
 }
 
 func AsWeaveAccounts(a *Accounts) WeaveAccounts {
@@ -68,10 +67,10 @@ func (m *Accounts) Copy() orm.CloneableData {
 }
 
 func (m *Accounts) Validate() error {
-	if err := m.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "metadata")
-	}
-	return AsWeaveAccounts(m).Validate()
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", m.Metadata.Validate())
+	errs = errors.Append(errs, AsWeaveAccounts(m).Validate())
+	return errs
 }
 
 type AccountBucket struct {

--- a/x/validators/msg.go
+++ b/x/validators/msg.go
@@ -1,6 +1,8 @@
 package validators
 
 import (
+	fmt "fmt"
+
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/migration"
@@ -19,18 +21,15 @@ func (*ApplyDiffMsg) Path() string {
 }
 
 func (m *ApplyDiffMsg) Validate() error {
-	if err := m.Metadata.Validate(); err != nil {
-		return errors.Wrap(err, "metadata")
-	}
+	var errs error
+	errs = errors.AppendField(errs, "Metadata", m.Metadata.Validate())
 	if len(m.ValidatorUpdates) == 0 {
-		return errors.Wrap(errors.ErrEmpty, "validator set")
+		errs = errors.AppendField(errs, "ValidatorUpdates", errors.ErrEmpty)
 	}
-	for _, v := range m.ValidatorUpdates {
-		if err := v.Validate(); err != nil {
-			return err
-		}
+	for i, v := range m.ValidatorUpdates {
+		errs = errors.AppendField(errs, fmt.Sprintf("ValidatorUpdates.%d", i), v.Validate())
 	}
-	return nil
+	return errs
 }
 
 func (m *ApplyDiffMsg) AsABCI() []abci.ValidatorUpdate {


### PR DESCRIPTION
Update all extensions to use multi-error for validation errors. This
means that when validation a model or a message, we get all validation
errors together instead of only the first one.

resolve #890