### PR TITLE
Update `cmd/bnscli` documentation

### DIFF
--- a/cmd/bnscli/README.md
+++ b/cmd/bnscli/README.md
@@ -28,3 +28,24 @@ workflow. Combine them using UNIX pipes to create a powerful pipelines.
 For example usage of commands as well as pipelines, see
 [`clitests/`](clitests/) directory. Files with extension `.test` contains short
 code snippets.
+
+Notice that all pipelines end with `bnscli view`. This displays the
+transaction. To submit it, after the transaction is prepared, sign it and
+submit it. This is done by piping the transaction to `bnscli`:
+
+```
+<build tx with bnscli> | bnscli sign | bnscli submit
+```
+
+To sign and submit you must provide the signature key and set tendermint
+adderess. Both can be set via environment variables `BNSCLI_PRIV_KEY` and
+`BNSCLI_TM_ADDR`.
+
+- [Send funds from the `src` to the `dst` account](clitests/send_tokens.test).
+  For example, transfer funds from guarantee to reward account.
+- [Add a single or multiple validators](clitests/set_validators.test).
+- [Update an electorate](clitests/gov_update-electorate.test) via proposal. For
+  example to add a new member to the tech committee.
+- [Update configuration of a election
+  rule](clitests/gov_update-election-rule.test) via proposal. For example,
+  create a proposal to change the quorum for the economic committee.


### PR DESCRIPTION
Update `cmd/bnscli` documentation and provide description for some of
the test examples describing the use case.

As [described by Ethan](https://github.com/iov-one/weave/issues/853#issuecomment-509590729) this provides the executable examples that should be incorporated into our documentation.

@kmw101 can you have a look at both [the README](https://github.com/iov-one/weave/blob/faa1d33dc83e6fb9041f1d27b4d97c69b40770f8/cmd/bnscli/README.md#cookbook) and linked  there examples and let us know if this is good enough?

Resolve #853

!nochangelog