### PR TITLE
[DO NOT MERGE] init cron pkg no matter what

### DIFF
--- a/migration/init.go
+++ b/migration/init.go
@@ -58,5 +58,7 @@ func (Initializer) FromGenesis(opts weave.Options, params weave.GenesisParams, k
 		}
 	}
 
+	MustInitPkg(kv, "cron")
+
 	return nil
 }


### PR DESCRIPTION
As requested - force init cron package migration for investigation.

DO NOT MERGE - this change is going to be discarded after the investigation.