### PR TITLE
x/cron: store cron executed message log

### DIFF
--- a/x/cron/cron.go
+++ b/x/cron/cron.go
@@ -247,6 +247,7 @@ func (t *Ticker) tick(ctx context.Context, db store.CacheableKVStore) ([]common.
 				} else {
 					taskTags = r.Tags
 					taskDiff = r.Diff
+					res.Info = r.Log
 				}
 			}
 

--- a/x/cron/model.go
+++ b/x/cron/model.go
@@ -17,8 +17,13 @@ func (t *TaskResult) Validate() error {
 	var errs error
 	errs = errors.AppendField(errs, "Metadata", t.Metadata.Validate())
 	errs = errors.AppendField(errs, "ExecTime", t.ExecTime.Validate())
+	if len(t.Info) > maxInfoSize {
+		errs = errors.Append(errs, errors.Field("Info", errors.ErrInput, "maximum allowed length is %d", maxInfoSize))
+	}
 	return errs
 }
+
+const maxInfoSize = 10240
 
 func (t *TaskResult) Copy() orm.CloneableData {
 	return &TaskResult{

--- a/x/cron/model_test.go
+++ b/x/cron/model_test.go
@@ -1,0 +1,68 @@
+package cron
+
+import (
+	"strings"
+	"testing"
+
+	weave "github.com/iov-one/weave"
+	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/weavetest/assert"
+)
+
+func TestTaskResultValidation(t *testing.T) {
+	cases := map[string]struct {
+		Msg *TaskResult
+		// Field name to error mapping. Use `nil` if no error is expected.
+		WantErrs map[string]*errors.Error
+	}{
+		"valid message": {
+			Msg: &TaskResult{
+				Metadata: &weave.Metadata{Schema: 1},
+				ExecTime: weave.UnixTime(1000000),
+			},
+			WantErrs: map[string]*errors.Error{
+				"Metadata":   nil,
+				"Successful": nil,
+				"Info":       nil,
+				"ExecTime":   nil,
+				"ExecHeight": nil,
+			},
+		},
+		"info string too long": {
+			Msg: &TaskResult{
+				Metadata: &weave.Metadata{Schema: 1},
+				ExecTime: weave.UnixTime(1000000),
+				Info:     strings.Repeat("x", 10241),
+			},
+			WantErrs: map[string]*errors.Error{
+				"Metadata":   nil,
+				"Successful": nil,
+				"Info":       errors.ErrInput,
+				"ExecTime":   nil,
+				"ExecHeight": nil,
+			},
+		},
+		"missing metadata": {
+			Msg: &TaskResult{
+				Metadata: nil,
+				ExecTime: weave.UnixTime(1000000),
+			},
+			WantErrs: map[string]*errors.Error{
+				"Metadata":   errors.ErrMetadata,
+				"Successful": nil,
+				"Info":       nil,
+				"ExecTime":   nil,
+				"ExecHeight": nil,
+			},
+		},
+	}
+
+	for testName, tc := range cases {
+		t.Run(testName, func(t *testing.T) {
+			err := tc.Msg.Validate()
+			for field, wantErr := range tc.WantErrs {
+				assert.FieldError(t, err, field, wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When successfully executing a message as a cron task, store result log
information within the task result. This is useful for `TallyMsg` where
althugh the message processing was successful and returned no error, the
process failed and tally could not execute its functionality. The only
feedback `TallyMsg` is providing is the response log.

The final result might be confusing. It is possible that for a single cron task result:
- :heavy_check_mark:  a tally cron task executed successfully,
- :heavy_check_mark: tally message was handled without an error,
- :no_entry_sign:  proposal that the tally was created for could not successfully execute stored procedure (failed) 

resolve #905

!nochangelog