### PR TITLE
bnsd/username: allow for only iov domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - update all extensions to use multi-error for gathering validation errors.
 
+Breaking changes
+
+- `bnsd/x/username`: `iov` is the only valid and accepted domain name for a
+  username. This limitation is forced for the MVP release as we do not have
+  namespace management implemented.
 
 ## 0.19.0
 

--- a/cmd/bnsd/x/username/username.go
+++ b/cmd/bnsd/x/username/username.go
@@ -52,6 +52,15 @@ func (u Username) Validate() error {
 	if !validUsername(string(u)) {
 		return errors.Wrap(errors.ErrInput, "invalid username")
 	}
+
+	// Currently only IOV namespace is supported. This is a public
+	// namespace that anyone can register in an IOV owns. This limitation
+	// exists because for the MVP release we do not provide a way to
+	// register and manage namespaces.
+	if u.Domain() != "iov" {
+		return errors.Field("Domain", errors.ErrInput, "invalid namespace")
+	}
+
 	return nil
 }
 

--- a/cmd/bnsd/x/username/username_test.go
+++ b/cmd/bnsd/x/username/username_test.go
@@ -20,14 +20,14 @@ func TestUsername(t *testing.T) {
 			WantDomain: "iov",
 		},
 		"shortest valid name and domain": {
-			Raw:        strings.Repeat("x", 4) + "*" + strings.Repeat("x", 3),
+			Raw:        strings.Repeat("x", 4) + "*iov",
 			WantName:   strings.Repeat("x", 4),
-			WantDomain: strings.Repeat("x", 3),
+			WantDomain: "iov",
 		},
 		"longest valid name and domain": {
-			Raw:        strings.Repeat("x", 64) + "*" + strings.Repeat("x", 16),
+			Raw:        strings.Repeat("x", 64) + "*iov",
 			WantName:   strings.Repeat("x", 64),
-			WantDomain: strings.Repeat("x", 16),
+			WantDomain: "iov",
 		},
 		"too long name": {
 			Raw:        strings.Repeat("x", 65) + "*" + strings.Repeat("x", 6),
@@ -60,10 +60,10 @@ func TestUsername(t *testing.T) {
 			WantDomain: "",
 		},
 		"missing name": {
-			Raw:        "*foo",
+			Raw:        "*iov",
 			WantErr:    errors.ErrInput,
 			WantName:   "",
-			WantDomain: "foo",
+			WantDomain: "iov",
 		},
 		"missing separator": {
 			Raw:        "xyz",
@@ -76,6 +76,12 @@ func TestUsername(t *testing.T) {
 			WantErr:    errors.ErrInput,
 			WantName:   "😈",
 			WantDomain: "😀",
+		},
+		"invalid domain name": {
+			Raw:        "extreme*expert",
+			WantErr:    errors.ErrInput,
+			WantName:   "extreme",
+			WantDomain: "expert",
 		},
 	}
 


### PR DESCRIPTION
Restrict name registration to only iov domain as the only available
domain. This restriction is needed because for MVP release we do not
provide any namespace implementation. You cannot register and maintain
namespaces. To avoid chaos and radom namespace usage, we allow only iov
for now.

resolve #907