### PR TITLE
cmd/bnscli: improve how proposal is formatted when queried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HEAD
 
 - update all extensions to use multi-error for gathering validation errors.
+- add `query` command to the `bnscli` tool
 
 
 ## 0.19.0


### PR DESCRIPTION
When a query result returns a proposal, in addition to printing a JSON
serialized proposal structure include deserialized raw options value.
This allows the user to inspect what message is being proposed and voted
on.

resolve #914