### PR TITLE
store/iavl: fix iterator race condition

### DIFF
--- a/store/iavl/iterator_test.go
+++ b/store/iavl/iterator_test.go
@@ -1,0 +1,23 @@
+package iavl
+
+import (
+	"testing"
+)
+
+func TestRelease(t *testing.T) {
+	// This test ensures that a bug of writing to a closed channel is fixed.
+
+	it := newLazyIterator()
+
+	done := make(chan struct{})
+	go func() {
+		// Ensure the iteration takes enough time to be active while
+		// Release is called.
+		for i := 0; i < 10000; i++ {
+			it.add(nil, nil)
+		}
+		close(done)
+	}()
+	it.Release()
+	<-done
+}


### PR DESCRIPTION
When an active iterator is released, a race condition is created. Write
to a closed `read` channel is performed. Restructure how the iterator is
implemented to eliminate the race condition.

Tests are added to confirm that the change fix the issue.

!nochangelog