### PR TITLE
bnsd: add validate command for validating genesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - `cmd/bnscli`: a new command `mnemonic` was added for generating a random
   mnemonic as described in BIP-39.
+- `cmd/bnsd`: a new command `validate` for validating genesis state declaration
+  was added.
 
 Breaking changes
 

--- a/cmd/bnsd/app/init.go
+++ b/cmd/bnsd/app/init.go
@@ -92,7 +92,13 @@ func GenerateApp(options *server.Options) (abci.Application, error) {
 
 // DecorateApp adds initializers and Logger to an Application
 func DecorateApp(application app.BaseApp, logger log.Logger) app.BaseApp {
-	application.WithInit(app.ChainInitializers(
+	application.WithInit(Initializers())
+	application.WithLogger(logger)
+	return application
+}
+
+func Initializers() weave.Initializer {
+	return app.ChainInitializers(
 		&migration.Initializer{},
 		&multisig.Initializer{},
 		&cash.Initializer{},
@@ -103,9 +109,7 @@ func DecorateApp(application app.BaseApp, logger log.Logger) app.BaseApp {
 		&escrow.Initializer{Minter: cash.NewController(cash.NewBucket())},
 		&gov.Initializer{},
 		&username.Initializer{},
-	))
-	application.WithLogger(logger)
-	return application
+	)
 }
 
 // InlineApp will take a previously prepared CommitStore and return a complete Application

--- a/cmd/bnsd/main.go
+++ b/cmd/bnsd/main.go
@@ -20,7 +20,7 @@ var (
 
 func init() {
 	defaultHome := filepath.Join(os.ExpandEnv("$HOME"), ".bns")
-	varHome = flag.String(flagHome, defaultHome, "directory to store files under")
+	varHome = flag.String(flagHome, defaultHome, "Directory to store files under.")
 
 	flag.CommandLine.Usage = helpMessage
 }
@@ -34,6 +34,7 @@ func helpMessage() {
 	fmt.Println("start     Run the abci server")
 	fmt.Println("getblock  Extract a block from blockchain.db")
 	fmt.Println("retry     Run last block again to ensure it produces same result")
+	fmt.Println("validate  Parse given genesis file and ensure that defined there state can be loaded.")
 	fmt.Println("version   Print the app version")
 	fmt.Println(`
   -home string
@@ -70,6 +71,8 @@ func main() {
 		err = commands.TestGenCmd(bnsd.Examples(), rest)
 	case "version":
 		fmt.Println(weave.Version)
+	case "validate":
+		err = server.ValidateGenesis(bnsd.Initializers(), rest)
 	default:
 		err = fmt.Errorf("unknown command: %s", cmd)
 	}

--- a/commands/server/validate.go
+++ b/commands/server/validate.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/store"
+)
+
+// ValidateGenesis TODO
+func ValidateGenesis(ini weave.Initializer, genesisPaths []string) error {
+	for _, path := range genesisPaths {
+		if err := validateGenesis(ini, path); err != nil {
+			return errors.Wrap(err, path)
+		}
+	}
+	return nil
+}
+
+func validateGenesis(ini weave.Initializer, genesisPath string) error {
+	b, err := ioutil.ReadFile(genesisPath)
+	if err != nil {
+		return errors.Wrap(err, "cannot read genesis file")
+	}
+
+	var genesis struct {
+		State weave.Options `json:"app_state"`
+	}
+	if err := json.Unmarshal(b, &genesis); err != nil {
+		return errors.Wrap(err, "cannot JSON deserialize genesis")
+	}
+
+	// Use in memory store because we want to discard the result.
+	db := store.MemStore()
+
+	if err := ini.FromGenesis(genesis.State, weave.GenesisParams{}, db); err != nil {
+		return errors.Wrap(err, "cannot initialize from genesis")
+	}
+
+	return nil
+}


### PR DESCRIPTION
This change introduce a new `bnsd` command - `validate`. It reads a
genesis file under provided path and use application initializers chain
to load genesis declarations into a in-memory store. This functionality
allows for validating genesis state initialization configuration without
the need of running a tendermint server and without creating any files.

Error reporting can be further improved. Currently returned
initialization errors are often times providing only a very enigmatic
error description without any context information.

resolve #658

Example error output:
```
weave $ cmd/bnsd/bnsd validate /tmp/genesis.json
Error: 
github.com/iov-one/weave.ParseAddress
        /home/piotr/weave/conditions.go:171
github.com/iov-one/weave.(*Address).UnmarshalJSON
        /home/piotr/weave/conditions.go:143
encoding/json.(*decodeState).literalStore
        /home/piotr/.go_1.12.5/src/encoding/json/decode.go:855
encoding/json.(*decodeState).value
        /home/piotr/.go_1.12.5/src/encoding/json/decode.go:395
encoding/json.(*decodeState).object
        /home/piotr/.go_1.12.5/src/encoding/json/decode.go:763
encoding/json.(*decodeState).value
        /home/piotr/.go_1.12.5/src/encoding/json/decode.go:381
encoding/json.(*decodeState).array
        /home/piotr/.go_1.12.5/src/encoding/json/decode.go:560
encoding/json.(*decodeState).value
        /home/piotr/.go_1.12.5/src/encoding/json/decode.go:371
encoding/json.(*decodeState).unmarshal
        /home/piotr/.go_1.12.5/src/encoding/json/decode.go:179
encoding/json.Unmarshal
        /home/piotr/.go_1.12.5/src/encoding/json/decode.go:106
github.com/iov-one/weave.Options.ReadOptions
        /home/piotr/weave/handler.go:60
github.com/iov-one/weave/cmd/bnsd/x/username.(*Initializer).FromGenesis
        /home/piotr/weave/cmd/bnsd/x/username/init.go:23
github.com/iov-one/weave/app.chainInitializer.FromGenesis
        /home/piotr/weave/app/genesis.go:23
github.com/iov-one/weave/commands/server.validateGenesis
        /home/piotr/weave/commands/server/validate.go:38
github.com/iov-one/weave/commands/server.ValidateGenesis
        /home/piotr/weave/commands/server/validate.go:15
main.main
        /home/piotr/weave/cmd/bnsd/main.go:75
/tmp/genesis.json: cannot initialize from genesis: initializer "github.com/iov-one/weave/cmd/bnsd/x/username": cannot load username tokens: cannot decode hex: encoding/hex: invalid byte: U+0078 'x'

bnsd
          Blockchain Name Service node

help      Print this message
init      Initialize app options in genesis file
start     Run the abci server
getblock  Extract a block from blockchain.db
retry     Run last block again to ensure it produces same result
validate  Parse given genesis file and ensure that defined there state can be loaded.
version   Print the app version

  -home string
        directory to store files under (default "$HOME/.bns")
```

```
weave $ cmd/bnsd/bnsd validate /tmp/genesis.json
Error: 
github.com/iov-one/weave/x/cash.Initializer.FromGenesis
        /home/piotr/weave/x/cash/init.go:27
github.com/iov-one/weave/app.chainInitializer.FromGenesis
        /home/piotr/weave/app/genesis.go:23
github.com/iov-one/weave/commands/server.validateGenesis
        /home/piotr/weave/commands/server/validate.go:38
github.com/iov-one/weave/commands/server.ValidateGenesis
        /home/piotr/weave/commands/server/validate.go:15
main.main
        /home/piotr/weave/cmd/bnsd/main.go:75
/tmp/genesis.json: cannot initialize from genesis: initializer "github.com/iov-one/weave/x/cash": read cash attribute: invalid format

bnsd
          Blockchain Name Service node

help      Print this message
init      Initialize app options in genesis file
start     Run the abci server
getblock  Extract a block from blockchain.db
retry     Run last block again to ensure it produces same result
validate  Parse given genesis file and ensure that defined there state can be loaded.
version   Print the app version

  -home string
        directory to store files under (default "$HOME/.bns")
```