### PR TITLE
cmd/bnscli: parse submit command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - `cmd/bnscli`: a new command `mnemonic` was added for generating a random
   mnemonic as described in BIP-39.
+- `cmd/bnscli`: when a transaction is submitted, for certain messages parse
+  returned response data and print it in a human readable format.
+
 
 Breaking changes
 

--- a/cmd/bnscli/cmd_submit.go
+++ b/cmd/bnscli/cmd_submit.go
@@ -5,7 +5,14 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/cmd/bnsd/client"
+	"github.com/iov-one/weave/x/aswap"
+	"github.com/iov-one/weave/x/batch"
+	"github.com/iov-one/weave/x/distribution"
+	"github.com/iov-one/weave/x/escrow"
+	"github.com/iov-one/weave/x/gov"
+	"github.com/iov-one/weave/x/paychan"
 )
 
 func cmdSubmitTransaction(input io.Reader, output io.Writer, args []string) error {
@@ -13,6 +20,10 @@ func cmdSubmitTransaction(input io.Reader, output io.Writer, args []string) erro
 	fl.Usage = func() {
 		fmt.Fprint(flag.CommandLine.Output(), `
 Read binary serialized transaction from standard input and submit it.
+
+For certain transactions response is written out. If a batch transaction was
+submitted, multiple responses can be printed out, one for each message
+submitted as part of the batch.
 
 Make sure to collect enough signatures before submitting the transaction.
 `)
@@ -28,11 +39,90 @@ Make sure to collect enough signatures before submitting the transaction.
 	if err != nil {
 		return fmt.Errorf("cannot read transaction from input: %s", err)
 	}
+
 	bnsClient := client.NewClient(client.NewHTTPConnection(*tmAddrFl))
 
-	if err := bnsClient.BroadcastTx(tx).IsError(); err != nil {
+	resp := bnsClient.BroadcastTx(tx)
+	if resp.IsError(); err != nil {
 		return fmt.Errorf("cannot broadcast transaction: %s", err)
 	}
-	return nil
 
+	responses, err := extractResponse(tx, resp.Response.DeliverTx.Data, formatters)
+	if err != nil {
+		return fmt.Errorf("cannot extract response: %s", err)
+	}
+	for _, r := range responses {
+		fmt.Fprintln(output, r)
+	}
+	return nil
+}
+
+// extractResponses parse given raw response data bytes according to what is
+// expected considering the submitted transaction. It returns a human readable
+// representation of given response. It can return no data (and no error) if
+// response does not contain anythink worth showing to the user or response is
+// not supported.
+func extractResponse(tx weave.Tx, respData []byte, fmts map[string]func([]byte) (string, error)) ([]string, error) {
+	var (
+		msgs          []weave.Msg
+		responsesData [][]byte
+	)
+	msg, err := tx.GetMsg()
+	if err != nil {
+		return nil, fmt.Errorf("cannot extract message from transaction: %s", err)
+	}
+	if b, ok := msg.(batch.Msg); ok {
+		bmsgs, err := b.MsgList()
+		if err != nil {
+			return nil, fmt.Errorf("cannot extract messages from a batch message trasnaction: %s", err)
+		}
+		msgs = append(msgs, bmsgs...)
+		var arr batch.ByteArrayList
+		if err := arr.Unmarshal(respData); err != nil {
+			return nil, fmt.Errorf("cannot unmarshal batch message transaction response: %s", err)
+		}
+		responsesData = arr.Elements
+	} else {
+		msgs = []weave.Msg{msg}
+		responsesData = [][]byte{respData}
+	}
+
+	var responses []string
+	for i, msg := range msgs {
+		format, ok := fmts[msg.Path()]
+		if !ok {
+			// If no formatter is registered, we do not print the result.
+			continue
+		}
+		pretty, err := format(responsesData[i])
+		if err != nil {
+			return nil, fmt.Errorf("cannot format #%d result data %x: %s", i, responsesData[i], err)
+		}
+
+		responses = append(responses, pretty)
+	}
+	return responses, nil
+}
+
+// formatters contains a mapping of a message path to response parser. Response
+// parse function accepts a raw bytes of serialized response and must return a
+// human representation of that data.
+//
+// Do not register a message if you want response returned after its submission
+// to be ignored (not printed to the user).
+var formatters = map[string]func([]byte) (string, error){
+	aswap.CreateMsg{}.Path():             fmtSequence,
+	distribution.CreateMsg{}.Path():      fmtSequence,
+	escrow.CreateMsg{}.Path():            fmtSequence,
+	gov.CreateProposalMsg{}.Path():       fmtSequence,
+	gov.CreateTextResolutionMsg{}.Path(): fmtSequence,
+	paychan.CreateMsg{}.Path():           fmtSequence,
+}
+
+func fmtSequence(raw []byte) (string, error) {
+	n, err := fromSequence(raw)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse sequence: %s", err)
+	}
+	return fmt.Sprint(n), nil
 }

--- a/cmd/bnscli/cmd_submit_test.go
+++ b/cmd/bnscli/cmd_submit_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/iov-one/weave"
 	bnsd "github.com/iov-one/weave/cmd/bnsd/app"
 	"github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/weavetest"
 	"github.com/iov-one/weave/weavetest/assert"
+	"github.com/iov-one/weave/x/batch"
 	"github.com/iov-one/weave/x/cash"
 )
 
@@ -56,4 +58,100 @@ func TestCmdSubmitTxHappyPath(t *testing.T) {
 	if err := cmdSubmitTransaction(&signedTx, &output, args); err != nil {
 		t.Fatalf("cannot submit the transaction: %s", err)
 	}
+}
+
+func TestSubmitTxResponse(t *testing.T) {
+	fmts := map[string]func([]byte) (string, error){
+		"mymsg":      fmtSequence,
+		"anothermsg": func(b []byte) (string, error) { return string(b), nil },
+	}
+
+	cases := map[string]struct {
+		Tx          weave.Tx
+		DeliverData []byte
+		WantResp    []string
+		WantErr     bool
+	}{
+		"not supported message returns no response": {
+			Tx:          &weavetest.Tx{Msg: &weavetest.Msg{RoutePath: "message/not/supported"}},
+			DeliverData: []byte(`this-data-must-not-be-parsed`),
+			WantResp:    nil,
+		},
+		"a sequence formatter returns a decimal representation": {
+			Tx: &weavetest.Tx{
+				Msg: &weavetest.Msg{
+					RoutePath: "mymsg", // Registered in fmts
+				},
+			},
+			DeliverData: weavetest.SequenceID(123456),
+			WantResp:    []string{"123456"},
+		},
+		"formatter for the invalid response returns an error": {
+			Tx: &weavetest.Tx{
+				Msg: &weavetest.Msg{
+					RoutePath: "mymsg", // Registered in fmts
+				},
+			},
+			DeliverData: []byte("x"),
+			WantResp:    nil,
+			WantErr:     true,
+		},
+		"a batch message response is parsed and every response is formatted separately": {
+			Tx: &weavetest.Tx{
+				Msg: &batchMsg{
+					Msgs: []weave.Msg{
+						&weavetest.Msg{RoutePath: "mymsg"},
+						&weavetest.Msg{RoutePath: "anothermsg"},
+					},
+				},
+			},
+			DeliverData: batchResp(t,
+				weavetest.SequenceID(123456),
+				[]byte("foobar"),
+			),
+			WantResp: []string{
+				"123456",
+				"foobar",
+			},
+		},
+	}
+
+	for testName, tc := range cases {
+		t.Run(testName, func(t *testing.T) {
+			resp, err := extractResponse(tc.Tx, tc.DeliverData, fmts)
+			hasErr := err != nil
+			if tc.WantErr != hasErr {
+				t.Fatalf("returned error: %+v", err)
+			}
+			assert.Equal(t, tc.WantResp, resp)
+		})
+	}
+}
+
+// batchMsg clubs together any number of messages and implements batch.Msg
+// interface. It does not intent to implement weave.Msg interface though.
+type batchMsg struct {
+	weave.Msg
+	weave.Batch
+
+	Msgs []weave.Msg
+}
+
+func (m *batchMsg) MsgList() ([]weave.Msg, error) {
+	return m.Msgs, nil
+}
+
+// batchResp returns a set of response serialized using batch byte array. This
+// is the same format as the batch extension is using for serializing multiple
+// responses.
+func batchResp(t testing.TB, responses ...[]byte) []byte {
+	t.Helper()
+	arr := batch.ByteArrayList{
+		Elements: responses,
+	}
+	b, err := arr.Marshal()
+	if err != nil {
+		t.Fatalf("cannot marshal byte array list: %s", err)
+	}
+	return b
 }


### PR DESCRIPTION
When a transaction is submitted, for certain messages parse returned
response data and print it in a human readable format. For example, when
submitting a proposal, a decimal ID value of created proposal will be
printed.

resolve #913