### PR TITLE
SCURITY.md: add random number generator information

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,3 +57,12 @@ QQM22M3gnZQsefEYucpqHsnQx7s=
 =mWRd
 -----END PGP PUBLIC KEY BLOCK-----
 ```
+
+# Random number generation
+
+Depending on the system a different source of a random number generator is
+used. Full explanation can be found in [Go
+documentation](https://golang.org/pkg/crypto/rand/#pkg-variables).
+
+On Windows [CryptoGenRandom](https://en.wikipedia.org/wiki/CryptGenRandom) is
+used which is considered insecure.


### PR DESCRIPTION
As recommended, update SECURITY.md to include information about the
random number generator.

resolve #938

To be honest, I do not feel confident about adding this information to the security file. This is because [in Go documentation it states](https://golang.org/pkg/crypto/rand/#pkg-variables):

>  Reader is a global, shared instance of a cryptographically secure random number generator. 

Now I consider Go team to have higher level of expertise than me. In addition, there are plenty of companies relying on this code that audited it. It feels wrong to be smarter than all those people and warn about something we do not understand.