### PR TITLE
gconf: update references to conf

### DIFF
--- a/cmd/bnsd/client/testdata/genesis.json
+++ b/cmd/bnsd/client/testdata/genesis.json
@@ -85,9 +85,9 @@
        "timeout": "2999-12-31T00:00:00Z"
      }
    ],
-   "gconf": {
-     "cash:collector_address": "cond:dist/revenue/0000000000000001",
-     "cash:minimal_fee": {
+   "conf": {
+     "collector_address": "cond:dist/revenue/0000000000000001",
+     "minimal_fee": {
        "fractional": 100000000,
        "ticker": "CASH",
        "//amount": "0.1CASH"

--- a/cmd/bnsd/client/testdata/genesis_json.md
+++ b/cmd/bnsd/client/testdata/genesis_json.md
@@ -119,18 +119,18 @@ The role of the arbiter requires therefore a lot of trust which can be modeled w
 * `"timeout": 9223372036854775807` = very very high block height to never expire
 
 
-# gconf settings they can tweak (eg. anti-spam fee)
-gconf is a configuration store intended to be used as a global, in-database configuration. The anti spam fee is
-defined by the `cash:collector_address`and `cash:minimal_fee` keys. Like any weave address the collector address
+# conf settings they can tweak (eg. anti-spam fee)
+conf is a configuration store intended to be used as a global, in-database configuration. The anti spam fee is
+defined by the `collector_address`and `minimal_fee` keys. Like any weave address the collector address
 can also point to a contract to distribute the amount within a group.
 
 ```json
-  "gconf": {
-    "cash:collector_address": "cond:distribution/revenue/0000000000000001",
-     "cash:minimal_fee": "0.1 IOV"
+  "conf": {
+    "collector_address": "cond:distribution/revenue/0000000000000001",
+    "minimal_fee": "0.1 IOV"
   },
 ```
-* `"cash:collector_address": "cond:distribution/revenue/0000000000000001"`= distribution contract with ID=1
+* `"collector_address": "cond:distribution/revenue/0000000000000001"`= distribution contract with ID=1
 
 ### Setting product fees
 Our internal protbuf messages are identified by a unique bath that maps to the type. This path is the reference key to assign

--- a/gconf/gconf_test.go
+++ b/gconf/gconf_test.go
@@ -11,10 +11,10 @@ import (
 func TestLoadSave(t *testing.T) {
 	db := store.MemStore()
 	c := configuration{raw: "foobar"}
-	if err := Save(db, "gconf", &c); err != nil {
+	if err := Save(db, "conf", &c); err != nil {
 		t.Fatalf("cannot save configuration: %s", err)
 	}
-	if err := Load(db, "gconf", &c); err != nil {
+	if err := Load(db, "conf", &c); err != nil {
 		t.Fatalf("cannot load configuration: %s", err)
 	}
 }


### PR DESCRIPTION
On v0.15.0 `gconf` has been updated to `conf` as seen on [CHANGELOG](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#L194) yet some references on test and documentation have not been updated. The cleaning lady is here :information_desk_person: