### PR TITLE
orm: deterministic versionedIDRef serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Breaking changes
 
 - `cmd/bnscli`: `keygen` command was updated and requires a mnemonic to
   generate a key.
+- `orm`: `VersionedIDRef` is now de/serialized by appending BigEndian ID and BigEndian Version
+- `cmd/bnscli`: now expects VersionedIDRef to be serialised using the new format
 
 
 ## 0.20.0

--- a/cmd/bnscli/cmd_query.go
+++ b/cmd/bnscli/cmd_query.go
@@ -199,7 +199,8 @@ func refID(s string) ([]byte, error) {
 	}
 
 	ref := orm.VersionedIDRef{ID: encID, Version: version}
-	return ref.Marshal()
+
+	return orm.MarshalVersionedID(ref, true), nil
 }
 
 func addressID(s string) ([]byte, error) {
@@ -210,10 +211,11 @@ func refKey(raw []byte) (string, error) {
 	// Skip the prefix, being the characters before : (including separator)
 	val := raw[bytes.Index(raw, []byte(":"))+1:]
 
-	var ref orm.VersionedIDRef
-	if err := ref.Unmarshal(val); err != nil {
+	ref, err := orm.UnmarshalVersionedID(val)
+	if err != nil {
 		return "", fmt.Errorf("cannot unmarshal versioned key: %s", err)
 	}
+
 	id := binary.BigEndian.Uint64(ref.ID)
 	return fmt.Sprintf("%d/%d", id, ref.Version), nil
 }

--- a/cmd/bnscli/cmd_query.go
+++ b/cmd/bnscli/cmd_query.go
@@ -200,7 +200,11 @@ func refID(s string) ([]byte, error) {
 
 	ref := orm.VersionedIDRef{ID: encID, Version: version}
 
-	return orm.MarshalVersionedID(ref, true), nil
+	if ref.Version == 0 {
+		return ref.ID, nil
+	}
+
+	return orm.MarshalVersionedID(ref), nil
 }
 
 func addressID(s string) ([]byte, error) {

--- a/orm/versioning_bucket.go
+++ b/orm/versioning_bucket.go
@@ -227,6 +227,10 @@ func (m marker) Equal(o []byte) bool {
 	return bytes.Equal(m, o)
 }
 
+// MarshalVersionedID is used to guarantee determinism while serializing a VersionedIDRef.
+// It comes with the option to omit empty version should you want to do a prefix query.
+// This flag should be set to false when writing to the underlying storage as we depend
+// on the fact that last 4 bytes of the IDRef are used for version in UnmarshalVersionedID.
 func MarshalVersionedID(key VersionedIDRef, omitEmptyVersion bool) []byte {
 	res := make([]byte, 0, len(key.ID)+versionMaxBytes)
 
@@ -243,6 +247,8 @@ func MarshalVersionedID(key VersionedIDRef, omitEmptyVersion bool) []byte {
 	return res
 }
 
+// UnmarshalVersionedID is used to deserialize a VersionedIDRef from a deterministic format.
+// It expects version to be stored in the last 4 bytes of the passed slice.
 func UnmarshalVersionedID(b []byte) (VersionedIDRef, error) {
 	// Sanity-check this value to be greater than just version.
 	if len(b) < 5 {

--- a/orm/versioning_bucket.go
+++ b/orm/versioning_bucket.go
@@ -8,6 +8,8 @@ import (
 	"github.com/iov-one/weave/errors"
 )
 
+const versionMaxBytes = 4
+
 type VersioningBucket struct {
 	IDGenBucket
 }
@@ -226,10 +228,10 @@ func (m marker) Equal(o []byte) bool {
 }
 
 func MarshalVersionedID(key VersionedIDRef) []byte {
-	res := make([]byte, 0, len(key.ID)+4)
+	res := make([]byte, 0, len(key.ID)+versionMaxBytes)
 
 	res = append(res, key.ID...)
-	buf := make([]byte, 4)
+	buf := make([]byte, versionMaxBytes)
 	binary.BigEndian.PutUint32(buf, key.Version)
 	res = append(res, buf...)
 
@@ -242,8 +244,8 @@ func UnmarshalVersionedID(b []byte) (VersionedIDRef, error) {
 		return VersionedIDRef{}, errors.Wrap(errors.ErrState, "versioned id too small")
 	}
 
-	id := b[0 : len(b)-4]
-	version := b[len(b)-4:]
+	id := b[0 : len(b)-versionMaxBytes]
+	version := b[len(b)-versionMaxBytes:]
 
 	return VersionedIDRef{
 		ID:      id,

--- a/orm/versioning_bucket.go
+++ b/orm/versioning_bucket.go
@@ -8,7 +8,7 @@ import (
 	"github.com/iov-one/weave/errors"
 )
 
-const versionMaxBytes = 4
+const versionSize = 4
 
 type VersioningBucket struct {
 	IDGenBucket
@@ -232,7 +232,7 @@ func (m marker) Equal(o []byte) bool {
 // This flag should be set to false when writing to the underlying storage as we depend
 // on the fact that last 4 bytes of the IDRef are used for version in UnmarshalVersionedID.
 func MarshalVersionedID(key VersionedIDRef, omitEmptyVersion bool) []byte {
-	res := make([]byte, 0, len(key.ID)+versionMaxBytes)
+	res := make([]byte, 0, len(key.ID)+versionSize)
 
 	res = append(res, key.ID...)
 
@@ -240,7 +240,7 @@ func MarshalVersionedID(key VersionedIDRef, omitEmptyVersion bool) []byte {
 		return res
 	}
 
-	buf := make([]byte, versionMaxBytes)
+	buf := make([]byte, versionSize)
 	binary.BigEndian.PutUint32(buf, key.Version)
 	res = append(res, buf...)
 
@@ -255,8 +255,8 @@ func UnmarshalVersionedID(b []byte) (VersionedIDRef, error) {
 		return VersionedIDRef{}, errors.Wrap(errors.ErrState, "versioned id too small")
 	}
 
-	id := b[0 : len(b)-versionMaxBytes]
-	version := b[len(b)-versionMaxBytes:]
+	id := b[0 : len(b)-versionSize]
+	version := b[len(b)-versionSize:]
 
 	return VersionedIDRef{
 		ID:      id,

--- a/orm/versioning_bucket.go
+++ b/orm/versioning_bucket.go
@@ -2,6 +2,7 @@ package orm
 
 import (
 	"bytes"
+	"encoding/binary"
 
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
@@ -37,11 +38,7 @@ func WithVersioning(b IDGenBucket) VersioningBucket {
 //  - ErrDeleted when deleted
 // Object won't be nil in success case
 func (b VersioningBucket) GetLatestVersion(db weave.ReadOnlyKVStore, id []byte) (*VersionedIDRef, Object, error) {
-	idWithoutVersion := VersionedIDRef{ID: id}
-	prefix, err := idWithoutVersion.Marshal()
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to marshal versioned ID ref")
-	}
+	prefix := id
 	dbKeyLength := len(b.DBKey(prefix)) - len(prefix)
 	matches, err := b.Query(db, weave.PrefixQueryMod, prefix)
 	if err != nil {
@@ -51,9 +48,9 @@ func (b VersioningBucket) GetLatestVersion(db weave.ReadOnlyKVStore, id []byte) 
 	var highestVersion VersionedIDRef
 	var found weave.Model
 	for _, m := range matches {
-		var vID VersionedIDRef
 		idData := m.Key[dbKeyLength:]
-		if err := vID.Unmarshal(idData); err != nil {
+		vID, err := UnmarshalVersionedID(idData)
+		if err != nil {
 			return nil, nil, errors.Wrap(err, "wrong key type")
 		}
 		if vID.Version > highestVersion.Version {
@@ -100,10 +97,7 @@ func (b VersioningBucket) Get(db weave.ReadOnlyKVStore, key []byte) (Object, err
 // Object won't be nil in success case
 
 func (b VersioningBucket) GetVersion(db weave.ReadOnlyKVStore, ref VersionedIDRef) (Object, error) {
-	key, err := ref.Marshal()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal version id key")
-	}
+	key := MarshalVersionedID(ref)
 	return b.Get(db, key)
 }
 
@@ -174,10 +168,7 @@ func (b VersioningBucket) Update(db weave.KVStore, id []byte, data versionedData
 
 // safeUpdate expects all validations have happened before
 func (b VersioningBucket) safeUpdate(db weave.KVStore, newVersionKey VersionedIDRef, data CloneableData) (*VersionedIDRef, error) {
-	key, err := newVersionKey.Marshal()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshall versioned id ref")
-	}
+	key := MarshalVersionedID(newVersionKey)
 	// store new version
 	return &newVersionKey, b.Bucket.Save(db, NewSimpleObj(key, data))
 }
@@ -232,4 +223,30 @@ func (marker) Copy() CloneableData {
 
 func (m marker) Equal(o []byte) bool {
 	return bytes.Equal(m, o)
+}
+
+func MarshalVersionedID(key VersionedIDRef) []byte {
+	res := make([]byte, 0, len(key.ID)+4)
+
+	res = append(res, key.ID...)
+	buf := make([]byte, 4)
+	binary.BigEndian.PutUint32(buf, key.Version)
+	res = append(res, buf...)
+
+	return res
+}
+
+func UnmarshalVersionedID(b []byte) (VersionedIDRef, error) {
+	// Sanity-check this value to be greater than just version.
+	if len(b) < 5 {
+		return VersionedIDRef{}, errors.Wrap(errors.ErrState, "versioned id too small")
+	}
+
+	id := b[0 : len(b)-4]
+	version := b[len(b)-4:]
+
+	return VersionedIDRef{
+		ID:      id,
+		Version: binary.BigEndian.Uint32(version),
+	}, nil
 }

--- a/orm/versioning_bucket_test.go
+++ b/orm/versioning_bucket_test.go
@@ -10,7 +10,37 @@ import (
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/weavetest"
+	"github.com/iov-one/weave/weavetest/assert"
 )
+
+func TesVersionedIDSerialization(t *testing.T) {
+	specs := map[string]struct {
+		src    *VersionedIDRef
+		expErr *errors.Error
+	}{
+		"With zero version": {
+			src: &VersionedIDRef{ID: []byte("anyValue")},
+		},
+		"Version set": {
+			src: &VersionedIDRef{ID: []byte("anyValue"), Version: 2},
+		},
+		"Empty ID": {
+			src:    &VersionedIDRef{ID: nil, Version: 2},
+			expErr: errors.ErrState,
+		},
+	}
+
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			res := MarshalVersionedID(*spec.src)
+			resRef, err := UnmarshalVersionedID(res)
+			assert.IsErr(t, spec.expErr, err)
+			if spec.expErr == nil {
+				assert.Equal(t, *spec.src, resRef)
+			}
+		})
+	}
+}
 
 func TestGetLatestVersion(t *testing.T) {
 	bucketImpl := NewBucket("any", NewSimpleObj(nil, &VersionedIDRef{}))

--- a/x/gov/bucket_test.go
+++ b/x/gov/bucket_test.go
@@ -171,17 +171,17 @@ func TestQueryElectorate(t *testing.T) {
 	}{
 		"By ID and first version": {
 			path: "/electorates",
-			data: orm.MarshalVersionedID(*vRefV1),
+			data: orm.MarshalVersionedID(*vRefV1, false),
 			exp:  []Electorate{electorateV1},
 		},
 		"By ID and second version": {
 			path: "/electorates",
-			data: orm.MarshalVersionedID(*vRefV2),
+			data: orm.MarshalVersionedID(*vRefV2, false),
 			exp:  []Electorate{electorateV2},
 		},
 		"By ID and unknown version": {
 			path: "/electorates",
-			data: orm.MarshalVersionedID(orm.VersionedIDRef{ID: vRefV1.ID, Version: 99}),
+			data: orm.MarshalVersionedID(orm.VersionedIDRef{ID: vRefV1.ID, Version: 99}, false),
 		},
 		"By prefix query and ID": {
 			path:      "/electorates",
@@ -191,11 +191,11 @@ func TestQueryElectorate(t *testing.T) {
 		},
 		"By unknown ID": {
 			path: "/electorates",
-			data: orm.MarshalVersionedID(orm.VersionedIDRef{ID: []byte{0x1}, Version: 1}),
+			data: orm.MarshalVersionedID(orm.VersionedIDRef{ID: []byte{0x1}, Version: 1}, false),
 		},
 		"By unknown key": {
 			path: "/electorates",
-			data: []byte{0x1},
+			data: orm.MarshalVersionedID(orm.VersionedIDRef{ID: []byte{0x1}}, true),
 		},
 	}
 

--- a/x/gov/bucket_test.go
+++ b/x/gov/bucket_test.go
@@ -171,27 +171,27 @@ func TestQueryElectorate(t *testing.T) {
 	}{
 		"By ID and first version": {
 			path: "/electorates",
-			data: mustMarshal(t, vRefV1),
+			data: orm.MarshalVersionedID(*vRefV1),
 			exp:  []Electorate{electorateV1},
 		},
 		"By ID and second version": {
 			path: "/electorates",
-			data: mustMarshal(t, vRefV2),
+			data: orm.MarshalVersionedID(*vRefV2),
 			exp:  []Electorate{electorateV2},
 		},
 		"By ID and unknown version": {
 			path: "/electorates",
-			data: mustMarshal(t, &orm.VersionedIDRef{ID: vRefV1.ID, Version: 99}),
+			data: orm.MarshalVersionedID(orm.VersionedIDRef{ID: vRefV1.ID, Version: 99}),
 		},
 		"By prefix query and ID": {
 			path:      "/electorates",
 			queryMode: weave.PrefixQueryMod,
-			data:      mustMarshal(t, &orm.VersionedIDRef{ID: vRefV1.ID}),
+			data:      vRefV1.ID,
 			exp:       []Electorate{electorateV1, electorateV2},
 		},
 		"By unknown ID": {
 			path: "/electorates",
-			data: mustMarshal(t, &orm.VersionedIDRef{ID: []byte{0x1}, Version: 1}),
+			data: orm.MarshalVersionedID(orm.VersionedIDRef{ID: []byte{0x1}, Version: 1}),
 		},
 		"By unknown key": {
 			path: "/electorates",

--- a/x/gov/bucket_test.go
+++ b/x/gov/bucket_test.go
@@ -171,17 +171,17 @@ func TestQueryElectorate(t *testing.T) {
 	}{
 		"By ID and first version": {
 			path: "/electorates",
-			data: orm.MarshalVersionedID(*vRefV1, false),
+			data: orm.MarshalVersionedID(*vRefV1),
 			exp:  []Electorate{electorateV1},
 		},
 		"By ID and second version": {
 			path: "/electorates",
-			data: orm.MarshalVersionedID(*vRefV2, false),
+			data: orm.MarshalVersionedID(*vRefV2),
 			exp:  []Electorate{electorateV2},
 		},
 		"By ID and unknown version": {
 			path: "/electorates",
-			data: orm.MarshalVersionedID(orm.VersionedIDRef{ID: vRefV1.ID, Version: 99}, false),
+			data: orm.MarshalVersionedID(orm.VersionedIDRef{ID: vRefV1.ID, Version: 99}),
 		},
 		"By prefix query and ID": {
 			path:      "/electorates",
@@ -191,11 +191,11 @@ func TestQueryElectorate(t *testing.T) {
 		},
 		"By unknown ID": {
 			path: "/electorates",
-			data: orm.MarshalVersionedID(orm.VersionedIDRef{ID: []byte{0x1}, Version: 1}, false),
+			data: orm.MarshalVersionedID(orm.VersionedIDRef{ID: []byte{0x1}, Version: 1}),
 		},
 		"By unknown key": {
 			path: "/electorates",
-			data: orm.MarshalVersionedID(orm.VersionedIDRef{ID: []byte{0x1}}, true),
+			data: []byte{0x1},
 		},
 	}
 


### PR DESCRIPTION
Fixes #918 

You will notice that prefix queries should be done by id alone, because there is no way we can consistently deserialise if we ignore `Version` when it is zero.

This also needs bnscli changes, but first I'd like to validate the approach.