### PR TITLE
Set git hash length explicitely for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
     - MAIN_GO_VERSION=1.12
     - GORACE="halt_on_error=1"
     - FORCE_TM_TEST=1
-    - VERSION=$(git describe --tags | sed 's/^v//')
+    - VERSION=$(git describe --tags --abbrev=9 | sed 's/^v//')
     - COMMIT=$(git log -1 --format='%H')
     - IMAGE_NAME="iov1/bnsd:${BUILD_VERSION}"
 
@@ -48,7 +48,7 @@ install:
   cd -;
 
 script:
-- set -o pipefail
+- set -eo pipefail
 - make protolint;
 - make protodocs;
 - make install;

--- a/contrib/gitian-descriptors/bns-linux.yml
+++ b/contrib/gitian-descriptors/bns-linux.yml
@@ -53,7 +53,7 @@ script: |
 
   # Make release tarball
   pushd weave
-  VERSION=$(git describe --tags | sed 's/^v//')
+  VERSION=$(git describe --tags --abbrev=9 | sed 's/^v//')
   COMMIT=$(git log -1 --format='%H')
   DISTNAME=bnsd-${VERSION}
   git archive --format tar.gz --prefix ${DISTNAME}/ -o ${DISTNAME}.tar.gz HEAD


### PR DESCRIPTION
> Instead of using the default 7 hexadecimal digits as the abbreviated object name, use <n> digits, or as many digits as needed to form a unique object name

https://git-scm.com/docs/git-describe#Documentation/git-describe.txt---abbrevltngt