### PR TITLE
Rollback travis CI to Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 
 language: go
 
-dist: bionic
+dist: xenial
 
 services:
 - docker

--- a/orm/versioning_bucket_test.go
+++ b/orm/versioning_bucket_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/iov-one/weave/weavetest/assert"
 )
 
-func TesVersionedIDSerialization(t *testing.T) {
+func TestVersionedIDSerialization(t *testing.T) {
 	specs := map[string]struct {
 		src    *VersionedIDRef
 		expErr *errors.Error


### PR DESCRIPTION
    rollback travis VM to Ubuntu 16.04
    
    Using Ubuntu 18.04 does not pass the bnscli tests. For some reason,
    client is not able to connect to a tendermint server running on
    localhost:4444.


!nochangelog