### PR TITLE
bnscli: support for more queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ when parsing large json objects.
   returned response data and print it in a human readable format.
 - `clean_protos.sh` appends `option go_package = "github.com/iov-one/weave";`
   to prevent protoc error in weave based frameworks
+- `cmd/bnscli` support for more query endpoints
+
 Breaking changes
 
 - `cmd/bnscli`: `keygen` command was updated and requires a mnemonic to

--- a/cmd/bnscli/cmd_query.go
+++ b/cmd/bnscli/cmd_query.go
@@ -18,7 +18,10 @@ import (
 	"github.com/iov-one/weave/cmd/bnsd/x/username"
 	"github.com/iov-one/weave/orm"
 	"github.com/iov-one/weave/x/cash"
+	"github.com/iov-one/weave/x/distribution"
+	"github.com/iov-one/weave/x/escrow"
 	"github.com/iov-one/weave/x/gov"
+	"github.com/iov-one/weave/x/multisig"
 )
 
 func cmdQuery(input io.Reader, output io.Writer, args []string) error {
@@ -163,6 +166,21 @@ var queries = map[string]struct {
 		newObj: func() model { return &cash.Set{} },
 		decKey: rawKey,
 		encID:  addressID,
+	},
+	"/escrows": {
+		newObj: func() model { return &escrow.Escrow{} },
+		decKey: sequenceKey,
+		encID:  numericID,
+	},
+	"/revenues": {
+		newObj: func() model { return &distribution.Revenue{} },
+		decKey: sequenceKey,
+		encID:  numericID,
+	},
+	"/contracts": {
+		newObj: func() model { return &multisig.Contract{} },
+		decKey: sequenceKey,
+		encID:  numericID,
 	},
 }
 


### PR DESCRIPTION
Query support in `bnscli` was extended. New supported endpoints are
- `/escrows`
- `/revenues`
- `/contracts`

fix #925