### PR TITLE
bnsd/x/username: update username validation rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Breaking changes
   generate a key.
 - `orm`: `VersionedIDRef` is now de/serialized by appending BigEndian ID and BigEndian Version
 - `cmd/bnscli`: now expects VersionedIDRef to be serialised using the new format
+- `bnsd/x/username`: username validation rules were updated to be more
+  restrictive.
 
 
 ## 0.20.0

--- a/cmd/bnsd/x/username/username.go
+++ b/cmd/bnsd/x/username/username.go
@@ -67,7 +67,7 @@ func (u Username) Validate() error {
 }
 
 var (
-	validName = regexp.MustCompile(`^[a-z0-9\-\._]{0,64}$`).MatchString
+	validName = regexp.MustCompile(`^[a-z0-9\-._]{0,64}$`).MatchString
 	// Currently only IOV namespace is supported. This is a public
 	// namespace that anyone can register in an IOV owns. This limitation
 	// exists because for the MVP release we do not provide a way to

--- a/cmd/bnsd/x/username/username_test.go
+++ b/cmd/bnsd/x/username/username_test.go
@@ -20,8 +20,8 @@ func TestUsername(t *testing.T) {
 			WantDomain: "iov",
 		},
 		"shortest valid name and domain": {
-			Raw:        strings.Repeat("x", 4) + "*iov",
-			WantName:   strings.Repeat("x", 4),
+			Raw:        "*iov",
+			WantName:   "",
 			WantDomain: "iov",
 		},
 		"longest valid name and domain": {
@@ -30,27 +30,15 @@ func TestUsername(t *testing.T) {
 			WantDomain: "iov",
 		},
 		"too long name": {
-			Raw:        strings.Repeat("x", 65) + "*" + strings.Repeat("x", 6),
+			Raw:        strings.Repeat("x", 65) + "*iov",
 			WantName:   strings.Repeat("x", 65),
-			WantDomain: strings.Repeat("x", 6),
+			WantDomain: "iov",
 			WantErr:    errors.ErrInput,
 		},
-		"too long domain": {
-			Raw:        strings.Repeat("x", 8) + "*" + strings.Repeat("x", 17),
-			WantName:   strings.Repeat("x", 8),
-			WantDomain: strings.Repeat("x", 17),
-			WantErr:    errors.ErrInput,
-		},
-		"too short name": {
-			Raw:        strings.Repeat("x", 3) + "*" + strings.Repeat("x", 6),
-			WantName:   strings.Repeat("x", 3),
-			WantDomain: strings.Repeat("x", 6),
-			WantErr:    errors.ErrInput,
-		},
-		"too short domain": {
-			Raw:        strings.Repeat("x", 8) + "*" + strings.Repeat("x", 2),
-			WantName:   strings.Repeat("x", 8),
-			WantDomain: strings.Repeat("x", 2),
+		"all valid characters in name": {
+			Raw:        `abcdefghijklmnopqrstuvwxyz 0123456789.-_*iov`,
+			WantName:   `abcdefghijklmnopqrstuvwxyz 0123456789.-_`,
+			WantDomain: "iov",
 			WantErr:    errors.ErrInput,
 		},
 		"missing domain": {
@@ -59,12 +47,6 @@ func TestUsername(t *testing.T) {
 			WantName:   "foo",
 			WantDomain: "",
 		},
-		"missing name": {
-			Raw:        "*iov",
-			WantErr:    errors.ErrInput,
-			WantName:   "",
-			WantDomain: "iov",
-		},
 		"missing separator": {
 			Raw:        "xyz",
 			WantErr:    errors.ErrInput,
@@ -72,12 +54,12 @@ func TestUsername(t *testing.T) {
 			WantDomain: "",
 		},
 		"invalid characters (emoji)": {
-			Raw:        "😈*😀",
+			Raw:        "😈*iov",
 			WantErr:    errors.ErrInput,
 			WantName:   "😈",
-			WantDomain: "😀",
+			WantDomain: "iov",
 		},
-		"invalid domain name": {
+		"invalid domain name (only iov is allowed)": {
 			Raw:        "extreme*expert",
 			WantErr:    errors.ErrInput,
 			WantName:   "extreme",

--- a/cmd/bnsd/x/username/username_test.go
+++ b/cmd/bnsd/x/username/username_test.go
@@ -30,40 +30,37 @@ func TestUsername(t *testing.T) {
 			WantDomain: "iov",
 		},
 		"too long name": {
-			Raw:        strings.Repeat("x", 65) + "*iov",
-			WantName:   strings.Repeat("x", 65),
-			WantDomain: "iov",
-			WantErr:    errors.ErrInput,
+			Raw:     strings.Repeat("x", 65) + "*iov",
+			WantErr: errors.ErrInput,
+		},
+		"space is not an allowed character": {
+			Raw:     `foo bar*iov`,
+			WantErr: errors.ErrInput,
 		},
 		"all valid characters in name": {
-			Raw:        `abcdefghijklmnopqrstuvwxyz 0123456789.-_*iov`,
-			WantName:   `abcdefghijklmnopqrstuvwxyz 0123456789.-_`,
+			Raw:        `abcdefghijklmnopqrstuvwxyz0123456789.-_*iov`,
+			WantName:   `abcdefghijklmnopqrstuvwxyz0123456789.-_`,
 			WantDomain: "iov",
-			WantErr:    errors.ErrInput,
+		},
+		"double separator": {
+			Raw:     "foo*bar*iov",
+			WantErr: errors.ErrInput,
 		},
 		"missing domain": {
-			Raw:        "foo*",
-			WantErr:    errors.ErrInput,
-			WantName:   "foo",
-			WantDomain: "",
+			Raw:     "foo*",
+			WantErr: errors.ErrInput,
 		},
 		"missing separator": {
-			Raw:        "xyz",
-			WantErr:    errors.ErrInput,
-			WantName:   "",
-			WantDomain: "",
+			Raw:     "xyz",
+			WantErr: errors.ErrInput,
 		},
 		"invalid characters (emoji)": {
-			Raw:        "😈*iov",
-			WantErr:    errors.ErrInput,
-			WantName:   "😈",
-			WantDomain: "iov",
+			Raw:     "😈*iov",
+			WantErr: errors.ErrInput,
 		},
 		"invalid domain name (only iov is allowed)": {
-			Raw:        "extreme*expert",
-			WantErr:    errors.ErrInput,
-			WantName:   "extreme",
-			WantDomain: "expert",
+			Raw:     "extreme*expert",
+			WantErr: errors.ErrInput,
 		},
 	}
 
@@ -72,6 +69,12 @@ func TestUsername(t *testing.T) {
 			u, err := ParseUsername(tc.Raw)
 			if !tc.WantErr.Is(err) {
 				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.WantErr != nil {
+				// Cut short the test because the returned
+				// username is not valid and therefore
+				// undefined.
+				return
 			}
 
 			if n := u.Name(); n != tc.WantName {


### PR DESCRIPTION
The bnsd username implelementation has now an updated validation rules:
- A namespace must be iov
- A name must be between 0 and not longer than 64 characters
- A name must consist of only the following ASCII characters
  - letters abcdefghijklmnopqrstuvwxyz
  - digits 0123456789
  - special characters -._

**Please double check the validation rules, because I have updated rules for both user name and namespace label (i.e. removed `@` character)**
- [user name](https://github.com/iov-one/weave/pull/975/files#diff-369e9fa1b1f9d72f6f9c8b3635820af7R70)
- [namespace label](https://github.com/iov-one/weave/pull/975/files#diff-369e9fa1b1f9d72f6f9c8b3635820af7R75)


resolve #952