### PR TITLE
orm: add ValidateSequence

### DIFF
--- a/orm/idgen_bucket.go
+++ b/orm/idgen_bucket.go
@@ -49,3 +49,15 @@ type IDGeneratorFunc func(db weave.KVStore, obj CloneableData) ([]byte, error)
 func (i IDGeneratorFunc) NextVal(db weave.KVStore, obj CloneableData) ([]byte, error) {
 	return i(db, obj)
 }
+
+// ValidateSequence returns an error if this is not an 8-byte
+// as expected for orm.IDGenBucket
+func ValidateSequence(id []byte) error {
+	if len(id) == 0 {
+		return errors.Wrap(errors.ErrEmpty, "sequence missing")
+	}
+	if len(id) != 8 {
+		return errors.Wrap(errors.ErrInput, "sequence is invalid length (expect 8 bytes)")
+	}
+	return nil
+}

--- a/orm/idgen_bucket_test.go
+++ b/orm/idgen_bucket_test.go
@@ -64,3 +64,35 @@ func TestIDGenBucket(t *testing.T) {
 	}
 
 }
+
+func TestValidateSequence(t *testing.T) {
+	cases := map[string]struct {
+		bytes   []byte
+		wantErr *errors.Error
+	}{
+		"success": {
+			bytes:   []byte{0, 1, 2, 3, 4, 5, 6, 7},
+			wantErr: nil,
+		},
+		"failure missing": {
+			bytes:   nil,
+			wantErr: errors.ErrEmpty,
+		},
+		"failure invalid length": {
+			bytes:   []byte{0, 1},
+			wantErr: errors.ErrInput,
+		},
+	}
+
+	for testName, tc := range cases {
+		t.Run(testName, func(t *testing.T) {
+			err := ValidateSequence(tc.bytes)
+			if !tc.wantErr.Is(err) {
+				t.Fatalf("unexpected error: %+v", err)
+			}
+			if tc.wantErr != nil {
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
On https://github.com/iov-one/tutorial/blob/master/x/orderbook/msg.go#L94-L104 and starter kit will use `validateID` so I thought maybe It would be good to have this helper since weave based apps might need this method. If you think `ValidateSequence` method belongs to somewhere else rather than `orm` package please let me know where to put 👀 

!nochangelog