### PR TITLE
cmd/bnsd/client: rename ParseBcpTx to ParseBnsdTx

### DIFF
--- a/cmd/bnsd/client/tx.go
+++ b/cmd/bnsd/client/tx.go
@@ -41,8 +41,8 @@ func SignTx(tx *bnsd.Tx, signer *PrivateKey, chainID string, nonce int64) error 
 	return nil
 }
 
-// ParseBcpTx will load a serialize tx into a format we can read
-func ParseBcpTx(data []byte) (*bnsd.Tx, error) {
+// ParseBnsdTx will load a serialize tx into a format we can read
+func ParseBnsdTx(data []byte) (*bnsd.Tx, error) {
 	var tx bnsd.Tx
 	err := tx.Unmarshal(data)
 	if err != nil {

--- a/cmd/bnsd/client/tx.go
+++ b/cmd/bnsd/client/tx.go
@@ -41,8 +41,8 @@ func SignTx(tx *bnsd.Tx, signer *PrivateKey, chainID string, nonce int64) error 
 	return nil
 }
 
-// ParseBnsdTx will load a serialize tx into a format we can read
-func ParseBnsdTx(data []byte) (*bnsd.Tx, error) {
+// ParseBnsTx will load a serialize tx into a format we can read
+func ParseBnsTx(data []byte) (*bnsd.Tx, error) {
 	var tx bnsd.Tx
 	err := tx.Unmarshal(data)
 	if err != nil {

--- a/cmd/bnsd/client/tx_test.go
+++ b/cmd/bnsd/client/tx_test.go
@@ -41,7 +41,7 @@ func TestSendTx(t *testing.T) {
 	// parse tx and verify we have the proper fields
 	data, err := tx.Marshal()
 	assert.Nil(t, err)
-	parsed, err := ParseBcpTx(data)
+	parsed, err := ParseBnsdTx(data)
 	assert.Nil(t, err)
 	msg, err := parsed.GetMsg()
 	assert.Nil(t, err)

--- a/cmd/bnsd/client/tx_test.go
+++ b/cmd/bnsd/client/tx_test.go
@@ -41,7 +41,7 @@ func TestSendTx(t *testing.T) {
 	// parse tx and verify we have the proper fields
 	data, err := tx.Marshal()
 	assert.Nil(t, err)
-	parsed, err := ParseBnsdTx(data)
+	parsed, err := ParseBnsTx(data)
 	assert.Nil(t, err)
 	msg, err := parsed.GetMsg()
 	assert.Nil(t, err)


### PR DESCRIPTION
When looking through client code I noticed this `ParseBcpTx`. This module was removed on _v0.17.0_. So I thought maybe rename this to `ParseBnsdTx` for convenience? Maybe remove this function, I can't see its use anywhere.

!nochangelog
