### PR TITLE
tmtest: refactor RunBnsd method to be generic

### DIFF
--- a/cmd/bnscli/main_test.go
+++ b/cmd/bnscli/main_test.go
@@ -19,6 +19,9 @@ const privKeyHex = "d34c1970ae90acf3405f2d99dcaca16d0c7db379f4beafcfdf667b9d69ce
 // addr is the hex address of the account that corresponds to privKeyHex
 const addr = "E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0"
 
+// appName is the name of the application
+const appName = "bnsd"
+
 func TestMain(m *testing.M) {
 	code := runTestMain(m)
 	os.Exit(code)
@@ -34,7 +37,7 @@ func runTestMain(m *testing.M) int {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	tmtest.RunBnsd(ctx, t, home)
+	tmtest.RunApp(ctx, t, appName, home)
 	tmtest.RunTendermint(ctx, t, home)
 
 	return m.Run()
@@ -61,7 +64,7 @@ func (mockAsserter) Logf(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 	fmt.Println("")
 }
-func (m mockAsserter) Skip(args ...interface{}) {
-	m.Log(args...)
+func (m mockAsserter) Skipf(format string, args ...interface{}) {
+	m.Logf(format, args...)
 	os.Exit(0)
 }

--- a/cmd/bnscli/main_test.go
+++ b/cmd/bnscli/main_test.go
@@ -64,6 +64,10 @@ func (mockAsserter) Logf(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 	fmt.Println("")
 }
+func (m mockAsserter) Skip(args ...interface{}) {
+	m.Log(args...)
+	os.Exit(0)
+}
 func (m mockAsserter) Skipf(format string, args ...interface{}) {
 	m.Logf(format, args...)
 	os.Exit(0)

--- a/tmtest/tmtest.go
+++ b/tmtest/tmtest.go
@@ -21,6 +21,7 @@ import (
 // TestReporter is the minimal subset of testing.TB needed to run these test helpers
 type TestReporter interface {
 	assert.Tester
+	Skip(...interface{})
 	Skipf(string, ...interface{})
 	Logf(string, ...interface{})
 }
@@ -38,7 +39,7 @@ func RunTendermint(ctx context.Context, t TestReporter, home string) (cleanup fu
 	tmpath, err := exec.LookPath("tendermint")
 	if err != nil {
 		if os.Getenv("FORCE_TM_TEST") != "1" {
-			t.Skipf("Tendermint binary not found. Set FORCE_TM_TEST=1 to fail this test.")
+			t.Skip("Tendermint binary not found. Set FORCE_TM_TEST=1 to fail this test.")
 		} else {
 			t.Fatalf("Tendermint binary not found. Do not set FORCE_TM_TEST=1 to skip this test.")
 		}
@@ -87,7 +88,7 @@ func RunTendermint(ctx context.Context, t TestReporter, home string) (cleanup fu
 }
 
 // RunApp is like RunTendermint, just executes the application executable, assuming a prepared home directory
-func RunApp(ctx context.Context, t TestReporter, appName string, home string) (cleanup func()) {
+func RunApp(ctx context.Context, t TestReporter, appName, home string) (cleanup func()) {
 	t.Helper()
 
 	appPath, err := exec.LookPath(appName)


### PR DESCRIPTION
While I was working on `customcli` in weave-starter-kit, I noticed `main_test.go` depends on `RunBnsd` method which is not generic at all. I refactored it to be easily used by weave based projects.

!nochangelog