### PR TITLE
Handle submission error in bnscli

### DIFF
--- a/cmd/bnscli/cmd_submit.go
+++ b/cmd/bnscli/cmd_submit.go
@@ -43,7 +43,7 @@ Make sure to collect enough signatures before submitting the transaction.
 	bnsClient := client.NewClient(client.NewHTTPConnection(*tmAddrFl))
 
 	resp := bnsClient.BroadcastTx(tx)
-	if resp.IsError(); err != nil {
+	if err := resp.IsError(); err != nil {
 		return fmt.Errorf("cannot broadcast transaction: %s", err)
 	}
 


### PR DESCRIPTION
Any submission error is currently ignored and we see instead:
```
response: %!q(<nil>)cannot extract response: cannot format #0 result data : cannot parse sequence: sequence must be 8 bytes: ""
``` 

!nochangelog