### PR TITLE
x/msgfee: add message to change the message fee value

### DIFF
--- a/cmd/bnscli/main_test.go
+++ b/cmd/bnscli/main_test.go
@@ -37,8 +37,11 @@ func runTestMain(m *testing.M) int {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	tmtest.RunApp(ctx, t, appName, home)
-	tmtest.RunTendermint(ctx, t, home)
+	appCleanup := tmtest.RunApp(ctx, t, appName, home)
+	tmCleanup := tmtest.RunTendermint(ctx, t, home)
+
+	defer appCleanup()
+	defer tmCleanup()
 
 	return m.Run()
 }

--- a/cmd/bnscli/testdata/config/genesis.json
+++ b/cmd/bnscli/testdata/config/genesis.json
@@ -29,6 +29,10 @@
         "collector_address": "seq:dist/revenue/1",
         "minimal_fee": "0.1 IOV"
       },
+      "msgfee": {
+        "owner": "E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0",
+        "fee_admin": "E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0"
+      },
       "migration": {
         "admin": "E28AE9A6EB94FC88B73EB7CBD6B87BF93EB9BEF0"
       },

--- a/tmtest/tmtest.go
+++ b/tmtest/tmtest.go
@@ -76,14 +76,6 @@ func RunTendermint(ctx context.Context, t TestReporter, home string) (cleanup fu
 		<-done
 	}
 
-	go func() {
-		select {
-		case <-ctx.Done():
-			cleanup()
-		case <-done:
-		}
-	}()
-
 	return cleanup
 }
 
@@ -121,10 +113,7 @@ func RunApp(ctx context.Context, t TestReporter, appName, home string) (cleanup 
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
 	}
-	go func() {
-		<-ctx.Done()
-		cleanup()
-	}()
+
 	return cleanup
 }
 


### PR DESCRIPTION
`x/msgfee` was extended to provide a message to set a fee for a given
message path. Use zero value amount to delete a fee. Transaction for
setting a message fee must be signed by the fee administrator.
Fee administrator is set in the `x/msgfee` configuration, using gconf
and should be initialized with the genesis file.

The messsage fee setting message was added to `bnsd` and `bnscli`.