### PR TITLE
add script to cache docker images on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ cache:
     - $HOME/gopath/pkg/mod
     - $TRAVIS_BUILD_DIR/.gitian-builder-cache
     - /var/cache/apt-cacher-ng
+    - $HOME/docker
+    
+before_cache:
+  # Save tagged docker images
+  - mkdir -p $HOME/docker && docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}' | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker/$1.tar.gz'
 
 os:
 - linux
@@ -39,6 +44,10 @@ env:
     - VERSION=$(git describe --tags --abbrev=9 | sed 's/^v//')
     - COMMIT=$(git log -1 --format='%H')
     - IMAGE_NAME="iov1/bnsd:${BUILD_VERSION}"
+
+before_install:
+  # Load cached docker images
+  - if [[ -d $HOME/docker ]]; then ls $HOME/docker/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load"; fi
 
 install:
 - go get -d github.com/tendermint/tendermint/... ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
     - $TRAVIS_BUILD_DIR/.gitian-builder-cache
     - /var/cache/apt-cacher-ng
     - $HOME/docker
-    
+
 before_cache:
   # Save tagged docker images
   - mkdir -p $HOME/docker && docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}' | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker/$1.tar.gz'
@@ -32,7 +32,6 @@ go:
 # reason for bumping 1.11.x to 1.11.4+ is this: https://github.com/golang/go/issues/30446#issuecomment-468038052
 - "1.11.4"
 - "1.12"
-
 
 env:
   global:
@@ -117,4 +116,3 @@ deploy:
   on:
     tags: true
     condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$
-

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,11 @@ TOOLS := cmd/bnsd cmd/bnscli
 # MODE=set just records which lines were hit by one test
 MODE ?= set
 
-# Check if linter exists
-LINT := $(shell command -v golangci-lint 2> /dev/null)
-
 # for dockerized prototool
 USER := $(shell id -u):$(shell id -g)
 DOCKER_BASE := docker run --rm -v $(shell pwd):/work iov1/prototool:v0.2.2
 PROTOTOOL := $(DOCKER_BASE) prototool
 PROTOC := $(DOCKER_BASE) protoc
-
 
 all: test lint
 


### PR DESCRIPTION
On build, travis downloads docker images every time and this slows the build process. After merge, docker images will be cached.

!nochangelog