### PR TITLE
Move compatibilty charts to a new file

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,36 @@
+# Compatibility Charts
+
+| Weave | Tendermint |
+|--------|-----------|
+|v0.20.x | v0.31.5|
+|v0.19.x | v0.31.5|
+|v0.18.x | v0.31.5|
+|v0.17.x | v0.31.5|
+|v0.16.x | v0.31.5|
+|v0.15.x | v0.31.5|
+|v0.14.x | v0.29.1|
+|v0.13.0 | v0.29.1|
+|v0.12.0 | v0.29.1|
+|v0.11.1 | v0.29.1|
+|v0.11.0 | v0.27.4|
+|v0.10.x | v0.27.4|
+|v0.9.3	| v0.25.0|
+
+| Weave | Protobuf compatible to previous version| Comments |
+|--------|--------------------|------------------|
+|v0.20.0 | :heavy_check_mark:| See [CHANGELOG for 0.20.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0200) |
+|v0.19.0 | :x:| See [CHANGELOG for 0.19.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0190) |
+|v0.18.0 | :x:| See [CHANGELOG for 0.18.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0180) |
+|v0.17.0 | :x:| See [CHANGELOG for 0.17.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0170) |
+|v0.16.0 | :x:| See [CHANGELOG for 0.16.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0160) |
+|v0.15.0 | :x:| See [CHANGELOG for 0.15.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0150) |
+|v0.14.0 | :x:| See [CHANGELOG for 0.14.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0140) |
+|v0.13.0 | :x:| Changes in `x/multisig` - signer weights added. |
+|v0.12.1 | :x:| Changes in `x/escrow` - wall clock timeout implemented. |
+|v0.12.0 | :x:| Currency no longer supports supplying SigFigs nor returns them. |
+|v0.11.1 | :heavy_check_mark:| |
+|v0.11.0 | :heavy_check_mark:| |
+|v0.10.2 | :heavy_check_mark:| |
+|v0.10.1 | :x:| |
+|v0.10.0 | :x:| |
+|v0.9.3	| :heavy_check_mark:| |

--- a/README.md
+++ b/README.md
@@ -85,42 +85,9 @@ as well as the documentation on the
 Once it compiles, I highly suggest going through the
 [readthedocs](https://weave.readthedocs.io/en/latest)
 
-## Compatibility Charts
+## Compatibility
 
-| Weave | Tendermint |
-|--------|-----------|
-|v0.20.x | v0.31.5|
-|v0.19.x | v0.31.5|
-|v0.18.x | v0.31.5|
-|v0.17.x | v0.31.5|
-|v0.16.x | v0.31.5|
-|v0.15.x | v0.31.5|
-|v0.14.x | v0.29.1|
-|v0.13.0 | v0.29.1|
-|v0.12.0 | v0.29.1|
-|v0.11.1 | v0.29.1|
-|v0.11.0 | v0.27.4|
-|v0.10.x | v0.27.4|
-|v0.9.3	| v0.25.0|
-
-| Weave | Protobuf compatible to previous version| Comments |
-|--------|--------------------|------------------|
-|v0.20.0 | :heavy_check_mark:| See [CHANGELOG for 0.20.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0200) |
-|v0.19.0 | :x:| See [CHANGELOG for 0.19.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0190) |
-|v0.18.0 | :x:| See [CHANGELOG for 0.18.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0180) |
-|v0.17.0 | :x:| See [CHANGELOG for 0.17.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0170) |
-|v0.16.0 | :x:| See [CHANGELOG for 0.16.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0160) |
-|v0.15.0 | :x:| See [CHANGELOG for 0.15.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0150) |
-|v0.14.0 | :x:| See [CHANGELOG for 0.14.0](https://github.com/iov-one/weave/blob/master/CHANGELOG.md#0140) |
-|v0.13.0 | :x:| Changes in `x/multisig` - signer weights added. |
-|v0.12.1 | :x:| Changes in `x/escrow` - wall clock timeout implemented. |
-|v0.12.0 | :x:| Currency no longer supports supplying SigFigs nor returns them. |
-|v0.11.1 | :heavy_check_mark:| |
-|v0.11.0 | :heavy_check_mark:| |
-|v0.10.2 | :heavy_check_mark:| |
-|v0.10.1 | :x:| |
-|v0.10.0 | :x:| |
-|v0.9.3	| :heavy_check_mark:| |
+Check out [compatibility charts](./COMPATIBILITY.md)
 
 ## Protobuf Documentation
 


### PR DESCRIPTION
I thought compatibility charts filled too much space in the main `README.md` file so moving it to a new file favor repo cosmetics. If you have the same idea press the `approve` button 😄 