### PR TITLE
Let AntispamFeeDecorator handle empty product fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## HEAD
-
+## 0.21.1
+- Let AntispamFeeDecorator handle empty product fee.
 ## 0.21.0
 - `x/batch`: increase maximum number of messages to 15
 - `cmd/bnscli`: a new command `mnemonic` was added for generating a random

--- a/x/msgfee/antispam_fee_decorator.go
+++ b/x/msgfee/antispam_fee_decorator.go
@@ -37,7 +37,8 @@ func (d *AntispamFeeDecorator) Check(ctx weave.Context, store weave.KVStore, tx 
 		return nil, err
 	}
 	if res.RequiredFee.IsZero() {
-		return nil, errors.Wrap(errors.ErrEmpty, "required must not be zero")
+		res.RequiredFee = d.fee
+		return res, nil
 	}
 	if !res.RequiredFee.SameType(d.fee) {
 		return nil, errors.Wrapf(errors.ErrCurrency,

--- a/x/msgfee/antispam_fee_decorator_test.go
+++ b/x/msgfee/antispam_fee_decorator_test.go
@@ -73,6 +73,13 @@ func TestNewAntispamFeeDecorator(t *testing.T) {
 			AntiSpamFee:  coin.NewCoin(0, 1235, "GATO"),
 			WantCheckErr: errors.ErrCurrency,
 		},
+		"Product fee can be empty": {
+			ReqFee:       coin.Coin{},
+			Handler:      &weavetest.Handler{},
+			Tx:           &weavetest.Tx{Msg: &weavetest.Msg{RoutePath: "foo/bar"}},
+			AntiSpamFee:  coin.NewCoin(0, 1, "DOGE"),
+			WantCheckFee: coin.NewCoin(0, 1, "DOGE"),
+		},
 		"deliver err propagates": {
 			ReqFee:         coin.NewCoin(0, 1234, "DOGE"),
 			Handler:        &weavetest.Handler{},


### PR DESCRIPTION
The handlers sets the antispam fee instead of returning an error and rejecting the Tx.

Fixes #1001 