### PR TITLE
Enable travisCI build for release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ notifications:
 branches:
   only:
   - master
-  - launch
+  - /^v[0-9]+\.[0-9]+\.x$/
   - /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 deploy:


### PR DESCRIPTION
Allow CI builds for release branches that follow our tag convention with a `x` wildcard in the end. For example `v0.21.x`.