### PR TITLE
Optimize get latest version

### DIFF
--- a/store.go
+++ b/store.go
@@ -19,7 +19,7 @@ type ReadOnlyKVStore interface {
 	Iterator(start, end []byte) (Iterator, error)
 
 	// ReverseIterator over a domain of keys in descending order. End is exclusive.
-	// Start must be greater than end, or the Iterator is invalid.
+	// Start must be less than end, or the Iterator is invalid.
 	// CONTRACT: No writes may happen within a domain while an iterator exists over it.
 	ReverseIterator(start, end []byte) (Iterator, error)
 }


### PR DESCRIPTION
Previous implementation was fetching all elements of a range under the hood while we only need a single one. No api changes involved.

!nochangelog