### PR TITLE
crypto: fix missing PrivKeyEd25519FromSeed audit vulnurability

### DIFF
--- a/crypto/ed25519_test.go
+++ b/crypto/ed25519_test.go
@@ -70,3 +70,40 @@ func TestEd25519Address(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, read.Condition(), pub.Condition())
 }
+
+func TestPrivKeyEd25519FromSeed(t *testing.T) {
+	cases := map[string]struct {
+		seed     []byte
+		expected []byte
+	}{
+		"success 1": {
+			seed:     []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			expected: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 59, 106, 39, 188, 206, 182, 164, 45, 98, 163, 168, 208, 42, 111, 13, 115, 101, 50, 21, 119, 29, 226, 67, 166, 58, 192, 72, 161, 139, 89, 218, 41},
+		},
+		"success 2": {
+			seed:     []byte{31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31},
+			expected: []byte{31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 67, 4, 107, 254, 64, 146, 179, 233, 73, 148, 234, 218, 21, 220, 194, 13, 138, 170, 7, 182, 88, 253, 57, 84, 235, 142, 14, 251, 139, 220, 165, 222},
+		},
+		"failure no seed": {
+			seed:     nil,
+			expected: nil,
+		},
+		"failure wrong seed size (n<32)": {
+			seed:     []byte{0},
+			expected: nil,
+		},
+		"failure wrong seed size (n>32)": {
+			seed:     []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			expected: nil,
+		},
+	}
+	
+	for _, tc := range cases {
+		if tc.expected != nil {
+			privKey := PrivKeyEd25519FromSeed(tc.seed)
+			assert.Equal(t, tc.expected, privKey.GetEd25519())
+		} else {
+			assert.Panics(t, func() { PrivKeyEd25519FromSeed(tc.seed) })
+		}
+	}
+}


### PR DESCRIPTION
From Audit:
> Severity: Informational
Status: Open
Description
The function PrivKeyEd25519FromSeed that is critical for the generation of wallets is not
covered by any unit test and could, therefore, be prone to future errors being implemented
without being detected.

I fixed this _vulnurability_ in my free time. From now on Weave is bulletproof :joy:

!nochangelog
