### PR TITLE
update travis to run protoc on builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,7 @@ install:
 
 script:
 - set -eo pipefail
-- make protolint;
-- make protodocs;
+- make protoc;
 - make install;
 - make all;
 - if [[ "$TRAVIS_GO_VERSION" == "$MAIN_GO_VERSION" ]]; then


### PR DESCRIPTION
!nochangelog

This PR is created to address the issue raised by @webmaster128.
> Comment is wrong. I noted this some time ago but did not update the comment since it requires a local weave checkout and compilation step in order to create a PR. It would be great if the compiled docs are created at CI time and are not checked in. Then you can use Github Web UI to quickly fix stuff like this

TLDR; we cannot update commenting on proto files via Github Web UI. This way you will not have to run `protoc` locally every time you want to make a change in comments.