### PR TITLE
Update go version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ to your project.
 
 Join the Weave [community channel](https://riot.im/app/#/room/#weave:matrix.org) :loudspeaker:
 
-**Note: Requires Go 1.11.4+**
+**Note: Requires Go 1.13.0+**
 
 It is inspired by the routing and middleware model of many web
 application frameworks, and informed by years of wrestling with


### PR DESCRIPTION
Go version is set by go.mod and we set it in previous pull requests. I say we should fix the version to the latest go version(1.13) if there is no blocker.