### PR TITLE
orm: Fix PrimaryKey validation error on serial model bucket save

### DIFF
--- a/orm/serial_bucket.go
+++ b/orm/serial_bucket.go
@@ -314,10 +314,6 @@ func (smb *serialModelBucket) Save(db weave.KVStore, m SerialModel) error {
 		return errors.Wrap(err, "model type is not supported")
 	}
 
-	if err := m.Validate(); err != nil {
-		return errors.Wrap(err, "invalid serialmodel")
-	}
-
 	// If key is provided use it otherwise generate auto-incremented key
 	key := m.GetPrimaryKey()
 	if len(key) == 0 {
@@ -328,6 +324,10 @@ func (smb *serialModelBucket) Save(db weave.KVStore, m SerialModel) error {
 		if err := m.SetPrimaryKey(key); err != nil {
 			return errors.Wrap(err, "cannot set ID")
 		}
+	}
+
+	if err := m.Validate(); err != nil {
+		return errors.Wrap(err, "invalid serialmodel")
 	}
 
 	obj := NewSimpleObj(key, m)


### PR DESCRIPTION
I unnoticed the potential validation error when saving a serial model without preset **Primary Key**.

When a model is being saved to the store, validation is run before setting the primary key.

 ```go
if err := m.Validate(); err != nil {	
    return errors.Wrap(err, "invalid serialmodel")	
}
```

For example this is the blog model from blog-tutorial:

```go

// Validate validates blog's fields
func (m *Blog) Validate() error {
	var errs error

	errs = errors.AppendField(errs, "Metadata", m.Metadata.Validate())
	errs = errors.AppendField(errs, "PrimaryKey", orm.ValidateSequence(m.PrimaryKey))
	errs = errors.AppendField(errs, "Owner", m.Owner.Validate())
```

`orm.ValidateSequence(m.PrimaryKey)` throws error because the primary key is not set.

!nochangelog