### PR TITLE
orm: return not found error on serial model bucket ByIndex

### DIFF
--- a/orm/serial_bucket.go
+++ b/orm/serial_bucket.go
@@ -262,7 +262,7 @@ func (smb *serialModelBucket) ByIndex(db weave.ReadOnlyKVStore, indexName string
 		return err
 	}
 	if len(objs) == 0 {
-		return nil
+		return errors.Wrap(errors.ErrNotFound, "no objects found")
 	}
 
 	dest := reflect.ValueOf(destination)

--- a/orm/serial_bucket_test.go
+++ b/orm/serial_bucket_test.go
@@ -302,7 +302,7 @@ func TestSerialModelBucketByIndex(t *testing.T) {
 		"find none": {
 			IndexName:  "value",
 			QueryKey:   "124089710947120",
-			WantErr:    nil,
+			WantErr:    errors.ErrNotFound,
 			WantResPtr: nil,
 			WantRes:    nil,
 		},


### PR DESCRIPTION
When no objects found by index search `nil` is returned. This causes nil checks everywhere in code which I believe would lead to dirty code. I think it is better to return `errors.ErrNotFound` when no object found.

!nochangelog