### PR TITLE
orm: implement database native index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 ## HEAD
 
 - `datamigration` package added.
+- `orm` package was updated and provides a new index implementation, that is
+  using a native database store in order to maintain and iterate through an
+  index.
+  - `orm.Bucket` and `orm.ModelBucket` were updated to allow for the use of the
+    new index implementation.
+
+Breaking changes
+- `orm.Index` is an interface now to allow multiple implementations. The new
+  interface is a subset of the old structure, simplified and updated to support
+  lazy loading:
+  - `Keys` method returns an iterator,
+  - `GetLike` method was removed,
+- `orm.Bucket` interface was simplified. `GetIndexedLike` was removed,
+- `orm.WithIndex` supports multiple indexer types,
+- `orm.NewIndex` function was removed,
 
 
 ## 0.23.0

--- a/migration/orm.go
+++ b/migration/orm.go
@@ -112,6 +112,10 @@ func (m *ModelBucket) One(db weave.ReadOnlyKVStore, key []byte, dest orm.Model) 
 	return nil
 }
 
+func (m *ModelBucket) Index(name string) (orm.Index, error) {
+	return m.b.Index(name)
+}
+
 func (m *ModelBucket) ByIndex(db weave.ReadOnlyKVStore, indexName string, key []byte, dest orm.ModelSlicePtr) ([][]byte, error) {
 	keys, err := m.b.ByIndex(db, indexName, key, dest)
 	if err != nil {

--- a/orm/bucket.go
+++ b/orm/bucket.go
@@ -37,14 +37,31 @@ type Bucket interface {
 	DBKey(key []byte) []byte
 	Delete(db weave.KVStore, key []byte) error
 	Get(db weave.ReadOnlyKVStore, key []byte) (Object, error)
+	// Index returns an index with given name maintained for this bucket.
+	Index(name string) (Index, error)
 	GetIndexed(db weave.ReadOnlyKVStore, name string, key []byte) ([]Object, error)
-	GetIndexedLike(db weave.ReadOnlyKVStore, name string, pattern Object) ([]Object, error)
 	Parse(key, value []byte) (Object, error)
 	Register(name string, r weave.QueryRouter)
 	Save(db weave.KVStore, model Object) error
 	Sequence(name string) Sequence
+
+	// WithIndex returns a copy of this bucket with given index. Index is
+	// maintained as a single set. This implementation is suitable for
+	// small collections.
+	// Panics if it an index with that name is already registered.
 	WithIndex(name string, indexer Indexer, unique bool) Bucket
+
+	// WithMultiKeyIndex returns a copy of this bucket with given index.
+	// Index is maintained as a single set. This implementation is suitable
+	// for small collections.
+	// Panics if it an index with that name is already registered.
 	WithMultiKeyIndex(name string, indexer MultiKeyIndexer, unique bool) Bucket
+
+	// WithNativeIndex returns a copy of this bucket with given index.
+	// Index is maintained using database native support. This
+	// implementation is suitable for big collections.
+	// Panics if it an index with that name is already registered.
+	WithNativeIndex(name string, indexer MultiKeyIndexer) Bucket
 }
 
 // bucket is a generic holder that stores data as well
@@ -60,30 +77,30 @@ type bucket struct {
 	prefix []byte
 	model  reflect.Type
 	// index is a list of indexes sorted by
-	indexes namedIndexes
+	indexes boundIndexes
 }
 
 var _ Bucket = (*bucket)(nil)
 
-type namedIndex struct {
-	Index
+type bucketBoundIndex struct {
+	idx        Index
 	publicName string
 }
 
-type namedIndexes []namedIndex
+type boundIndexes []bucketBoundIndex
 
 // Get returns the index with the given (internal/db) name, or nil if not found
-func (n namedIndexes) Get(name string) *Index {
+func (n boundIndexes) Get(name string) Index {
 	for _, ni := range n {
 		if ni.publicName == name {
-			return &ni.Index
+			return ni.idx
 		}
 	}
 	return nil
 }
 
 // Has returns true iff an index with the given name is already registered
-func (n namedIndexes) Has(name string) bool {
+func (n boundIndexes) Has(name string) bool {
 	return n.Get(name) != nil
 }
 
@@ -110,7 +127,7 @@ func (b bucket) Register(name string, r weave.QueryRouter) {
 	root := "/" + name
 	r.Register(root, b)
 	for _, ni := range b.indexes {
-		r.Register(root+"/"+ni.publicName, ni.Index)
+		r.Register(root+"/"+ni.publicName, ni.idx)
 	}
 }
 
@@ -227,8 +244,8 @@ func (b bucket) updateIndexes(db weave.KVStore, key []byte, model Object) error 
 		if err != nil {
 			return err
 		}
-		for _, idx := range b.indexes {
-			err = idx.Update(db, prev, model)
+		for _, ni := range b.indexes {
+			err = ni.idx.Update(db, prev, model)
 			if err != nil {
 				return err
 			}
@@ -240,6 +257,23 @@ func (b bucket) updateIndexes(db weave.KVStore, key []byte, model Object) error 
 // Sequence returns a Sequence by name
 func (b bucket) Sequence(name string) Sequence {
 	return NewSequence(b.name, name)
+}
+
+func (b bucket) WithNativeIndex(name string, indexer MultiKeyIndexer) Bucket {
+	if b.indexes.Has(name) {
+		panic(fmt.Sprintf("Index %s registered twice", name))
+	}
+
+	iname := b.name + "_" + name
+	idxs := append(b.indexes, bucketBoundIndex{
+		idx:        NewNativeIndex(iname, indexer),
+		publicName: name,
+	})
+	sort.Slice(idxs, func(i int, j int) bool {
+		return idxs[i].idx.Name() < idxs[j].idx.Name()
+	})
+	b.indexes = idxs
+	return b
 }
 
 // WithIndex returns a copy of this bucket with given index,
@@ -258,10 +292,18 @@ func (b bucket) WithMultiKeyIndex(name string, indexer MultiKeyIndexer, unique b
 
 	iname := b.name + "_" + name
 	add := NewMultiKeyIndex(iname, indexer, unique, b.DBKey)
-	idxs := append(b.indexes, namedIndex{Index: add, publicName: name})
-	sort.Slice(idxs, func(i int, j int) bool { return idxs[i].name < idxs[j].name })
+	idxs := append(b.indexes, bucketBoundIndex{idx: add, publicName: name})
+	sort.Slice(idxs, func(i int, j int) bool { return idxs[i].idx.Name() < idxs[j].idx.Name() })
 	b.indexes = idxs
 	return b
+}
+
+func (b bucket) Index(name string) (Index, error) {
+	idx := b.indexes.Get(name)
+	if idx == nil {
+		return nil, errors.Wrap(ErrInvalidIndex, name)
+	}
+	return idx, nil
 }
 
 // GetIndexed queries the named index for the given key
@@ -270,20 +312,7 @@ func (b bucket) GetIndexed(db weave.ReadOnlyKVStore, name string, key []byte) ([
 	if idx == nil {
 		return nil, errors.Wrap(ErrInvalidIndex, name)
 	}
-	refs, err := idx.GetAt(db, key)
-	if err != nil {
-		return nil, err
-	}
-	return b.readRefs(db, refs)
-}
-
-// GetIndexedLike queries the named index with the given pattern
-func (b bucket) GetIndexedLike(db weave.ReadOnlyKVStore, name string, pattern Object) ([]Object, error) {
-	idx := b.indexes.Get(name)
-	if idx == nil {
-		return nil, errors.Wrap(ErrInvalidIndex, name)
-	}
-	refs, err := idx.GetLike(db, pattern)
+	refs, err := consumeIteratorKeys(idx.Keys(db, key))
 	if err != nil {
 		return nil, err
 	}

--- a/orm/bucket.go
+++ b/orm/bucket.go
@@ -54,12 +54,15 @@ type Bucket interface {
 	// WithMultiKeyIndex returns a copy of this bucket with given index.
 	// Index is maintained as a single set. This implementation is suitable
 	// for small collections.
+	//
 	// Panics if it an index with that name is already registered.
 	WithMultiKeyIndex(name string, indexer MultiKeyIndexer, unique bool) Bucket
 
 	// WithNativeIndex returns a copy of this bucket with given index.
-	// Index is maintained using database native support. This
-	// implementation is suitable for big collections.
+	// Index is maintained using database native support. Each index entry
+	// is stored as a separate database entry, lookups are using database
+	// iterator. This implementation is suitable for big collections.
+	//
 	// Panics if it an index with that name is already registered.
 	WithNativeIndex(name string, indexer MultiKeyIndexer) Bucket
 }

--- a/orm/index_test.go
+++ b/orm/index_test.go
@@ -2,30 +2,41 @@ package orm
 
 import (
 	"bytes"
-	"errors"
+	stderrors "errors"
 	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/store"
 	"github.com/iov-one/weave/weavetest/assert"
 )
 
+// newIndex constructs an index with single key Indexer.
+// Indexer calculates the index for an object
+// unique enforces a unique constraint on the index
+// refKey calculates the absolute dbkey for a ref
+func newIndex(name string, indexer Indexer, unique bool, refKey func([]byte) []byte) Index {
+	return NewMultiKeyIndex(name, asMultiKeyIndexer(indexer), unique, refKey)
+}
+
 // simple indexer for Counter
 func count(obj Object) ([]byte, error) {
 	if obj == nil {
-		return nil, errors.New("Cannot take index of nil")
+		return nil, stderrors.New("cannot take index of nil")
 	}
 	cntr, ok := obj.Value().(*Counter)
 	if !ok {
-		return nil, errors.New("Can only take index of Counter")
+		return nil, stderrors.New("can only take index of Counter")
 	}
 	// big-endian encoded int64
 	return encodeSequence(cntr.Count), nil
 }
 
 func TestCounterSingleKeyIndex(t *testing.T) {
-	multi := NewIndex("likes", count, false, nil)
-	uniq := NewIndex("magic", count, true, nil)
+	multi := newIndex("likes", count, false, nil).(compactIndex)
+	uniq := newIndex("magic", count, true, nil).(compactIndex)
 
 	// some keys to use
 	k1 := []byte("abc")
@@ -44,7 +55,7 @@ func TestCounterSingleKeyIndex(t *testing.T) {
 	e9 := encodeSequence(9)
 
 	cases := []struct {
-		idx        Index
+		idx        compactIndex
 		prev, next Object // for Update
 		isError    bool   // check Update result
 		// if there was no error, and these are non-nil, try
@@ -102,12 +113,12 @@ func TestCounterSingleKeyIndex(t *testing.T) {
 
 			assert.Nil(t, err)
 			if tc.getLike != nil {
-				res, err := idx.GetLike(db, tc.getLike)
+				res, err := idx.Like(db, tc.getLike)
 				assert.Nil(t, err)
 				assert.Equal(t, tc.likeRes, res)
 			}
 			if tc.getAt != nil {
-				res, err := idx.GetAt(db, tc.getAt)
+				res, err := consumeIteratorKeys(idx.Keys(db, tc.getAt))
 				assert.Nil(t, err)
 				assert.Equal(t, tc.atRes, res)
 			}
@@ -116,10 +127,10 @@ func TestCounterSingleKeyIndex(t *testing.T) {
 }
 
 func TestCounterMultiKeyIndex(t *testing.T) {
-	uniq := NewMultiKeyIndex("unique", evenOddIndexer, true, nil)
+	uniq := NewMultiKeyIndex("unique", evenOddIndexer, true, nil).(compactIndex)
 
 	specs := map[string]struct {
-		index               Index
+		index               compactIndex
 		store               Object
 		prev, next          Object
 		expError            bool
@@ -157,7 +168,7 @@ func TestCounterMultiKeyIndex(t *testing.T) {
 			expError: true,
 		},
 		"update without unique constraint": {
-			index:    NewMultiKeyIndex("multi", evenOddIndexer, false, nil),
+			index:    NewMultiKeyIndex("multi", evenOddIndexer, false, nil).(compactIndex),
 			store:    NewSimpleObj([]byte("even"), NewCounter(8)),
 			prev:     NewSimpleObj([]byte("my"), NewCounter(5)),
 			next:     NewSimpleObj([]byte("my"), NewCounter(6)),
@@ -202,7 +213,7 @@ func TestCounterMultiKeyIndex(t *testing.T) {
 			}
 			for _, k := range spec.expKeys {
 				// and index keys exists
-				pks, err := idx.GetAt(db, k)
+				pks, err := consumeIteratorKeys(idx.Keys(db, k))
 				assert.Nil(t, err)
 				// with proper pk
 				if idx.unique {
@@ -220,7 +231,7 @@ func TestCounterMultiKeyIndex(t *testing.T) {
 			}
 			// and previous index keys don't exist anymore
 			for _, k := range spec.expNotKeys {
-				pks, err := idx.GetAt(db, k)
+				pks, err := consumeIteratorKeys(idx.Keys(db, k))
 				assert.Nil(t, err)
 				assert.Nil(t, pks)
 			}
@@ -230,7 +241,7 @@ func TestCounterMultiKeyIndex(t *testing.T) {
 
 func TestGetLikeWithMultiKeyIndex(t *testing.T) {
 	db := store.MemStore()
-	idx := NewMultiKeyIndex("multi", evenOddIndexer, false, nil)
+	idx := NewMultiKeyIndex("multi", evenOddIndexer, false, nil).(compactIndex)
 
 	persistentObjects := []Object{
 		NewSimpleObj([]byte("firstOdd"), NewCounter(5)),
@@ -267,7 +278,7 @@ func TestGetLikeWithMultiKeyIndex(t *testing.T) {
 	}
 	for testName, spec := range specs {
 		t.Run(testName, func(t *testing.T) {
-			pks, err := idx.GetLike(db, spec.source)
+			pks, err := idx.Like(db, spec.source)
 			// then
 			assert.Nil(t, err)
 			assert.Equal(t, spec.expPKs, pks)
@@ -292,11 +303,11 @@ func evenOddIndexer(obj Object) ([][]byte, error) {
 // return first value (if any), or nil
 func first(obj Object) ([]byte, error) {
 	if obj == nil {
-		return nil, errors.New("Cannot take index of nil")
+		return nil, stderrors.New("Cannot take index of nil")
 	}
 	multi, ok := obj.Value().(*MultiRef)
 	if !ok {
-		return nil, errors.New("Can only take index of MultiRef")
+		return nil, stderrors.New("Can only take index of MultiRef")
 	}
 	if len(multi.Refs) == 0 {
 		return nil, nil
@@ -366,7 +377,7 @@ func TestNullableIndex(t *testing.T) {
 
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
-			uniq := NewIndex("no-null", first, true, nil)
+			uniq := newIndex("no-null", first, true, nil)
 			db := store.MemStore()
 			for _, init := range tc.setup {
 				err := uniq.Update(db, nil, init)
@@ -430,4 +441,217 @@ func toBytes(s []string) [][]byte {
 		source[i] = []byte(v)
 	}
 	return source
+}
+
+func TestNativeIndexPacking(t *testing.T) {
+	cases := map[string][][]byte{
+		"empty":                [][]byte{},
+		"one empty element":    [][]byte{[]byte{}},
+		"three empty elements": [][]byte{[]byte{}, []byte{}, []byte{}},
+		"one non empty element": [][]byte{
+			[]byte("foo"),
+		},
+		"two non empty elements": [][]byte{
+			[]byte("a"),
+			[]byte("a very long value that is below 255 characters"),
+		},
+		"three non empty elements": [][]byte{
+			[]byte("foo"),
+			[]byte("bar"),
+			[]byte("baz"),
+		},
+		"mixture of empty and non empty": [][]byte{
+			[]byte("non empty value"),
+			[]byte{},
+			[]byte("another non empty value"),
+			[]byte{},
+			[]byte{},
+			[]byte{},
+			[]byte("not empty"),
+			[]byte{},
+		},
+	}
+
+	for testName, chunks := range cases {
+		t.Run(testName, func(t *testing.T) {
+			packed, err := packNativeIdxKey(chunks)
+			if err != nil {
+				t.Fatalf("cannot pack: %s", err)
+			}
+			unpacked, err := unpackNativeIdxKey(packed)
+			if err != nil {
+				t.Fatalf("cannot unpack: %s", err)
+			}
+			if !reflect.DeepEqual(unpacked, chunks) {
+				t.Logf("packed: %x %q", packed, packed)
+				t.Fatalf("data malformed during serialization: %q", unpacked)
+			}
+		})
+	}
+}
+
+func TestCompactIndexImplementation(t *testing.T) {
+	testIndexImplementation(t, func(fn MultiKeyIndexer) Index {
+		return NewMultiKeyIndex("myindex", fn, false, func(b []byte) []byte { return b })
+	})
+}
+
+func TestNativeIndexImplementation(t *testing.T) {
+	testIndexImplementation(t, func(fn MultiKeyIndexer) Index {
+		return NewNativeIndex("myindex", fn)
+	})
+}
+
+func testIndexImplementation(t *testing.T, newIdx func(MultiKeyIndexer) Index) {
+	valueIdx := func(o Object) ([][]byte, error) {
+		c := o.Value().(*Counter).Count
+		return [][]byte{[]byte(fmt.Sprint(c))}, nil
+	}
+	idx := newIdx(valueIdx)
+
+	// Definition of a single Update method call and expected result.
+	type updateCall struct {
+		prev    Object
+		next    Object
+		wantErr *errors.Error
+	}
+
+	// Definition of a single Keys method call and expected results.
+	type keysCall struct {
+		value    []byte
+		wantKeys []string // []string and not [][]byte for nicer UI
+	}
+
+	cases := map[string]struct {
+		idx     Index
+		updates []updateCall
+		keys    []keysCall
+	}{
+		"no results found": {
+			idx:     idx,
+			updates: []updateCall{},
+			keys: []keysCall{
+				{value: []byte("random-value"), wantKeys: nil},
+			},
+		},
+		"a single item": {
+			idx: idx,
+			updates: []updateCall{
+				{prev: nil, next: NewSimpleObj([]byte("one"), &Counter{Count: 1})},
+			},
+			keys: []keysCall{
+				{value: []byte("1"), wantKeys: []string{"one"}},
+				{value: []byte("unindexed-value"), wantKeys: nil},
+			},
+		},
+		"two items, both with the same index value": {
+			idx: idx,
+			updates: []updateCall{
+				{prev: nil, next: NewSimpleObj([]byte("first"), &Counter{Count: 1})},
+				{prev: nil, next: NewSimpleObj([]byte("second"), &Counter{Count: 1})},
+			},
+			keys: []keysCall{
+				{value: []byte("1"), wantKeys: []string{"first", "second"}},
+				{value: []byte("unindexed-value"), wantKeys: nil},
+			},
+		},
+		"two items, each with a different index value": {
+			idx: idx,
+			updates: []updateCall{
+				{prev: nil, next: NewSimpleObj([]byte("one"), &Counter{Count: 1})},
+				{prev: nil, next: NewSimpleObj([]byte("two"), &Counter{Count: 2})},
+			},
+			keys: []keysCall{
+				{value: []byte("1"), wantKeys: []string{"one"}},
+				{value: []byte("2"), wantKeys: []string{"two"}},
+				{value: []byte("unindexed-value"), wantKeys: nil},
+			},
+		},
+		"many items, some with similar index value": {
+			idx: idx,
+			updates: []updateCall{
+				{prev: nil, next: NewSimpleObj([]byte("a"), &Counter{Count: 1})},
+				{prev: nil, next: NewSimpleObj([]byte("b"), &Counter{Count: 2})},
+				{prev: nil, next: NewSimpleObj([]byte("c"), &Counter{Count: 2})},
+				{prev: nil, next: NewSimpleObj([]byte("d"), &Counter{Count: 2})},
+				{prev: nil, next: NewSimpleObj([]byte("e"), &Counter{Count: 3})},
+			},
+			keys: []keysCall{
+				{value: []byte("1"), wantKeys: []string{"a"}},
+				{value: []byte("2"), wantKeys: []string{"b", "c", "d"}},
+				{value: []byte("3"), wantKeys: []string{"e"}},
+				{value: []byte("unindexed-value"), wantKeys: nil},
+			},
+		},
+		"deleting an item from an index": {
+			idx: idx,
+			updates: []updateCall{
+				{prev: nil, next: NewSimpleObj([]byte("one"), &Counter{Count: 1})},
+				{prev: nil, next: NewSimpleObj([]byte("two"), &Counter{Count: 2})},
+				{prev: NewSimpleObj([]byte("two"), &Counter{Count: 2}), next: nil},
+			},
+			keys: []keysCall{
+				{value: []byte("1"), wantKeys: []string{"one"}},
+				{value: []byte("2"), wantKeys: nil},
+			},
+		},
+		"reindexing an item with a different value": {
+			idx: idx,
+			updates: []updateCall{
+				{prev: nil, next: NewSimpleObj([]byte("two"), &Counter{Count: 1})},
+				{prev: nil, next: NewSimpleObj([]byte("one"), &Counter{Count: 1})},
+				{prev: NewSimpleObj([]byte("two"), &Counter{Count: 1}), next: NewSimpleObj([]byte("two"), &Counter{Count: 2})},
+			},
+			keys: []keysCall{
+				{value: []byte("1"), wantKeys: []string{"one"}},
+				{value: []byte("2"), wantKeys: []string{"two"}},
+				{value: []byte("unindexed-value"), wantKeys: nil},
+			},
+		},
+	}
+
+	for testName, tc := range cases {
+		t.Run(testName, func(t *testing.T) {
+			db := store.MemStore()
+
+			for i, u := range tc.updates {
+				if err := tc.idx.Update(db, u.prev, u.next); !u.wantErr.Is(err) {
+					t.Fatalf("%d update: want %q error, got %q", i, u.wantErr, err)
+				}
+			}
+
+			for i, k := range tc.keys {
+				keys, err := iteratorKeys(tc.idx.Keys(db, k.value))
+				if err != nil {
+					t.Fatalf("%d iterator keys failed: %s", i, err)
+				}
+
+				var want [][]byte
+				for _, k := range k.wantKeys {
+					want = append(want, []byte(k))
+				}
+				if !reflect.DeepEqual(keys, want) {
+					t.Logf("want keys: %q", want)
+					t.Logf(" got keys: %q", keys)
+					t.Errorf("%d keys call returned unexpected keys for value %q", i, k.value)
+				}
+			}
+		})
+	}
+}
+
+func iteratorKeys(it weave.Iterator) ([][]byte, error) {
+	defer it.Release()
+
+	var res [][]byte
+	for {
+		switch key, _, err := it.Next(); {
+		case err == nil:
+			res = append(res, key)
+		case errors.ErrIteratorDone.Is(err):
+			return res, nil
+		default:
+			return res, err
+		}
+	}
 }

--- a/orm/model_bucket_test.go
+++ b/orm/model_bucket_test.go
@@ -86,26 +86,20 @@ func TestModelBucketPutSequence(t *testing.T) {
 
 func TestModelBucketByIndex(t *testing.T) {
 	cases := map[string]struct {
-		IndexName  string
 		QueryKey   string
 		DestFn     func() ModelSlicePtr
-		WantErr    *errors.Error
 		WantResPtr []*Counter
 		WantRes    []Counter
 		WantKeys   [][]byte
 	}{
 		"find none": {
-			IndexName:  "value",
 			QueryKey:   "124089710947120",
-			WantErr:    nil,
 			WantResPtr: nil,
 			WantRes:    nil,
 			WantKeys:   nil,
 		},
 		"find one": {
-			IndexName: "value",
-			QueryKey:  "1",
-			WantErr:   nil,
+			QueryKey: "1",
 			WantResPtr: []*Counter{
 				{Count: 1001},
 			},
@@ -117,9 +111,7 @@ func TestModelBucketByIndex(t *testing.T) {
 			},
 		},
 		"find two": {
-			IndexName: "value",
-			QueryKey:  "4",
-			WantErr:   nil,
+			QueryKey: "4",
 			WantResPtr: []*Counter{
 				{Count: 4001},
 				{Count: 4002},
@@ -133,26 +125,28 @@ func TestModelBucketByIndex(t *testing.T) {
 				weavetest.SequenceID(4),
 			},
 		},
-		"non existing index name": {
-			IndexName: "xyz",
-			WantErr:   ErrInvalidIndex,
-		},
 	}
 
 	for testName, tc := range cases {
 		t.Run(testName, func(t *testing.T) {
 			db := store.MemStore()
 
-			indexByBigValue := func(obj Object) ([]byte, error) {
+			indexByBigValue := func(obj Object) ([][]byte, error) {
 				c, ok := obj.Value().(*Counter)
 				if !ok {
 					return nil, errors.Wrapf(errors.ErrType, "%T", obj.Value())
 				}
 				// Index by the value, ignoring anything below 1k.
 				raw := strconv.FormatInt(c.Count/1000, 10)
-				return []byte(raw), nil
+				return [][]byte{[]byte(raw)}, nil
 			}
-			b := NewModelBucket("cnts", &Counter{}, WithIndex("value", indexByBigValue, false))
+
+			// Use both native and compact index to test both
+			// implementation integrations.
+			b := NewModelBucket("cnts", &Counter{},
+				WithNativeIndex("native", indexByBigValue),
+				WithIndex("compact", indexByBigValue, false),
+			)
 
 			if _, err := b.Put(db, nil, &Counter{Count: 1001}); err != nil {
 				t.Fatalf("cannot save counter instance: %s", err)
@@ -167,21 +161,26 @@ func TestModelBucketByIndex(t *testing.T) {
 				t.Fatalf("cannot save counter instance: %s", err)
 			}
 
-			var dest []Counter
-			keys, err := b.ByIndex(db, tc.IndexName, []byte(tc.QueryKey), &dest)
-			if !tc.WantErr.Is(err) {
-				t.Fatalf("unexpected error: %s", err)
-			}
-			assert.Equal(t, tc.WantKeys, keys)
-			assert.Equal(t, tc.WantRes, dest)
+			indexes := []string{"native", "compact"}
+			for _, indexName := range indexes {
+				t.Run(indexName, func(t *testing.T) {
+					var dest []Counter
+					keys, err := b.ByIndex(db, indexName, []byte(tc.QueryKey), &dest)
+					if err != nil {
+						t.Fatalf("unexpected error: %s", err)
+					}
+					assert.Equal(t, tc.WantKeys, keys)
+					assert.Equal(t, tc.WantRes, dest)
 
-			var destPtr []*Counter
-			keys, err = b.ByIndex(db, tc.IndexName, []byte(tc.QueryKey), &destPtr)
-			if !tc.WantErr.Is(err) {
-				t.Fatalf("unexpected error: %s", err)
+					var destPtr []*Counter
+					keys, err = b.ByIndex(db, indexName, []byte(tc.QueryKey), &destPtr)
+					if err != nil {
+						t.Fatalf("unexpected error: %s", err)
+					}
+					assert.Equal(t, tc.WantKeys, keys)
+					assert.Equal(t, tc.WantResPtr, destPtr)
+				})
 			}
-			assert.Equal(t, tc.WantKeys, keys)
-			assert.Equal(t, tc.WantResPtr, destPtr)
 		})
 	}
 }


### PR DESCRIPTION
`orm` package was updated and provides a new index implementation, that
is using a native database store in order to maintain and iterate
through an index. `orm.Bucket` and `orm.ModelBucket` were updated to
allow for the use of the new index implementation.

`orm.Index` is an interface now to allow multiple implementations. The
new interface is a subset of the old structure, simplified and updated
to support lazy loading:
- `Keys` method returns an iterator
- `GetLike` method was removed

`orm.Bucket` interface was simplified. `GetIndexedLike` was removed.
`orm.WithIndex` supports multiple indexer types.
`orm.NewIndex` function was removed.

resolve #1059