### PR TITLE
bsnd: data migration for rewriting username entities to account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD
 
+- a new `orm.IterAll` iterator was implemented to allow iterating through all
+  entities of a given bucket.
+- a `bnsd` data migration was added that rewrites all accounts from
+  `x/username` extension to `x/account`.
 
 ## 0.24.0
 

--- a/cmd/bnsd/app/datamigration.go
+++ b/cmd/bnsd/app/datamigration.go
@@ -77,7 +77,7 @@ func rewriteUsernameAccounts(ctx context.Context, db weave.KVStore) error {
 		Domain:       "iov",
 		Admin:        governingBoard,
 		HasSuperuser: false,
-		AccountRenew: weave.AsUnixDuration(30 * 24 * time.Hour),
+		AccountRenew: weave.AsUnixDuration(tenYears),
 		// IOV domain is not supposed to expire. It is
 		// not our problem in 100 years ;)
 		ValidUntil: weave.AsUnixTime(now.Add(oneHundredYears)),
@@ -143,5 +143,9 @@ func parseUsername(u string) (string, string) {
 	return chunks[0], chunks[1]
 }
 
-// Around 100 years.
-const oneHundredYears = 100 * 365 * 24 * time.Hour
+const (
+	// Around 100 years.
+	oneHundredYears = 100 * 365 * 24 * time.Hour
+	// Around 10 years.
+	tenYears = 10 * 365 * 24 * time.Hour
+)

--- a/cmd/bnsd/app/datamigration.go
+++ b/cmd/bnsd/app/datamigration.go
@@ -2,11 +2,16 @@ package bnsd
 
 import (
 	"context"
+	"strings"
+	"time"
 
 	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/cmd/bnsd/x/account"
+	"github.com/iov-one/weave/cmd/bnsd/x/username"
 	"github.com/iov-one/weave/datamigration"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/gconf"
+	"github.com/iov-one/weave/orm"
 	"github.com/iov-one/weave/x/msgfee"
 )
 
@@ -22,7 +27,9 @@ func init() {
 
 	datamigration.MustRegister("initialize x/msgfee configuration owner", datamigration.Migration{
 		RequiredSigners: []weave.Address{governingBoard},
-		ChainID:         "iov-mainnet",
+		ChainIDs: []string{
+			"iov-mainnet",
+		},
 		Migrate: func(ctx context.Context, db weave.KVStore) error {
 			var conf msgfee.Configuration
 			switch err := gconf.Load(db, "msgfee", &msgfee.Configuration{}); {
@@ -44,4 +51,97 @@ func init() {
 			return nil
 		},
 	})
+
+	datamigration.MustRegister("rewrite username accounts", datamigration.Migration{
+		RequiredSigners: []weave.Address{governingBoard},
+		ChainIDs: []string{
+			"iov-mainnet",
+		},
+		Migrate: rewriteUsernameAccounts,
+	})
 }
+
+func rewriteUsernameAccounts(ctx context.Context, db weave.KVStore) error {
+	governingBoard, err := weave.ParseAddress("cond:gov/rule/0000000000000001")
+	if err != nil {
+		panic(err)
+	}
+
+	now, err := weave.BlockTime(ctx)
+	if err != nil {
+		return errors.Wrap(err, "block time")
+	}
+
+	iov := account.Domain{
+		Metadata:     &weave.Metadata{Schema: 1},
+		Domain:       "iov",
+		Admin:        governingBoard,
+		HasSuperuser: false,
+		AccountRenew: weave.AsUnixDuration(30 * 24 * time.Hour),
+		// IOV domain is not supposed to expire. It is
+		// not our problem in 100 years ;)
+		ValidUntil: weave.AsUnixTime(now.Add(oneHundredYears)),
+	}
+	if _, err := account.NewDomainBucket().Put(db, []byte("iov"), &iov); err != nil {
+		return errors.Wrap(err, "save iov domain")
+	}
+
+	accounts := account.NewAccountBucket()
+
+	// Every domain must contain an empty account.
+	empty := &account.Account{
+		Metadata:     &weave.Metadata{Schema: 1},
+		Domain:       "iov",
+		Name:         "",
+		Owner:        iov.Admin,
+		ValidUntil:   weave.AsUnixTime(now.Add(iov.AccountRenew.Duration())),
+		Certificates: nil,
+	}
+	if _, err := accounts.Put(db, []byte("*iov"), empty); err != nil {
+		return errors.Wrap(err, "save empty account")
+	}
+
+	it := orm.IterAll("tokens")
+	for {
+		var token username.Token
+		switch key, err := it.Next(db, &token); {
+		case err == nil:
+			name, domain := parseUsername(key)
+			if domain != "iov" {
+				// Ignore all non IOV domains. Username should not contain
+				// any non IOV names, but better be sure.
+				continue
+			}
+			acc := &account.Account{
+				Metadata:     &weave.Metadata{Schema: 1},
+				Domain:       "iov",
+				Name:         name,
+				Owner:        token.Owner,
+				ValidUntil:   weave.AsUnixTime(now.Add(iov.AccountRenew.Duration())),
+				Certificates: nil,
+			}
+			for _, t := range token.Targets {
+				acc.Targets = append(acc.Targets, account.BlockchainAddress{
+					BlockchainID: t.BlockchainID,
+					Address:      t.Address,
+				})
+			}
+			accountKey := []byte(name + "*" + domain)
+			if _, err := accounts.Put(db, accountKey, acc); err != nil {
+				return errors.Wrapf(err, "save account %q", key)
+			}
+		case errors.ErrIteratorDone.Is(err):
+			return nil
+		default:
+			return errors.Wrap(err, "iterator next")
+		}
+	}
+}
+
+func parseUsername(u string) (string, string) {
+	chunks := strings.SplitN(u, "*", 2)
+	return chunks[0], chunks[1]
+}
+
+// Around 100 years.
+const oneHundredYears = 100 * 365 * 24 * time.Hour

--- a/cmd/bnsd/app/datamigration_test.go
+++ b/cmd/bnsd/app/datamigration_test.go
@@ -1,0 +1,88 @@
+package bnsd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/cmd/bnsd/x/account"
+	"github.com/iov-one/weave/cmd/bnsd/x/username"
+	"github.com/iov-one/weave/migration"
+	"github.com/iov-one/weave/store"
+	"github.com/iov-one/weave/weavetest/assert"
+)
+
+func TestRewriteUsernameAccounts(t *testing.T) {
+	db := store.MemStore()
+	migration.MustInitPkg(db, "datamigration", "username", "account")
+
+	ctx := context.Background()
+	ctx = weave.WithBlockTime(ctx, time.Now())
+
+	var (
+		aliceCond = weave.NewCondition("alice", "test", []byte{1})
+		bobCond   = weave.NewCondition("bob", "test", []byte{1})
+	)
+
+	tokens := username.NewTokenBucket()
+	_, err := tokens.Put(db, []byte("alice*iov"), &username.Token{
+		Metadata: &weave.Metadata{Schema: 1},
+		Owner:    aliceCond.Address(),
+		Targets: []username.BlockchainAddress{
+			{BlockchainID: "blockchain1", Address: "addr1"},
+			{BlockchainID: "blockchain2", Address: "addr2"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("cannot store alice: %s", err)
+	}
+	_, err = tokens.Put(db, []byte("bob*iov"), &username.Token{
+		Metadata: &weave.Metadata{Schema: 1},
+		Owner:    bobCond.Address(),
+		Targets:  nil,
+	})
+	if err != nil {
+		t.Fatalf("cannot store bob: %s", err)
+	}
+
+	if err := rewriteUsernameAccounts(ctx, db); err != nil {
+		t.Fatalf("cannot rewrite username accounts: %s", err)
+	}
+
+	domains := account.NewDomainBucket()
+	var d account.Domain
+	if err := domains.One(db, []byte("iov"), &d); err != nil {
+		t.Fatalf("cannot get iov domain: %s", err)
+	}
+	assert.Equal(t, d.Domain, "iov")
+	assert.Equal(t, d.HasSuperuser, false)
+
+	accounts := account.NewAccountBucket()
+
+	var empty account.Account
+	if err := accounts.One(db, []byte("*iov"), &empty); err != nil {
+		t.Fatalf("cannot get empty account: %s", err)
+	}
+
+	var alice account.Account
+	if err := accounts.One(db, []byte("alice*iov"), &alice); err != nil {
+		t.Fatalf("cannot get alice account: %s", err)
+	}
+	assert.Equal(t, alice.Domain, "iov")
+	assert.Equal(t, alice.Name, "alice")
+	assert.Equal(t, alice.Owner, aliceCond.Address())
+	assert.Equal(t, alice.Targets, []account.BlockchainAddress{
+		{BlockchainID: "blockchain1", Address: "addr1"},
+		{BlockchainID: "blockchain2", Address: "addr2"},
+	})
+
+	var bob account.Account
+	if err := accounts.One(db, []byte("bob*iov"), &bob); err != nil {
+		t.Fatalf("cannot get bob account: %s", err)
+	}
+	assert.Equal(t, bob.Domain, "iov")
+	assert.Equal(t, bob.Name, "bob")
+	assert.Equal(t, bob.Owner, bobCond.Address())
+	assert.Equal(t, len(bob.Targets), 0)
+}

--- a/datamigration/handler.go
+++ b/datamigration/handler.go
@@ -71,8 +71,8 @@ func (h *executeMigrationHandler) validate(ctx weave.Context, db weave.KVStore, 
 		}
 	}
 
-	if m.ChainID != weave.GetChainID(ctx) {
-		return nil, nil, errors.Wrapf(errors.ErrChain, "allowed only on %q chain", m.ChainID)
+	if !containStr(m.ChainIDs, weave.GetChainID(ctx)) {
+		return nil, nil, errors.Wrapf(errors.ErrChain, "allowed only on %q chains", m.ChainIDs)
 	}
 
 	switch err := h.bucket.Has(db, []byte(msg.MigrationID)); {
@@ -84,6 +84,15 @@ func (h *executeMigrationHandler) validate(ctx weave.Context, db weave.KVStore, 
 		return nil, nil, errors.Wrap(err, "cannot check if migration was executed")
 	}
 	return &msg, m, nil
+}
+
+func containStr(collection []string, item string) bool {
+	for _, s := range collection {
+		if s == item {
+			return true
+		}
+	}
+	return false
 }
 
 func RegisterQuery(qr weave.QueryRouter) {

--- a/datamigration/handler_test.go
+++ b/datamigration/handler_test.go
@@ -83,7 +83,7 @@ func TestHandler(t *testing.T) {
 			MustRegister(
 				"zero migration",
 				Migration{
-					ChainID:         "testchain",
+					ChainIDs:        []string{"testchain"},
 					RequiredSigners: []weave.Address{aliceCond.Address()},
 					Migrate:         func(context.Context, weave.KVStore) error { panic("never to be called") },
 				},
@@ -92,7 +92,7 @@ func TestHandler(t *testing.T) {
 			MustRegister(
 				"first migration",
 				Migration{
-					ChainID:         "testchain",
+					ChainIDs:        []string{"staging", "testchain"},
 					RequiredSigners: []weave.Address{aliceCond.Address()},
 					Migrate:         func(context.Context, weave.KVStore) error { return nil },
 				},
@@ -100,7 +100,7 @@ func TestHandler(t *testing.T) {
 			MustRegister(
 				"second migration",
 				Migration{
-					ChainID:         "staging",
+					ChainIDs:        []string{"staging", "production"},
 					RequiredSigners: []weave.Address{aliceCond.Address()},
 					Migrate:         func(context.Context, weave.KVStore) error { return nil },
 				},
@@ -108,7 +108,7 @@ func TestHandler(t *testing.T) {
 			MustRegister(
 				"third migration",
 				Migration{
-					ChainID:         "testchain",
+					ChainIDs:        []string{"testchain", "production"},
 					RequiredSigners: []weave.Address{aliceCond.Address()},
 					Migrate:         func(context.Context, weave.KVStore) error { return errors.ErrHuman },
 				},

--- a/datamigration/registry.go
+++ b/datamigration/registry.go
@@ -37,12 +37,12 @@ type Migration struct {
 	// chicken-egg problem.
 	RequiredSigners []weave.Address
 
-	// ChainID specifies which chain this migration can be executed on.
+	// ChainIDs specifies which chains this migration can be executed on.
 	// This is helpful because no two chains are the same and therefore now
 	// two chains should require the same set of data migrations. Usually
 	// we run staging/testing/production setup, each maintaining a
 	// different state.
-	ChainID string
+	ChainIDs []string
 
 	Migrate func(context.Context, weave.KVStore) error
 }

--- a/datamigration/registry_test.go
+++ b/datamigration/registry_test.go
@@ -15,12 +15,12 @@ func TestMigrationCanBeRegisteredOnce(t *testing.T) {
 	noop := func(context.Context, weave.KVStore) error { return nil }
 	sigs := []weave.Address{weavetest.NewCondition().Address()}
 
-	if err := reg.Register("migration name", Migration{ChainID: "chain-a", RequiredSigners: sigs, Migrate: noop}); err != nil {
+	if err := reg.Register("migration name", Migration{ChainIDs: []string{"chain-a"}, RequiredSigners: sigs, Migrate: noop}); err != nil {
 		t.Fatalf("unexpected failure: %+v", err)
 	}
 
 	// Double registration
-	if err := reg.Register("migration name", Migration{ChainID: "chain-a", RequiredSigners: sigs, Migrate: noop}); !errors.ErrState.Is(err) {
+	if err := reg.Register("migration name", Migration{ChainIDs: []string{"chain-a"}, RequiredSigners: sigs, Migrate: noop}); !errors.ErrState.Is(err) {
 		t.Fatalf("expected ErrState, got %+v", err)
 	}
 }

--- a/orm/model_bucket.go
+++ b/orm/model_bucket.go
@@ -1,6 +1,7 @@
 package orm
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 
@@ -79,6 +80,70 @@ type ModelBucket interface {
 	// Register registers this buckets content to be accessible via query
 	// requests under the given name.
 	Register(name string, r weave.QueryRouter)
+}
+
+// IterAll returns an iterator instance that loops through all entities kept by
+// given bucket.
+// Returned iterator does not support schema migration. It always returns the
+// entity in version it is stored in the database.
+func IterAll(bucketName string) *ModelBucketIterator {
+	// This is how Bucket.DBKey is implemented.
+	dbkey := []byte(bucketName + ":")
+
+	start := []byte(bucketName + ":")
+	end := append([]byte(bucketName+":"), 255, 255, 255, 255, 255, 255, 255)
+
+	return &ModelBucketIterator{
+		dbprefix: len(dbkey),
+		cursor:   start,
+		end:      end,
+	}
+}
+
+// ModelBucketIterator allows for iteration over all entities of a single
+// bucket.
+type ModelBucketIterator struct {
+	dbprefix int
+	cursor   []byte
+	end      []byte
+	err      error
+}
+
+// Next returns the next item key. Load the value of the item into provided
+// model. For each call a new iterator is created so that database modification
+// can be done between this method calls.
+func (it *ModelBucketIterator) Next(db weave.ReadOnlyKVStore, dest Model) (string, error) {
+	if it.err != nil {
+		return "", it.err
+	}
+
+	if bytes.Compare(it.cursor, it.end) >= 0 {
+		return "", errors.ErrIteratorDone
+	}
+
+	iter, err := db.Iterator(it.cursor, it.end)
+	if err != nil {
+		return "", errors.Wrap(err, "new iterator")
+	}
+	// Use iterator as a one time fetch, so that other database operations
+	// can be performed between Next method calls.
+	defer iter.Release()
+
+	key, value, err := iter.Next()
+	if err != nil {
+		return "", errors.Wrap(err, "iterator next")
+	}
+
+	if err := dest.Unmarshal(value); err != nil {
+		return "", errors.Wrap(err, "cannot unmarshal model value")
+	}
+
+	// Key was consumed. Iterator is inclusive, so we must use the very
+	// next possible key. Which is this very key with zero appended.
+	it.cursor = make([]byte, len(key)+1)
+	copy(it.cursor, key)
+
+	return string(key[it.dbprefix:]), nil
 }
 
 // NewModelBucket returns a ModelBucket instance. This implementation relies on

--- a/orm/model_bucket_test.go
+++ b/orm/model_bucket_test.go
@@ -303,9 +303,14 @@ func TestIterAll(t *testing.T) {
 
 			// Add some rubbish to the database, so that any
 			// unexected result can be detected.
-			db.Set([]byte{0}, []byte("xyz"))
-			db.Set([]byte{255}, []byte("z"))
-			db.Set([]byte("mystuff:abc"), []byte("mystuff"))
+			mustSet := func(k, v []byte) {
+				if err := db.Set(k, v); err != nil {
+					t.Fatalf("cannot set %q: %s", string(k), err)
+				}
+			}
+			mustSet([]byte{0}, []byte("xyz"))
+			mustSet([]byte{255}, []byte("z"))
+			mustSet([]byte("mystuff:abc"), []byte("mystuff"))
 
 			keys, counters := consumeIterAll(t, db, IterAll("cnts"))
 			if !reflect.DeepEqual(keys, tc.WantKeys) {


### PR DESCRIPTION
A new `bnsd` data migration was registered to rewrite all `username`
tokens to `account` extension.