### PR TITLE
x/msgfee: configuration is genesis is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+- `x/msgfee` configuration in genesis is optional. Not providing it no longer
+  fails initialization.
 - a new `orm.IterAll` iterator was implemented to allow iterating through all
   entities of a given bucket.
 - a `bnsd` data migration was added that rewrites all accounts from

--- a/x/msgfee/init.go
+++ b/x/msgfee/init.go
@@ -42,7 +42,8 @@ func (*Initializer) FromGenesis(opts weave.Options, params weave.GenesisParams, 
 		}
 	}
 
-	if err := gconf.InitConfig(kv, opts, "msgfee", &Configuration{}); err != nil {
+	// We allow to initialize configuration but it is not required.
+	if err := gconf.InitConfig(kv, opts, "msgfee", &Configuration{}); err != nil && !errors.ErrNotFound.Is(err) {
 		return errors.Wrap(err, "init config")
 	}
 

--- a/x/msgfee/init_test.go
+++ b/x/msgfee/init_test.go
@@ -85,3 +85,18 @@ func TestGenesisWithInvalidFee(t *testing.T) {
 	}
 
 }
+
+func TestGenesisConfigurationIsOptional(t *testing.T) {
+	const genesis = `{ "msgfee": [ ], "conf": {} }`
+	var opts weave.Options
+	if err := json.Unmarshal([]byte(genesis), &opts); err != nil {
+		t.Fatalf("cannot unmarshal genesis: %s", err)
+	}
+
+	db := store.MemStore()
+	migration.MustInitPkg(db, "msgfee")
+	var ini Initializer
+	if err := ini.FromGenesis(opts, weave.GenesisParams{}, db); err != nil {
+		t.Fatalf("cannot load genesis: %s", err)
+	}
+}


### PR DESCRIPTION
When initializing `x/msgfee` extension from genesis, allow for no
configuration. Previously such setup would fail initialization. Now it
quietly ignores missing configuration.

fix #1082