### PR TITLE
x/escrow: `CreateMsg.Source` is now required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD
 
+Breaking changes
+
+- `x/escrow`: `CreateMsg.Source` is no longer optional and is now required.
 
 ## 0.24.1
 
@@ -25,6 +28,7 @@
     new index implementation.
 
 Breaking changes
+
 - `orm.Index` is an interface now to allow multiple implementations. The new
   interface is a subset of the old structure, simplified and updated to support
   lazy loading:

--- a/docs/proto/index.html
+++ b/docs/proto/index.html
@@ -4485,7 +4485,7 @@ distributed to. Must be at least one. </p></td>
 
       
         <h3 id="escrow.CreateMsg">CreateMsg</h3>
-        <p>CreateMsg is a request to create an Escrow with some tokens.</p><p>If source is not defined, it defaults to the first signer</p><p>The rest must be defined</p>
+        <p>CreateMsg is a request to create an Escrow with some tokens.</p><p>Message must be authorized by the source.</p>
 
         
           <table class="field-table">
@@ -4621,7 +4621,7 @@ expired: [timeout, infinity) </p></td>
         
       
         <h3 id="escrow.ReleaseMsg">ReleaseMsg</h3>
-        <p>ReleaseMsg releases the content to the destination.</p><p>Must be authorized by source or arbiter.</p><p>If amount not provided, defaults to entire escrow,</p><p>May be a subset of the current balance.</p>
+        <p>ReleaseMsg releases the content to the destination.</p><p>Message must be authorized by the source or arbiter.</p><p>If amount not provided, defaults to entire escrow, May be a subset of the</p><p>current balance.</p>
 
         
           <table class="field-table">

--- a/spec/gogo/x/escrow/codec.proto
+++ b/spec/gogo/x/escrow/codec.proto
@@ -30,8 +30,7 @@ message Escrow {
 }
 
 // CreateMsg is a request to create an Escrow with some tokens.
-// If source is not defined, it defaults to the first signer
-// The rest must be defined
+// Message must be authorized by the source.
 message CreateMsg {
   weave.Metadata metadata = 1;
   bytes source = 2 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
@@ -46,9 +45,9 @@ message CreateMsg {
 }
 
 // ReleaseMsg releases the content to the destination.
-// Must be authorized by source or arbiter.
-// If amount not provided, defaults to entire escrow,
-// May be a subset of the current balance.
+// Message must be authorized by the source or arbiter.
+// If amount not provided, defaults to entire escrow, May be a subset of the
+// current balance.
 message ReleaseMsg {
   weave.Metadata metadata = 1;
   bytes escrow_id = 2;

--- a/spec/proto/x/escrow/codec.proto
+++ b/spec/proto/x/escrow/codec.proto
@@ -27,8 +27,7 @@ message Escrow {
 }
 
 // CreateMsg is a request to create an Escrow with some tokens.
-// If source is not defined, it defaults to the first signer
-// The rest must be defined
+// Message must be authorized by the source.
 message CreateMsg {
   weave.Metadata metadata = 1;
   bytes source = 2 ;
@@ -43,9 +42,9 @@ message CreateMsg {
 }
 
 // ReleaseMsg releases the content to the destination.
-// Must be authorized by source or arbiter.
-// If amount not provided, defaults to entire escrow,
-// May be a subset of the current balance.
+// Message must be authorized by the source or arbiter.
+// If amount not provided, defaults to entire escrow, May be a subset of the
+// current balance.
 message ReleaseMsg {
   weave.Metadata metadata = 1;
   bytes escrow_id = 2;

--- a/x/escrow/codec.pb.go
+++ b/x/escrow/codec.pb.go
@@ -131,8 +131,7 @@ func (m *Escrow) GetAddress() github_com_iov_one_weave.Address {
 }
 
 // CreateMsg is a request to create an Escrow with some tokens.
-// If source is not defined, it defaults to the first signer
-// The rest must be defined
+// Message must be authorized by the source.
 type CreateMsg struct {
 	Metadata    *weave.Metadata                  `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	Source      github_com_iov_one_weave.Address `protobuf:"bytes,2,opt,name=source,proto3,casttype=github.com/iov-one/weave.Address" json:"source,omitempty"`
@@ -229,9 +228,9 @@ func (m *CreateMsg) GetMemo() string {
 }
 
 // ReleaseMsg releases the content to the destination.
-// Must be authorized by source or arbiter.
-// If amount not provided, defaults to entire escrow,
-// May be a subset of the current balance.
+// Message must be authorized by the source or arbiter.
+// If amount not provided, defaults to entire escrow, May be a subset of the
+// current balance.
 type ReleaseMsg struct {
 	Metadata *weave.Metadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	EscrowId []byte          `protobuf:"bytes,2,opt,name=escrow_id,json=escrowId,proto3" json:"escrow_id,omitempty"`

--- a/x/escrow/codec.proto
+++ b/x/escrow/codec.proto
@@ -30,8 +30,7 @@ message Escrow {
 }
 
 // CreateMsg is a request to create an Escrow with some tokens.
-// If source is not defined, it defaults to the first signer
-// The rest must be defined
+// Message must be authorized by the source.
 message CreateMsg {
   weave.Metadata metadata = 1;
   bytes source = 2 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
@@ -46,9 +45,9 @@ message CreateMsg {
 }
 
 // ReleaseMsg releases the content to the destination.
-// Must be authorized by source or arbiter.
-// If amount not provided, defaults to entire escrow,
-// May be a subset of the current balance.
+// Message must be authorized by the source or arbiter.
+// If amount not provided, defaults to entire escrow, May be a subset of the
+// current balance.
 message ReleaseMsg {
   weave.Metadata metadata = 1;
   bytes escrow_id = 2;

--- a/x/escrow/handler.go
+++ b/x/escrow/handler.go
@@ -66,12 +66,6 @@ func (h CreateEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore, tx wea
 		return nil, err
 	}
 
-	// apply a default for source
-	source := msg.Source
-	if source == nil {
-		source = x.AnySigner(ctx, h.auth).Address()
-	}
-
 	key, err := escrowSeq.NextVal(db)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot acquire key")
@@ -80,7 +74,7 @@ func (h CreateEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore, tx wea
 	// create an escrow object
 	escrow := &Escrow{
 		Metadata:    &weave.Metadata{},
-		Source:      source,
+		Source:      msg.Source,
 		Arbiter:     msg.Arbiter,
 		Destination: msg.Destination,
 		Timeout:     msg.Timeout,

--- a/x/escrow/handler.go
+++ b/x/escrow/handler.go
@@ -104,18 +104,12 @@ func (h CreateEscrowHandler) validate(ctx weave.Context, db weave.KVStore, tx we
 	if err := weave.LoadMsg(tx, &msg); err != nil {
 		return nil, errors.Wrap(err, "load msg")
 	}
-
 	if weave.IsExpired(ctx, msg.Timeout) {
 		return nil, errors.Wrap(errors.ErrInput, "timeout in the past")
 	}
-
-	// Source must authorize this (if not set, defaults to AnySigner).
-	if msg.Source != nil {
-		if !h.auth.HasAddress(ctx, msg.Source) {
-			return nil, errors.ErrUnauthorized
-		}
+	if !h.auth.HasAddress(ctx, msg.Source) {
+		return nil, errors.ErrUnauthorized
 	}
-
 	return &msg, nil
 }
 

--- a/x/escrow/handler_test.go
+++ b/x/escrow/handler_test.go
@@ -190,9 +190,8 @@ func TestHandler(t *testing.T) {
 			all,
 			nil, // no prep, just one action
 			action{
-				perms: []weave.Condition{a},
-				// defaults to source!
-				msg:       NewCreateMsg(nil, b.Address(), c.Address(), all, weave.AsUnixTime(blockNow.Add(-2*time.Hour)), ""),
+				perms:     []weave.Condition{a},
+				msg:       NewCreateMsg(a.Address(), b.Address(), c.Address(), all, weave.AsUnixTime(blockNow.Add(-2*time.Hour)), ""),
 				blockTime: Timeout.Time().Add(-time.Hour),
 			},
 			errors.ErrInput,

--- a/x/escrow/msg.go
+++ b/x/escrow/msg.go
@@ -49,6 +49,7 @@ func (m *CreateMsg) Validate() error {
 	var errs error
 	errs = errors.AppendField(errs, "Metadata", m.Metadata.Validate())
 	errs = errors.AppendField(errs, "Arbiter", m.Arbiter.Validate())
+	errs = errors.AppendField(errs, "Source", m.Source.Validate())
 	errs = errors.AppendField(errs, "Destination", m.Destination.Validate())
 	if m.Timeout == 0 {
 		// Zero timeout is a valid value that dates to 1970-01-01. We

--- a/x/escrow/msg_test.go
+++ b/x/escrow/msg_test.go
@@ -57,7 +57,7 @@ func TestCreateMsg(t *testing.T) {
 			},
 			nil,
 		},
-		"missing source okay, dups okay": {
+		"source is required": {
 			&CreateMsg{
 				Metadata:    &weave.Metadata{Schema: 1},
 				Arbiter:     c.Address(),
@@ -66,7 +66,7 @@ func TestCreateMsg(t *testing.T) {
 				Timeout:     timeout,
 				Memo:        "some string",
 			},
-			nil,
+			errors.ErrEmpty,
 		},
 		"negative amount": {
 			&CreateMsg{


### PR DESCRIPTION
`escrow.CreateMsg.Source` is no longer optional and is now required.
This is a backward incompatible security fix.

resolve #1086