### PR TITLE
`x/sigs`: `BumpSequenceMsg.User` is now required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD
 
+Breaking changes
+
+- `x/sigs`: `BumpSequenceMsg.User` is now required and cannot be empty.
 
 ## 0.24.1
 

--- a/x/sigs/handler_test.go
+++ b/x/sigs/handler_test.go
@@ -38,29 +38,32 @@ func TestBumpSequence(t *testing.T) {
 				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key2, Sequence: 9},
 			},
 			Signers: []weave.Condition{key1.Condition()},
-			Msg:     BumpSequenceMsg{Metadata: &weave.Metadata{Schema: 1}, Increment: 2},
+			Msg: BumpSequenceMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
+				Increment: 2,
+				User:      key1.Address(),
+			},
 			WantSequences: []*UserData{
 				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key1, Sequence: 2},
 				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key2, Sequence: 9},
 			},
 		},
-		"incrementing sequence of the main signer": {
-			InitData: []*UserData{
-				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key1, Sequence: 1},
-				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key2, Sequence: 9},
+		"transaction must be signed by the user": {
+			Msg: BumpSequenceMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
+				Increment: 1,
+				User:      key2.Address(),
 			},
-			Signers: []weave.Condition{
-				key2.Condition(), // Main signer.
-				key1.Condition(),
-			},
-			Msg: BumpSequenceMsg{Metadata: &weave.Metadata{Schema: 1}, Increment: 2},
-			WantSequences: []*UserData{
-				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key1, Sequence: 1},
-				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key2, Sequence: 10},
-			},
+			Signers:        []weave.Condition{key1.Condition()},
+			WantCheckErr:   errors.ErrUnauthorized,
+			WantDeliverErr: errors.ErrUnauthorized,
 		},
 		"transaction with a missing signature is rejected": {
-			Msg:            BumpSequenceMsg{Metadata: &weave.Metadata{Schema: 1}, Increment: 1},
+			Msg: BumpSequenceMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
+				Increment: 1,
+				User:      key1.Address(),
+			},
 			Signers:        nil,
 			WantCheckErr:   errors.ErrUnauthorized,
 			WantDeliverErr: errors.ErrUnauthorized,
@@ -69,7 +72,11 @@ func TestBumpSequence(t *testing.T) {
 			InitData: []*UserData{
 				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key1, Sequence: 1},
 			},
-			Msg:            BumpSequenceMsg{Metadata: &weave.Metadata{Schema: 1}, Increment: 0},
+			Msg: BumpSequenceMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
+				Increment: 0,
+				User:      key1.Address(),
+			},
 			WantCheckErr:   errors.ErrMsg,
 			WantDeliverErr: errors.ErrMsg,
 		},
@@ -77,8 +84,12 @@ func TestBumpSequence(t *testing.T) {
 			InitData: []*UserData{
 				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key2, Sequence: 4},
 			},
-			Signers:        []weave.Condition{key1.Condition()},
-			Msg:            BumpSequenceMsg{Metadata: &weave.Metadata{Schema: 1}, Increment: 421},
+			Signers: []weave.Condition{key1.Condition()},
+			Msg: BumpSequenceMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
+				Increment: 421,
+				User:      key1.Address(),
+			},
 			WantCheckErr:   errors.ErrNotFound,
 			WantDeliverErr: errors.ErrNotFound,
 		},
@@ -86,8 +97,12 @@ func TestBumpSequence(t *testing.T) {
 			InitData: []*UserData{
 				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key1, Sequence: 4},
 			},
-			Signers:        []weave.Condition{key1.Condition()},
-			Msg:            BumpSequenceMsg{Metadata: &weave.Metadata{Schema: 1}, Increment: 1001},
+			Signers: []weave.Condition{key1.Condition()},
+			Msg: BumpSequenceMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
+				Increment: 1001,
+				User:      key1.Address(),
+			},
 			WantCheckErr:   errors.ErrMsg,
 			WantDeliverErr: errors.ErrMsg,
 		},
@@ -96,7 +111,11 @@ func TestBumpSequence(t *testing.T) {
 				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key1, Sequence: 4},
 			},
 			Signers: []weave.Condition{key1.Condition()},
-			Msg:     BumpSequenceMsg{Metadata: &weave.Metadata{Schema: 1}, Increment: 1000},
+			Msg: BumpSequenceMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
+				Increment: 1000,
+				User:      key1.Address(),
+			},
 			WantSequences: []*UserData{
 				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key1, Sequence: 1003},
 			},
@@ -106,7 +125,11 @@ func TestBumpSequence(t *testing.T) {
 				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key1, Sequence: math.MaxInt64 - 20},
 			},
 			Signers: []weave.Condition{key1.Condition()},
-			Msg:     BumpSequenceMsg{Metadata: &weave.Metadata{Schema: 1}, Increment: 20},
+			Msg: BumpSequenceMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
+				Increment: 20,
+				User:      key1.Address(),
+			},
 			WantSequences: []*UserData{
 				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key1, Sequence: math.MaxInt64 - 1},
 			},
@@ -115,8 +138,12 @@ func TestBumpSequence(t *testing.T) {
 			InitData: []*UserData{
 				{Metadata: &weave.Metadata{Schema: 1}, Pubkey: key1, Sequence: math.MaxInt64 - 20},
 			},
-			Signers:        []weave.Condition{key1.Condition()},
-			Msg:            BumpSequenceMsg{Metadata: &weave.Metadata{Schema: 1}, Increment: 21},
+			Signers: []weave.Condition{key1.Condition()},
+			Msg: BumpSequenceMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
+				Increment: 21,
+				User:      key1.Address(),
+			},
 			WantCheckErr:   errors.ErrOverflow,
 			WantDeliverErr: errors.ErrOverflow,
 		},

--- a/x/sigs/msg.go
+++ b/x/sigs/msg.go
@@ -20,11 +20,7 @@ var _ weave.Msg = (*BumpSequenceMsg)(nil)
 func (msg *BumpSequenceMsg) Validate() error {
 	var errs error
 	errs = errors.AppendField(errs, "Metadata", msg.Metadata.Validate())
-
-	// User field is optional.
-	if len(msg.User) != 0 {
-		errs = errors.AppendField(errs, "User", msg.User.Validate())
-	}
+	errs = errors.AppendField(errs, "User", msg.User.Validate())
 	if msg.Increment < minSequenceIncrement {
 		errs = errors.Append(errs,
 			errors.Field("Increment", errors.ErrMsg, "increment must be at least %d", minSequenceIncrement))

--- a/x/sigs/msg_test.go
+++ b/x/sigs/msg_test.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/weavetest"
 )
 
-func TextBumpSequenceValidate(t *testing.T) {
+func TestBumpSequenceValidate(t *testing.T) {
 	cases := map[string]struct {
 		Msg     weave.Msg
 		WantErr *errors.Error
@@ -16,13 +17,22 @@ func TextBumpSequenceValidate(t *testing.T) {
 			Msg: &BumpSequenceMsg{
 				Metadata:  &weave.Metadata{Schema: 1},
 				Increment: 1,
+				User:      weavetest.NewCondition().Address(),
 			},
 			WantErr: nil,
+		},
+		"missing user": {
+			Msg: &BumpSequenceMsg{
+				Metadata:  &weave.Metadata{Schema: 1},
+				Increment: 1,
+			},
+			WantErr: errors.ErrEmpty,
 		},
 		"missing metadata": {
 			Msg: &BumpSequenceMsg{
 				Metadata:  nil,
 				Increment: 1,
+				User:      weavetest.NewCondition().Address(),
 			},
 			WantErr: errors.ErrMetadata,
 		},
@@ -30,6 +40,7 @@ func TextBumpSequenceValidate(t *testing.T) {
 			Msg: &BumpSequenceMsg{
 				Metadata:  &weave.Metadata{Schema: 1},
 				Increment: 0,
+				User:      weavetest.NewCondition().Address(),
 			},
 			WantErr: errors.ErrMsg,
 		},
@@ -37,6 +48,7 @@ func TextBumpSequenceValidate(t *testing.T) {
 			Msg: &BumpSequenceMsg{
 				Metadata:  &weave.Metadata{Schema: 1},
 				Increment: 1001,
+				User:      weavetest.NewCondition().Address(),
 			},
 			WantErr: errors.ErrMsg,
 		},


### PR DESCRIPTION
`sigs.BumpSequenceMsg.User` is now required and cannot be empty. This is
a backward incompatible security fix.

resolve #1087