### PR TITLE
fix native index tests

### DIFF
--- a/orm/index.go
+++ b/orm/index.go
@@ -538,7 +538,7 @@ func (ix *nativeIndex) Update(db weave.KVStore, prev Object, next Object) error 
 			if err != nil {
 				return errors.Wrap(err, "build index key")
 			}
-			if err := db.Set(idxKey, nil); err != nil {
+			if err := db.Set(idxKey, []byte{}); err != nil {
 				return errors.Wrap(err, "db set")
 			}
 		}

--- a/orm/index_test.go
+++ b/orm/index_test.go
@@ -4,15 +4,13 @@ import (
 	"bytes"
 	stderrors "errors"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"reflect"
 	"testing"
 
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/errors"
 	"github.com/iov-one/weave/store"
-	"github.com/iov-one/weave/store/iavl"
+	"github.com/iov-one/weave/weavetest"
 	"github.com/iov-one/weave/weavetest/assert"
 )
 
@@ -618,7 +616,7 @@ func testIndexImplementation(t *testing.T, newIdx func(MultiKeyIndexer) Index) {
 			// Do not use MemStore because its implementation is
 			// not fully compatible with a real backend.
 			// db := store.MemStore()
-			store, cleanup := commitKVStore(t)
+			store, cleanup := weavetest.CommitKVStore(t)
 			defer cleanup()
 
 			db := store.CacheWrap()
@@ -654,16 +652,6 @@ func testIndexImplementation(t *testing.T, newIdx func(MultiKeyIndexer) Index) {
 			}
 		})
 	}
-}
-
-func commitKVStore(t testing.TB) (db weave.CommitKVStore, cleanup func()) {
-	dbpath, err := ioutil.TempDir("", "db")
-	if err != nil {
-		t.Fatalf("cannot create a temporary directory: %s", err)
-	}
-
-	db = iavl.NewCommitStore(dbpath, "db")
-	return db, func() { os.RemoveAll(dbpath) }
 }
 
 func iteratorKeys(it weave.Iterator) ([][]byte, error) {

--- a/weavetest/store.go
+++ b/weavetest/store.go
@@ -3,6 +3,8 @@ package weavetest
 import (
 	"io/ioutil"
 	"os"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/iov-one/weave"
@@ -14,7 +16,7 @@ import (
 // This implementation should be used instead of MemStore when you want the
 // exact same storage implementation as the production instance is using.
 func CommitKVStore(t testing.TB) (db weave.CommitKVStore, cleanup func()) {
-	dbpath, err := ioutil.TempDir("", t.Name())
+	dbpath, err := ioutil.TempDir("", asDirName(t.Name()))
 	if err != nil {
 		t.Fatalf("cannot create a temporary directory: %s", err)
 	}
@@ -22,3 +24,12 @@ func CommitKVStore(t testing.TB) (db weave.CommitKVStore, cleanup func()) {
 	db = iavl.NewCommitStore(dbpath, "db")
 	return db, func() { os.RemoveAll(dbpath) }
 }
+
+// asDirPath converts given string to a valid directory name. All invalid
+// characters are removed or replaced.
+func asDirName(s string) string {
+	s = invalidDirChar.ReplaceAllString(s, "_")
+	return strings.Trim(s, "_")
+}
+
+var invalidDirChar = regexp.MustCompile(`[^a-zA-Z0-9]+`)

--- a/weavetest/store.go
+++ b/weavetest/store.go
@@ -1,0 +1,24 @@
+package weavetest
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/store/iavl"
+)
+
+// CommitKVStore returns a store instance that is using a filesystem backend
+// engine to store the data.
+// This implementation should be used instead of MemStore when you want the
+// exact same storage implementation as the production instance is using.
+func CommitKVStore(t testing.TB) (db weave.CommitKVStore, cleanup func()) {
+	dbpath, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatalf("cannot create a temporary directory: %s", err)
+	}
+
+	db = iavl.NewCommitStore(dbpath, "db")
+	return db, func() { os.RemoveAll(dbpath) }
+}


### PR DESCRIPTION
When storing an index, do not use `nil` as value. `nil` is not accepted
by all backends.
Update tests to use hard drive backed storage instead of in memory
implementation to ensure the functionality works.

!nochangelog