### PR TITLE
Doc: Fix a quoted sentence in overview.rst

### DIFF
--- a/docs/design/overview.rst
+++ b/docs/design/overview.rst
@@ -43,8 +43,7 @@ tendermint daemon and the state machine that processes
 the transactions, something akin to wsgi as the interface
 between apache/nginx and a django application.
 
- There is an
-`in-depth reference <https://tendermint.readthedocs.io/en/master/app-development.html>`__
+There is an `in-depth reference <https://tendermint.readthedocs.io/en/master/app-development.html>`__
 to the ABCI protocol, but in short, an ABCI application
 is a state machine that responds to messages sent from one
 client (the tendermint consensus engine). It is run in


### PR DESCRIPTION
It seems the `There is an` was made into a quote by mistake, opened this PR to resolve it.