### PR TITLE
update protobuf messages documentation

### DIFF
--- a/docs/proto/index.html
+++ b/docs/proto/index.html
@@ -4179,7 +4179,11 @@ needed to make use of gconf.NewUpdateConfigurationHandler </p></td>
                   <td>payer</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>Payer represents an address that will pay the fee. A fee fund will be
+withdrawn from that account in order to process a transaction.
+Warning: This field is optional and when not set it will default to any
+signer. It is recommended to always explicitely set the value of this
+field, as the signer order is not guaranteed. </p></td>
                 </tr>
               
                 <tr>
@@ -5006,7 +5010,10 @@ expired: [timeout, infinity) </p></td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
                   <td><p>Author is an optional field to set the address of the author with a proposal. The author must sign the message.
-When not set it will default to the main signer. </p></td>
+The author of the created proposal.
+Warning: This field is optional and when not set it will default to any
+signer. It is recommended to always explicitely set the value of this
+field, as the signer order is not guaranteed. </p></td>
                 </tr>
               
             </tbody>
@@ -5705,8 +5712,11 @@ with weight=0. </p></td>
                   <td>voter</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p>voter address is an optional field. When not set the main signer will be used as default. The voter address
-must be included in the electorate for a valid vote. </p></td>
+                  <td><p>The address of the voter. The voter address must be part of the electorate
+in order to be allowed to vote.
+Warning: This field is optional and when not set it will default to any
+signer. It is recommended to always explicitely set the value of this
+field, as the signer order is not guaranteed. </p></td>
                 </tr>
               
                 <tr>

--- a/spec/gogo/x/cash/codec.proto
+++ b/spec/gogo/x/cash/codec.proto
@@ -32,6 +32,11 @@ message SendMsg {
 // FeeInfo records who pays what fees to have this
 // message processed
 message FeeInfo {
+  // Payer represents an address that will pay the fee. A fee fund will be
+  // withdrawn from that account in order to process a transaction.
+  // Warning: This field is optional and when not set it will default to any
+  // signer. It is recommended to always explicitely set the value of this
+  // field, as the signer order is not guaranteed.
   bytes payer = 2 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
   coin.Coin fees = 3;
 }

--- a/spec/gogo/x/gov/codec.proto
+++ b/spec/gogo/x/gov/codec.proto
@@ -199,7 +199,10 @@ message CreateProposalMsg {
   // Unix timestamp when the proposal starts. Must be in the future.
   int64 start_time = 6 [(gogoproto.casttype) = "github.com/iov-one/weave.UnixTime"];
   // Author is an optional field to set the address of the author with a proposal. The author must sign the message.
-  // When not set it will default to the main signer.
+  // The author of the created proposal.
+  // Warning: This field is optional and when not set it will default to any
+  // signer. It is recommended to always explicitely set the value of this
+  // field, as the signer order is not guaranteed.
   bytes author = 7 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
 }
 
@@ -223,8 +226,11 @@ message VoteMsg {
   weave.Metadata metadata = 1;
   // The unique id of the proposal.
   bytes proposal_id = 2 [(gogoproto.customname) = "ProposalID"];
-  // voter address is an optional field. When not set the main signer will be used as default. The voter address
-  // must be included in the electorate for a valid vote.
+  // The address of the voter. The voter address must be part of the electorate
+  // in order to be allowed to vote.
+  // Warning: This field is optional and when not set it will default to any
+  // signer. It is recommended to always explicitely set the value of this
+  // field, as the signer order is not guaranteed.
   bytes voter = 3 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
   // Option for the vote. Must be Yes, No or Abstain for a valid vote.
   VoteOption selected = 4;

--- a/spec/proto/x/cash/codec.proto
+++ b/spec/proto/x/cash/codec.proto
@@ -31,6 +31,11 @@ message SendMsg {
 // FeeInfo records who pays what fees to have this
 // message processed
 message FeeInfo {
+  // Payer represents an address that will pay the fee. A fee fund will be
+  // withdrawn from that account in order to process a transaction.
+  // Warning: This field is optional and when not set it will default to any
+  // signer. It is recommended to always explicitely set the value of this
+  // field, as the signer order is not guaranteed.
   bytes payer = 2 ;
   coin.Coin fees = 3;
 }

--- a/spec/proto/x/gov/codec.proto
+++ b/spec/proto/x/gov/codec.proto
@@ -198,7 +198,10 @@ message CreateProposalMsg {
   // Unix timestamp when the proposal starts. Must be in the future.
   int64 start_time = 6 ;
   // Author is an optional field to set the address of the author with a proposal. The author must sign the message.
-  // When not set it will default to the main signer.
+  // The author of the created proposal.
+  // Warning: This field is optional and when not set it will default to any
+  // signer. It is recommended to always explicitely set the value of this
+  // field, as the signer order is not guaranteed.
   bytes author = 7 ;
 }
 
@@ -222,8 +225,11 @@ message VoteMsg {
   weave.Metadata metadata = 1;
   // The unique id of the proposal.
   bytes proposal_id = 2 ;
-  // voter address is an optional field. When not set the main signer will be used as default. The voter address
-  // must be included in the electorate for a valid vote.
+  // The address of the voter. The voter address must be part of the electorate
+  // in order to be allowed to vote.
+  // Warning: This field is optional and when not set it will default to any
+  // signer. It is recommended to always explicitely set the value of this
+  // field, as the signer order is not guaranteed.
   bytes voter = 3 ;
   // Option for the vote. Must be Yes, No or Abstain for a valid vote.
   VoteOption selected = 4;

--- a/x/cash/codec.pb.go
+++ b/x/cash/codec.pb.go
@@ -173,6 +173,11 @@ func (m *SendMsg) GetRef() []byte {
 // FeeInfo records who pays what fees to have this
 // message processed
 type FeeInfo struct {
+	// Payer represents an address that will pay the fee. A fee fund will be
+	// withdrawn from that account in order to process a transaction.
+	// Warning: This field is optional and when not set it will default to any
+	// signer. It is recommended to always explicitely set the value of this
+	// field, as the signer order is not guaranteed.
 	Payer github_com_iov_one_weave.Address `protobuf:"bytes,2,opt,name=payer,proto3,casttype=github.com/iov-one/weave.Address" json:"payer,omitempty"`
 	Fees  *coin.Coin                       `protobuf:"bytes,3,opt,name=fees,proto3" json:"fees,omitempty"`
 }

--- a/x/cash/codec.proto
+++ b/x/cash/codec.proto
@@ -32,6 +32,11 @@ message SendMsg {
 // FeeInfo records who pays what fees to have this
 // message processed
 message FeeInfo {
+  // Payer represents an address that will pay the fee. A fee fund will be
+  // withdrawn from that account in order to process a transaction.
+  // Warning: This field is optional and when not set it will default to any
+  // signer. It is recommended to always explicitely set the value of this
+  // field, as the signer order is not guaranteed.
   bytes payer = 2 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
   coin.Coin fees = 3;
 }

--- a/x/gov/codec.pb.go
+++ b/x/gov/codec.pb.go
@@ -918,7 +918,10 @@ type CreateProposalMsg struct {
 	// Unix timestamp when the proposal starts. Must be in the future.
 	StartTime github_com_iov_one_weave.UnixTime `protobuf:"varint,6,opt,name=start_time,json=startTime,proto3,casttype=github.com/iov-one/weave.UnixTime" json:"start_time,omitempty"`
 	// Author is an optional field to set the address of the author with a proposal. The author must sign the message.
-	// When not set it will default to the main signer.
+	// The author of the created proposal.
+	// Warning: This field is optional and when not set it will default to any
+	// signer. It is recommended to always explicitely set the value of this
+	// field, as the signer order is not guaranteed.
 	Author github_com_iov_one_weave.Address `protobuf:"bytes,7,opt,name=author,proto3,casttype=github.com/iov-one/weave.Address" json:"author,omitempty"`
 }
 
@@ -1063,8 +1066,11 @@ type VoteMsg struct {
 	Metadata *weave.Metadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// The unique id of the proposal.
 	ProposalID []byte `protobuf:"bytes,2,opt,name=proposal_id,json=proposalId,proto3" json:"proposal_id,omitempty"`
-	// voter address is an optional field. When not set the main signer will be used as default. The voter address
-	// must be included in the electorate for a valid vote.
+	// The address of the voter. The voter address must be part of the electorate
+	// in order to be allowed to vote.
+	// Warning: This field is optional and when not set it will default to any
+	// signer. It is recommended to always explicitely set the value of this
+	// field, as the signer order is not guaranteed.
 	Voter github_com_iov_one_weave.Address `protobuf:"bytes,3,opt,name=voter,proto3,casttype=github.com/iov-one/weave.Address" json:"voter,omitempty"`
 	// Option for the vote. Must be Yes, No or Abstain for a valid vote.
 	Selected VoteOption `protobuf:"varint,4,opt,name=selected,proto3,enum=gov.VoteOption" json:"selected,omitempty"`

--- a/x/gov/codec.proto
+++ b/x/gov/codec.proto
@@ -199,7 +199,10 @@ message CreateProposalMsg {
   // Unix timestamp when the proposal starts. Must be in the future.
   int64 start_time = 6 [(gogoproto.casttype) = "github.com/iov-one/weave.UnixTime"];
   // Author is an optional field to set the address of the author with a proposal. The author must sign the message.
-  // When not set it will default to the main signer.
+  // The author of the created proposal.
+  // Warning: This field is optional and when not set it will default to any
+  // signer. It is recommended to always explicitely set the value of this
+  // field, as the signer order is not guaranteed.
   bytes author = 7 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
 }
 
@@ -223,8 +226,11 @@ message VoteMsg {
   weave.Metadata metadata = 1;
   // The unique id of the proposal.
   bytes proposal_id = 2 [(gogoproto.customname) = "ProposalID"];
-  // voter address is an optional field. When not set the main signer will be used as default. The voter address
-  // must be included in the electorate for a valid vote.
+  // The address of the voter. The voter address must be part of the electorate
+  // in order to be allowed to vote.
+  // Warning: This field is optional and when not set it will default to any
+  // signer. It is recommended to always explicitely set the value of this
+  // field, as the signer order is not guaranteed.
   bytes voter = 3 [(gogoproto.casttype) = "github.com/iov-one/weave.Address"];
   // Option for the vote. Must be Yes, No or Abstain for a valid vote.
   VoteOption selected = 4;


### PR DESCRIPTION
For each affected by the `x.AnySigner` function message add a warning
explanation why a value should be always explicitly specified.

!nochangelog