### PR TITLE
x/txfee: update behaviour when configuration does not exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,8 @@ os:
 - linux
 
 go:
-# reason for bumping 1.11.x to 1.11.4+ is this: https://github.com/golang/go/issues/30446#issuecomment-468038052
-- "1.11.4"
-- "1.12"
+- "1.11.13"
+- "1.12.14"
 
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD
 
+Breaking changes
+
+- `x/txfee` extension decorator is a no-op wrapper when configuration for
+  `x/txfee` does not exist.
 
 ## 0.25.0
 

--- a/x/txfee/decorator.go
+++ b/x/txfee/decorator.go
@@ -35,7 +35,7 @@ func (d *Decorator) Check(ctx weave.Context, store weave.KVStore, tx weave.Tx, n
 	if err != nil {
 		if errors.ErrNotFound.Is(err) {
 			// If configuration does not exist, this decorator is no-op.
-			return res, err
+			return res, nil
 		}
 		return nil, errors.Wrap(err, "cannot compute transaction size fee")
 	}
@@ -59,7 +59,7 @@ func (d *Decorator) Deliver(ctx weave.Context, store weave.KVStore, tx weave.Tx,
 	if err != nil {
 		if errors.ErrNotFound.Is(err) {
 			// If configuration does not exist, this decorator is no-op.
-			return res, err
+			return res, nil
 		}
 		return nil, errors.Wrap(err, "cannot compute transaction size fee")
 	}

--- a/x/txfee/decorator_test.go
+++ b/x/txfee/decorator_test.go
@@ -149,3 +149,30 @@ func asCoin(t testing.TB, s string) coin.Coin {
 	}
 	return c
 }
+
+func TestDecoratorWithoutConfiguration(t *testing.T) {
+	decorator := NewDecorator()
+	db := store.MemStore()
+	migration.MustInitPkg(db, "txfee")
+
+	tx := &txMock{Raw: []byte{1, 2, 3, 4, 5}}
+	handler := &weavetest.Handler{}
+
+	// Without configuration, decorator should be a no-op wrapper.
+
+	cres, err := decorator.Check(nil, db, tx, handler)
+	if err != nil {
+		t.Fatalf("unexpected check error: %v", err)
+	}
+	if !cres.RequiredFee.IsZero() {
+		t.Fatalf("unexpected check fee: %v", cres.RequiredFee)
+	}
+
+	dres, err := decorator.Deliver(nil, db, tx, handler)
+	if err != nil {
+		t.Fatalf("unexpected deliver error: %v", err)
+	}
+	if !dres.RequiredFee.IsZero() {
+		t.Fatalf("unexpected deliver fee: %v", dres.RequiredFee)
+	}
+}


### PR DESCRIPTION
When configuration entity was not created for the `x/txfee` extension,
middleware provided by `x/txfee` is a no-op. This behaviour allows for
backward compatibility with an existing blockchain and easy introduction
of the middleware.

@davepuchyr I hope this solves the issue that you have with running a new network.