### PR TITLE
include proposal ID in relivery log

### DIFF
--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -211,7 +211,10 @@ func (h TallyHandler) Deliver(ctx weave.Context, db weave.KVStore, tx weave.Tx) 
 	}()
 
 	if common.Result != Proposal_Accepted {
-		return &weave.DeliverResult{Log: "Proposal not accepted"}, nil
+		res := &weave.DeliverResult{
+			Log: fmt.Sprintf("Proposal %q not accepted", msg.ProposalID),
+		}
+		return res, nil
 	}
 
 	// we only execute the store options upon success

--- a/x/gov/handler_test.go
+++ b/x/gov/handler_test.go
@@ -2,6 +2,7 @@ package gov
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"reflect"
 	"strings"
@@ -875,7 +876,7 @@ func TestTally(t *testing.T) {
 			},
 			ExpResult:         Proposal_Rejected,
 			ExpExecutorResult: Proposal_NotRun,
-			WantDeliverLog:    "Proposal not accepted",
+			WantDeliverLog:    fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 			PostChecks: func(t *testing.T, db weave.KVStore) {
 				obj, err := NewResolutionBucket().Get(db, weavetest.SequenceID(1))
 				assert.Nil(t, obj)
@@ -893,7 +894,7 @@ func TestTally(t *testing.T) {
 			},
 			ExpResult:         Proposal_Rejected,
 			ExpExecutorResult: Proposal_NotRun,
-			WantDeliverLog:    "Proposal not accepted",
+			WantDeliverLog:    fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 		"Rejected without voters": {
 			Src: tallySetup{
@@ -902,7 +903,7 @@ func TestTally(t *testing.T) {
 			},
 			ExpResult:         Proposal_Rejected,
 			ExpExecutorResult: Proposal_NotRun,
-			WantDeliverLog:    "Proposal not accepted",
+			WantDeliverLog:    fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 		"Rejected without enough votes: 2/3": {
 			Src: tallySetup{
@@ -912,7 +913,7 @@ func TestTally(t *testing.T) {
 			},
 			ExpResult:         Proposal_Rejected,
 			ExpExecutorResult: Proposal_NotRun,
-			WantDeliverLog:    "Proposal not accepted",
+			WantDeliverLog:    fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 		"Accepted with quorum and acceptance thresholds exceeded: 5/9": {
 			Src: tallySetup{
@@ -934,7 +935,7 @@ func TestTally(t *testing.T) {
 			},
 			ExpResult:         Proposal_Rejected,
 			ExpExecutorResult: Proposal_NotRun,
-			WantDeliverLog:    "Proposal not accepted",
+			WantDeliverLog:    fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 		"Accepted with quorum and acceptance thresholds exceeded: 4/9": {
 			Src: tallySetup{
@@ -958,7 +959,7 @@ func TestTally(t *testing.T) {
 			},
 			ExpResult:         Proposal_Rejected,
 			ExpExecutorResult: Proposal_NotRun,
-			WantDeliverLog:    "Proposal not accepted",
+			WantDeliverLog:    fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 		"Rejected by single No when unanimity required": {
 			Src: tallySetup{
@@ -970,7 +971,7 @@ func TestTally(t *testing.T) {
 			},
 			ExpResult:         Proposal_Rejected,
 			ExpExecutorResult: Proposal_NotRun,
-			WantDeliverLog:    "Proposal not accepted",
+			WantDeliverLog:    fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 		"Rejected by missing vote when all required": {
 			Src: tallySetup{
@@ -981,7 +982,7 @@ func TestTally(t *testing.T) {
 			},
 			ExpResult:         Proposal_Rejected,
 			ExpExecutorResult: Proposal_NotRun,
-			WantDeliverLog:    "Proposal not accepted",
+			WantDeliverLog:    fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 		"Accept on quorum fraction 1/1": {
 			Src: tallySetup{
@@ -1030,7 +1031,7 @@ func TestTally(t *testing.T) {
 			},
 			ExpResult:         Proposal_Rejected,
 			ExpExecutorResult: Proposal_NotRun,
-			WantDeliverLog:    "Proposal not accepted",
+			WantDeliverLog:    fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 		"Accepted with acceptance thresholds < quorum": {
 			Src: tallySetup{
@@ -1079,7 +1080,7 @@ func TestTally(t *testing.T) {
 			},
 			ExpResult:         Proposal_Rejected,
 			ExpExecutorResult: Proposal_NotRun,
-			WantDeliverLog:    "Proposal not accepted",
+			WantDeliverLog:    fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 		"Updates latest electorate on success": {
 			Init: func(t *testing.T, db weave.KVStore) {
@@ -1197,7 +1198,7 @@ func TestTally(t *testing.T) {
 					t.Errorf("expected %v but got %v", exp, got)
 				}
 			},
-			WantDeliverLog: "Proposal not accepted",
+			WantDeliverLog: fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 		"Fails on second tally": {
 			Mods: func(_ weave.Context, p *Proposal) {
@@ -1210,7 +1211,7 @@ func TestTally(t *testing.T) {
 			WantDeliverErr:    errors.ErrState,
 			ExpResult:         Proposal_Accepted,
 			ExpExecutorResult: Proposal_Success,
-			WantDeliverLog:    "Proposal not accepted",
+			WantDeliverLog:    fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 		"Fails on tally before end date": {
 			Mods: func(ctx weave.Context, p *Proposal) {
@@ -1222,7 +1223,7 @@ func TestTally(t *testing.T) {
 			},
 			WantDeliverErr: errors.ErrState,
 			ExpResult:      Proposal_Undefined,
-			WantDeliverLog: "Proposal not accepted",
+			WantDeliverLog: fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 		"Fails on tally at end date": {
 			Mods: func(ctx weave.Context, p *Proposal) {
@@ -1234,7 +1235,7 @@ func TestTally(t *testing.T) {
 			},
 			WantDeliverErr: errors.ErrState,
 			ExpResult:      Proposal_Undefined,
-			WantDeliverLog: "Proposal not accepted",
+			WantDeliverLog: fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 		"Fails on withdrawn proposal": {
 			Mods: func(ctx weave.Context, p *Proposal) {
@@ -1246,7 +1247,7 @@ func TestTally(t *testing.T) {
 			},
 			WantDeliverErr: errors.ErrState,
 			ExpResult:      Proposal_Undefined,
-			WantDeliverLog: "Proposal not accepted",
+			WantDeliverLog: fmt.Sprintf("Proposal %q not accepted", weavetest.SequenceID(1)),
 		},
 	}
 	rt := app.NewRouter()


### PR DESCRIPTION
When a proposal failed to execute, include that proposal ID for the ease
of tracking.

@davepuchyr notice that the ID is a binary data, not a numeric value. This is because this binary key might contain encoded number, but that does not have to be always true. Is this acceptable?

!nochangelog