### PR TITLE
update account transfer and deletion rules

### DIFF
--- a/cmd/bnsd/x/account/handler.go
+++ b/cmd/bnsd/x/account/handler.go
@@ -269,6 +269,9 @@ func (h *transferDomainHandler) validate(ctx weave.Context, db weave.KVStore, tx
 	if err := h.domains.One(db, []byte(msg.Domain), &domain); err != nil {
 		return nil, nil, errors.Wrap(err, "cannot get domain")
 	}
+	if !domain.HasSuperuser {
+		return nil, nil, errors.Wrap(errors.ErrState, "domain without a superuser cannot be transferred")
+	}
 	if !h.auth.HasAddress(ctx, domain.Admin) {
 		return nil, nil, errors.Wrap(errors.ErrUnauthorized, "only owner can transfer a domain")
 	}
@@ -474,6 +477,9 @@ func (h *deleteDomainHandler) validate(ctx weave.Context, db weave.KVStore, tx w
 	var domain Domain
 	if err := h.domains.One(db, []byte(msg.Domain), &domain); err != nil {
 		return nil, nil, errors.Wrap(err, "cannot get domain")
+	}
+	if !domain.HasSuperuser {
+		return nil, nil, errors.Wrap(errors.ErrState, "domain without a superuser cannot be deleted")
 	}
 	if !h.auth.HasAddress(ctx, domain.Admin) {
 		return nil, nil, errors.Wrap(errors.ErrUnauthorized, "only admin can delete a domain")

--- a/cmd/bnsd/x/account/handler_test.go
+++ b/cmd/bnsd/x/account/handler_test.go
@@ -1067,6 +1067,37 @@ func TestUseCases(t *testing.T) {
 				assertAccounts(t, db, "wunderland", nil)
 			},
 		},
+		"domain without a superuser cannot be deleted": {
+			Requests: []Request{
+				{
+					Now:        now,
+					Conditions: []weave.Condition{adminCond},
+					Tx: &weavetest.Tx{
+						Msg: &RegisterDomainMsg{
+							Metadata:     &weave.Metadata{Schema: 1},
+							Domain:       "wunderland",
+							Admin:        adminCond.Address(),
+							HasSuperuser: false,
+							AccountRenew: 1000,
+						},
+					},
+					BlockHeight: 100,
+					WantErr:     nil,
+				},
+				{
+					Now:        now + 2,
+					Conditions: []weave.Condition{adminCond},
+					Tx: &weavetest.Tx{
+						Msg: &DeleteDomainMsg{
+							Metadata: &weave.Metadata{Schema: 1},
+							Domain:   "wunderland",
+						},
+					},
+					BlockHeight: 102,
+					WantErr:     errors.ErrState,
+				},
+			},
+		},
 		"deleting all accounts (flushing) does not delete the empty name account": {
 			Requests: []Request{
 				{
@@ -1372,6 +1403,38 @@ func TestUseCases(t *testing.T) {
 					},
 					BlockHeight: 101,
 					WantErr:     nil,
+				},
+			},
+		},
+		"domain without a superuser cannot be transferred": {
+			Requests: []Request{
+				{
+					Now:        now,
+					Conditions: []weave.Condition{adminCond},
+					Tx: &weavetest.Tx{
+						Msg: &RegisterDomainMsg{
+							Metadata:     &weave.Metadata{Schema: 1},
+							Domain:       "wunderland",
+							Admin:        adminCond.Address(),
+							HasSuperuser: false,
+							AccountRenew: 1000,
+						},
+					},
+					BlockHeight: 100,
+					WantErr:     nil,
+				},
+				{
+					Now:        now + 2,
+					Conditions: []weave.Condition{adminCond},
+					Tx: &weavetest.Tx{
+						Msg: &TransferDomainMsg{
+							Metadata: &weave.Metadata{Schema: 1},
+							Domain:   "wunderland",
+							NewAdmin: bobCond.Address(),
+						},
+					},
+					BlockHeight: 102,
+					WantErr:     errors.ErrState,
 				},
 			},
 		},


### PR DESCRIPTION
A domain without a superuser cannot be deleted or transferred.

resolve #1137

!nochangelog