### PR TITLE
bnsd: keep the zero address wallet empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 Breaking change
 
+- `bnsd` was updated to burn (remove from the system) any funds send to
+  `iov1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvnwh0u` address.
 - minimal Go version is now 1.12.14.
 - bnsd/x/account: a new `admin` index in Domain bucket
 - bnsd/x/account: a new `owner` index in Account bucket

--- a/cmd/bnsd/app/app.go
+++ b/cmd/bnsd/app/app.go
@@ -51,10 +51,6 @@ func Authenticator() x.Authenticator {
 // Chain returns a chain of decorators, to handle authentication,
 // fees, logging, and recovery
 func Chain(authFn x.Authenticator, minFee coin.Coin) app.Decorators {
-	// ctrl can be initialized with any implementation, but must be used
-	// consistently everywhere.
-	var ctrl cash.Controller = cash.NewController(cash.NewBucket())
-
 	return app.ChainDecorators(
 		utils.NewLogging(),
 		utils.NewRecovery(),
@@ -79,7 +75,7 @@ func Chain(authFn x.Authenticator, minFee coin.Coin) app.Decorators {
 
 // ctrl can be initialized with any implementation, but must be used
 // consistently everywhere.
-var ctrl = cash.NewController(cash.NewBucket())
+var ctrl cash.Controller = BnsCashController(cash.NewController(cash.NewBucket()))
 
 // Router returns a default router, only dispatching to the
 // cash.SendMsg

--- a/cmd/bnsd/app/cashctrl.go
+++ b/cmd/bnsd/app/cashctrl.go
@@ -1,0 +1,51 @@
+package bnsd
+
+import (
+	"bytes"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/errors"
+	"github.com/iov-one/weave/x/cash"
+)
+
+// BnsCashController wraps provided cash controller implementation with
+// functionality specific to BNS.
+func BnsCashController(c cash.Controller) cash.Controller {
+	return &CashController{
+		b:    cash.NewBucket(),
+		ctrl: c,
+	}
+}
+
+// CashController is a BNS specific cash.Controller implementation.
+type CashController struct {
+	b    cash.Bucket
+	ctrl cash.Controller
+}
+
+func (c *CashController) MoveCoins(store weave.KVStore, src weave.Address, dest weave.Address, amount coin.Coin) error {
+	if err := c.ctrl.MoveCoins(store, src, dest, amount); err != nil {
+		return errors.Wrap(err, "move coins")
+	}
+	if dest.Equals(burnWallet) {
+		empty := cash.NewWallet(burnWallet)
+		if err := c.b.Save(store, empty); err != nil {
+			return errors.Wrap(err, "cannot flush burn wallet")
+		}
+	}
+	return nil
+}
+
+// Burn wallet as requested in https://github.com/iov-one/weave/issues/1140
+//
+// Any funds send to this wallet should be instantly removed from the system.
+// This can be achieved by making sure that the wallet is always empty and even
+// if any funds were sent to it, flush it instantly.
+//
+// This address is represented by iov1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvnwh0u
+var burnWallet = weave.Address(bytes.Repeat([]byte{0}, weave.AddressLength))
+
+func (c *CashController) Balance(db weave.KVStore, a weave.Address) (coin.Coins, error) {
+	return c.ctrl.Balance(db, a)
+}

--- a/cmd/bnsd/app/cashctrl_test.go
+++ b/cmd/bnsd/app/cashctrl_test.go
@@ -1,0 +1,61 @@
+package bnsd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/migration"
+	"github.com/iov-one/weave/store"
+	"github.com/iov-one/weave/weavetest"
+	"github.com/iov-one/weave/x/cash"
+)
+
+func TestBnsCashController(t *testing.T) {
+	db := store.MemStore()
+	migration.MustInitPkg(db, "cash")
+	var (
+		alice = weavetest.NewCondition().Address()
+		bob   = weavetest.NewCondition().Address()
+		burn  = weave.Address(bytes.Repeat([]byte{0}, weave.AddressLength))
+	)
+
+	ctrl := cash.NewController(cash.NewBucket())
+	if err := ctrl.CoinMint(db, alice, coin.NewCoin(100, 0, "IOV")); err != nil {
+		t.Fatalf("mint: %s", err)
+	}
+
+	bnsCtrl := BnsCashController(ctrl)
+
+	if err := bnsCtrl.MoveCoins(db, alice, bob, coin.NewCoin(10, 0, "IOV")); err != nil {
+		t.Fatalf("transfer from alice to bob: %s", err)
+	}
+
+	if funds, err := bnsCtrl.Balance(db, alice); err != nil {
+		t.Fatalf("alice balance: %s", err)
+	} else if !funds.Equals(coin.Coins{coin.NewCoinp(90, 0, "IOV")}) {
+		t.Fatalf("want 90 IOV, got %v", funds)
+	}
+
+	if funds, err := bnsCtrl.Balance(db, bob); err != nil {
+		t.Fatalf("bob balance: %s", err)
+	} else if !funds.Equals(coin.Coins{coin.NewCoinp(10, 0, "IOV")}) {
+		t.Fatalf("want 10 IOV, got %v", funds)
+	}
+
+	// Sending to a burn wallet must remove coins from the system.
+	if err := bnsCtrl.MoveCoins(db, alice, burn, coin.NewCoin(30, 0, "IOV")); err != nil {
+		t.Fatalf("transfer from alice to burn: %s", err)
+	}
+	if funds, err := bnsCtrl.Balance(db, alice); err != nil {
+		t.Fatalf("alice balance: %s", err)
+	} else if !funds.Equals(coin.Coins{coin.NewCoinp(60, 0, "IOV")}) {
+		t.Fatalf("want 60 IOV, got %v", funds)
+	}
+	if funds, err := bnsCtrl.Balance(db, burn); err != nil {
+		t.Fatalf("alice balance: %s", err)
+	} else if !funds.Equals(coin.Coins{}) {
+		t.Fatalf("want empty wallet, got %v", funds)
+	}
+}

--- a/x/cash/controller.go
+++ b/x/cash/controller.go
@@ -2,7 +2,7 @@ package cash
 
 import (
 	"github.com/iov-one/weave"
-	coin "github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/errors"
 )
 


### PR DESCRIPTION
`bnsd` cash controller was updated and now it ensures that zero address
wallet (`iov1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvnwh0u`) never exist.
Sending any funds to that address removes them from the system as all
funds are instantly purged after transfering.

resolve #1140