### PR TITLE
bnsd: allow for a zero fee for preregistation record msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## HEAD
 
+- `bnsd`: set fee to zero for `preregistration.RegisterMsg`
 - `bnsd`: add `msgfee.UpdateConfigurationMsg` support
 - `bnsd`: a data migration for rewriting blockchain ID to CAIP specified format
 - a new `weave.Fraction` type was added to represent fractional values. It

--- a/cmd/bnsd/app/app.go
+++ b/cmd/bnsd/app/app.go
@@ -63,6 +63,7 @@ func Chain(authFn x.Authenticator, minFee coin.Coin) app.Decorators {
 		cash.NewDynamicFeeDecorator(authFn, ctrl),
 		msgfee.NewAntispamFeeDecorator(minFee),
 		msgfee.NewFeeDecorator(),
+		preregistration.NewZeroFeeDecorator(),
 		account.NewAccountMsgFeeDecorator(),
 		// txfee decorator must be before batch to count the main
 		// transaction once, not for every message present in the

--- a/cmd/bnsd/x/preregistration/decorator.go
+++ b/cmd/bnsd/x/preregistration/decorator.go
@@ -1,0 +1,60 @@
+package preregistration
+
+import (
+	weave "github.com/iov-one/weave"
+	"github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/errors"
+)
+
+// NewZeroFeeDecorator returns a decorator that lowers the fee for a record
+// preregistration message.
+func NewZeroFeeDecorator() *ZeroFeeDecorator {
+	return &ZeroFeeDecorator{}
+}
+
+// ZeroFeeDecorator zero fee for a transaction that contains a single message
+// of registering a preregistration record. Preregistration records can be
+// inserted only by an admin, so even the antispam fee is not necessary.
+type ZeroFeeDecorator struct{}
+
+var _ weave.Decorator = (*ZeroFeeDecorator)(nil)
+
+func (*ZeroFeeDecorator) Check(ctx weave.Context, store weave.KVStore, tx weave.Tx, next weave.Checker) (*weave.CheckResult, error) {
+	res, err := next.Check(ctx, store, tx)
+	if err != nil {
+		return res, err
+	}
+	if res.RequiredFee.IsZero() {
+		return res, err
+	}
+
+	msg, err := tx.GetMsg()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot unpack transaction message")
+	}
+	if _, ok := msg.(*RegisterMsg); ok {
+		// Zero the fee.
+		res.RequiredFee = coin.Coin{}
+	}
+	return res, nil
+}
+
+func (*ZeroFeeDecorator) Deliver(ctx weave.Context, store weave.KVStore, tx weave.Tx, next weave.Deliverer) (*weave.DeliverResult, error) {
+	res, err := next.Deliver(ctx, store, tx)
+	if err != nil {
+		return res, err
+	}
+	if res.RequiredFee.IsZero() {
+		return res, err
+	}
+
+	msg, err := tx.GetMsg()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot unpack transaction message")
+	}
+	if _, ok := msg.(*RegisterMsg); ok {
+		// Zero the fee.
+		res.RequiredFee = coin.Coin{}
+	}
+	return res, nil
+}


### PR DESCRIPTION
A new preregistration decorator was added to `bnsd`. When `bnsd` is
configured correctly the newly added decorator allows for submitting
`preregistration.RegisterMsg` without any fee.

resolve #1143