### PR TITLE
feature/account: non-superuser domains cannot be flushed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## HEAD
 - `bug`: Fix renew domain handler renews empty string account
+- `feature/account`: Accounts in non super user domains cannot be flushed
 
 ## 1.0.3
 - `bnsd`: include domain grace period in `make protoc` generated files

--- a/cmd/bnsd/x/account/handler.go
+++ b/cmd/bnsd/x/account/handler.go
@@ -833,6 +833,9 @@ func (h *flushDomainHandler) validate(ctx weave.Context, db weave.KVStore, tx we
 	if err := h.domains.One(db, []byte(msg.Domain), &domain); err != nil {
 		return nil, errors.Wrap(err, "cannot get domain")
 	}
+	if !domain.HasSuperuser {
+		return nil, errors.Wrap(errors.ErrState, "domains without a superuser cannot be flushed")
+	}
 	if !h.auth.HasAddress(ctx, domain.Admin) {
 		return nil, errors.Wrap(errors.ErrUnauthorized, "only owner can delete accounts")
 	}

--- a/cmd/bnsd/x/account/handler_test.go
+++ b/cmd/bnsd/x/account/handler_test.go
@@ -2543,6 +2543,92 @@ func TestUseCases(t *testing.T) {
 				}
 			},
 		},
+		"non-superuser domains cannot be flushed": {
+			Requests: []Request{
+				{
+					Now:        now,
+					Conditions: []weave.Condition{adminCond},
+					Tx: &weavetest.Tx{
+						Msg: &RegisterDomainMsg{
+							Metadata:     &weave.Metadata{Schema: 1},
+							Domain:       "wunderland",
+							Admin:        aliceCond.Address(),
+							HasSuperuser: false,
+							AccountRenew: 1000,
+						},
+					},
+					BlockHeight: 100,
+					WantErr:     nil,
+				},
+				{
+					Now:        now + 1,
+					Conditions: []weave.Condition{bobCond},
+					Tx: &weavetest.Tx{
+						Msg: &RegisterAccountMsg{
+							Metadata: &weave.Metadata{Schema: 1},
+							Owner:    bobCond.Address(),
+							Domain:   "wunderland",
+							Name:     "bob",
+						},
+					},
+					BlockHeight: 101,
+					WantErr:     nil,
+				},
+				{
+					Now:        now + 2,
+					Conditions: []weave.Condition{charlieCond},
+					Tx: &weavetest.Tx{
+						Msg: &RegisterAccountMsg{
+							Metadata: &weave.Metadata{Schema: 1},
+							Owner:    charlieCond.Address(),
+							Domain:   "wunderland",
+							Name:     "charlie",
+						},
+					},
+					BlockHeight: 102,
+					WantErr:     nil,
+				},
+				{
+					Now:        now + 3,
+					Conditions: []weave.Condition{adminCond},
+					Tx: &weavetest.Tx{
+						Msg: &FlushDomainMsg{
+							Metadata: &weave.Metadata{Schema: 1},
+							Domain:   "wunderland",
+						},
+					},
+					BlockHeight: 103,
+					WantErr:     errors.ErrState,
+				},
+				{
+					Now:        now + 4,
+					Conditions: []weave.Condition{aliceCond},
+					Tx: &weavetest.Tx{
+						Msg: &FlushDomainMsg{
+							Metadata: &weave.Metadata{Schema: 1},
+							Domain:   "wunderland",
+						},
+					},
+					BlockHeight: 104,
+					WantErr:     errors.ErrState,
+				},
+			},
+			AfterTest: func(t *testing.T, db weave.KVStore) {
+				b := NewDomainBucket()
+				var d Domain
+				if err := b.One(db, []byte("wunderland"), &d); err != nil {
+					t.Fatalf("cannot get wunderland domain: %s", err)
+				}
+				a := NewAccountBucket()
+				var acc Account
+				if err := a.One(db, accountKey("", d.Domain), &acc); err != nil {
+					t.Fatalf("cannot get wunderland empty account: %s", err)
+				}
+				if got, want := acc.ValidUntil, d.ValidUntil; want != got {
+					t.Fatalf("want valid till %s, got %s", want, got)
+				}
+			},
+		},
 	}
 
 	for testName, tc := range cases {

--- a/cmd/bnsd/x/account/handler_test.go
+++ b/cmd/bnsd/x/account/handler_test.go
@@ -2620,12 +2620,13 @@ func TestUseCases(t *testing.T) {
 					t.Fatalf("cannot get wunderland domain: %s", err)
 				}
 				a := NewAccountBucket()
-				var acc Account
-				if err := a.One(db, accountKey("", d.Domain), &acc); err != nil {
-					t.Fatalf("cannot get wunderland empty account: %s", err)
+				var bobAcc Account
+				if err := a.One(db, accountKey("bob", d.Domain), &bobAcc); err != nil {
+					t.Fatalf("cannot get account: %s", err)
 				}
-				if got, want := acc.ValidUntil, d.ValidUntil; want != got {
-					t.Fatalf("want valid till %s, got %s", want, got)
+				var charlieAcc Account
+				if err := a.One(db, accountKey("charlie", d.Domain), &charlieAcc); err != nil {
+					t.Fatalf("cannot get account: %s", err)
 				}
 			},
 		},


### PR DESCRIPTION
Resolves https://github.com/iov-one/weave/issues/1207